### PR TITLE
Added health endpoint

### DIFF
--- a/analytics_dashboard/analytics_dashboard/tests.py
+++ b/analytics_dashboard/analytics_dashboard/tests.py
@@ -1,11 +1,65 @@
 import json
+from django.db import DatabaseError
+import mock
+
+from analyticsclient.exceptions import ClientError
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 
 
-class StatusTests(TestCase):
+class ViewTests(TestCase):
+    def assertUnhealthyAPI(self):
+        response = self.client.get(reverse('health'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['content-type'], 'application/json')
+        expected = {
+            u'overall_status': u'UNAVAILABLE',
+            u'detailed_status': {
+                u'database_connection': u'OK',
+                u'analytics_api': u'UNAVAILABLE'
+            }
+        }
+        self.assertDictEqual(json.loads(response.content), expected)
+
     def test_status(self):
         response = self.client.get(reverse('status'))
         self.assertEqual(response.status_code, 200)
+
+    @mock.patch('analyticsclient.status.Status.healthy', mock.PropertyMock(return_value=True))
+    def test_health(self):
+        response = self.client.get(reverse('health'))
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(response['content-type'], 'application/json')
-        self.assertDictEqual({'alive': True}, json.loads(response.content))
+
+        expected = {
+            u'overall_status': u'OK',
+            u'detailed_status': {
+                u'database_connection': u'OK',
+                u'analytics_api': u'OK'
+            }
+        }
+        self.assertDictEqual(json.loads(response.content), expected)
+
+    @mock.patch('analyticsclient.status.Status.healthy', mock.PropertyMock(return_value=True))
+    @mock.patch('django.db.backends.BaseDatabaseWrapper.cursor', mock.Mock(side_effect=DatabaseError))
+    def test_health_database_outage(self):
+        response = self.client.get(reverse('health'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['content-type'], 'application/json')
+
+        expected = {
+            u'overall_status': u'UNAVAILABLE',
+            u'detailed_status': {
+                u'database_connection': u'UNAVAILABLE',
+                u'analytics_api': u'OK'
+            }
+        }
+        self.assertDictEqual(json.loads(response.content), expected)
+
+    @mock.patch('analyticsclient.status.Status.healthy', mock.PropertyMock(return_value=False))
+    def test_health_analytics_api_unhealthy(self):
+        self.assertUnhealthyAPI()
+
+    @mock.patch('analyticsclient.status.Status.healthy', mock.PropertyMock(side_effect=ClientError))
+    def test_health_analytics_api_unreachable(self):
+        self.assertUnhealthyAPI()

--- a/analytics_dashboard/analytics_dashboard/urls.py
+++ b/analytics_dashboard/analytics_dashboard/urls.py
@@ -9,6 +9,7 @@ admin.autodiscover()
 urlpatterns = patterns(
     '',
     url(r'^status/$', views.status, name='status'),
+    url(r'^health/$', views.health, name='health'),
     url(r'^courses/', include('courses.urls', namespace='courses')),
     url(r'^admin/', include(admin.site.urls)),
 )

--- a/analytics_dashboard/analytics_dashboard/views.py
+++ b/analytics_dashboard/analytics_dashboard/views.py
@@ -1,6 +1,49 @@
+import json
+import logging
+from analyticsclient.client import Client
+from analyticsclient.exceptions import ClientError
+from django.conf import settings
+from django.db import connection, DatabaseError
 from django.http import HttpResponse
 
+logger = logging.getLogger(__name__)
 
-# pylint: disable=unused-argument
-def status(request):
-    return HttpResponse('{"alive": true}', content_type='application/json')
+
+def status(_request):
+    return HttpResponse()
+
+
+def health(_request):
+    OK = 'OK'
+    UNAVAILABLE = 'UNAVAILABLE'
+
+    overall_status = analytics_api_status = database_status = UNAVAILABLE
+
+    try:
+        cursor = connection.cursor()
+        cursor.execute("SELECT 1")
+        cursor.fetchone()
+        cursor.close()
+        database_status = OK
+    except DatabaseError:   # pylint: disable=catching-non-exception
+        database_status = UNAVAILABLE
+
+    try:
+        client = Client(base_url=settings.DATA_API_URL, auth_token=settings.DATA_API_AUTH_TOKEN)
+        if client.status.healthy:
+            analytics_api_status = OK
+    except ClientError as e:
+        logger.exception('API is not reachable from dashboard: %s', e)
+        analytics_api_status = UNAVAILABLE
+
+    overall_status = OK if (analytics_api_status == database_status == OK) else UNAVAILABLE
+
+    data = {
+        'overall_status': overall_status,
+        'detailed_status': {
+            'database_connection': database_status,
+            'analytics_api': analytics_api_status
+        }
+    }
+
+    return HttpResponse(json.dumps(data), content_type='application/json')


### PR DESCRIPTION
This will be used primarily for monitoring. The status endpoint was also updated to simply return an HTTP 200 status without the unnecessary content.
