### PR TITLE
Replaced code with alpha2

### DIFF
--- a/analytics_dashboard/courses/tests/test_views.py
+++ b/analytics_dashboard/courses/tests/test_views.py
@@ -164,7 +164,7 @@ class CourseEnrollmentByCountryJSONViewTests(CourseEnrollmentViewTestMixin, Test
         datum['course_id'] = self.course_id
         datum['count'] = datum['value']
         datum['country'] = {
-            'code': datum['country_code'],
+            'alpha2': datum['country_code'],
             'name': datum['country_name']
         }
 

--- a/analytics_dashboard/courses/tests/utils.py
+++ b/analytics_dashboard/courses/tests/utils.py
@@ -33,7 +33,7 @@ def get_mock_enrollment_location_data(course_id):
     data = []
     for item in ((u'US', u'United States', 500), (u'DE', u'Germany', 100), (u'CA', u'Canada', 300)):
         data.append({'date': '2014-01-01', 'course_id': course_id, 'count': item[2],
-                     'country': {'code': item[0], 'name': item[1]}})
+                     'country': {'alpha2': item[0], 'name': item[1]}})
     return data
 
 

--- a/analytics_dashboard/courses/views.py
+++ b/analytics_dashboard/courses/views.py
@@ -205,7 +205,7 @@ class CourseEnrollmentByCountryJSON(JSONResponseMixin, CourseView):
 
         if api_response:
             start_date = api_response[0]['date']
-            api_data = [{'country_code': datum['country']['code'],
+            api_data = [{'country_code': datum['country']['alpha2'],
                          'country_name': datum['country']['name'],
                          'value': datum['count']} for datum in api_response]
 


### PR DESCRIPTION
API uses alpha2 and alpha3 instead of code. @dsjen's plotting library changes will eventually make this obsolete, but I wanted to get the codebase back to a fully-working state.

@rocha @dsjen @mulby @jhelbert @brianhw 
