### PR TITLE
Using Fork of django-dynamic-fixture

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -75,9 +75,6 @@ disable=
 # (visual studio) and html
 output-format=text
 
-# Include message's id in output
-include-ids=yes
-
 # Put messages in a separate file for each module / package specified on the
 # command line instead of printing them on stdout. Reports (if any) will be
 # written in a file name "pylint_global.[txt|html]".

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -9,7 +9,8 @@ nose-exclude==0.2.0
 django-nose==1.2
 nose==1.3.3
 mock==1.0.1
-django-dynamic-fixture==1.7.0
+#django-dynamic-fixture==1.7.0
+-e git+git@github.com:paulocheque/django-dynamic-fixture.git@010913bfab1b010458570ec282abe80b8fd20ade#egg=django-dynamic-fixture
 sure==1.2.7
 httpretty==0.8.3
 testfixtures==4.0.1


### PR DESCRIPTION
The nose plugin included with django-dynamic-fixture has a bug that results in its being loaded unnecessarily. I have forked the repository and fixed this bug. Until my PR is merged, we will use the fork. I also fixed a Pylint warning about a deprecated directive.
