### PR TITLE
Cleaned Navbar Code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,3 +49,4 @@ demo:
 	cd analytics_dashboard && ./manage.py switch show_engagement_demo_interface on --create
 	cd analytics_dashboard && ./manage.py switch navbar_display_engagement on --create
 	cd analytics_dashboard && ./manage.py switch navbar_display_engagement_content on --create
+	cd analytics_dashboard && ./manage.py switch navbar_display_overview on --create

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The following switches are available:
 | show_engagement_demo_interface    | Show experimental content below the engagement summary   |
 | navbar_display_engagement         | Show the engagement item in the lens drop down           |
 | navbar_display_engagement_content | Show the "Content" sub-section in the engagement nav bar |
+| navbar_display_overview           | Show the overview item in the lens drop down             |
 
 Authentication & Authorization
 ------------------------------

--- a/analytics_dashboard/courses/tests/utils.py
+++ b/analytics_dashboard/courses/tests/utils.py
@@ -1,6 +1,9 @@
 import StringIO
 import csv
 import datetime
+
+import analyticsclient.activity_type as AT
+
 from courses.permissions import set_user_course_permissions
 
 
@@ -64,3 +67,13 @@ def convert_list_of_dicts_to_csv(data, fieldnames=None):
 def set_empty_permissions(user):
     set_user_course_permissions(user, [])
     return []
+
+
+def mock_engagement_summary_data():
+    return {
+        'interval_end': '2013-01-01T12:12:12Z',
+        AT.ANY: 100,
+        AT.ATTEMPTED_PROBLEM: 301,
+        AT.PLAYED_VIDEO: 1000,
+        AT.POSTED_FORUM: 0,
+    }

--- a/analytics_dashboard/templates/lens-navigation.html
+++ b/analytics_dashboard/templates/lens-navigation.html
@@ -5,7 +5,6 @@ Partial for displaying the lens navigation and the sections within the lenses.
 <nav class="navbar navbar-default lens-nav" role="navigation">
     <div class="container ">
         <ul class="nav navbar-nav">
-
             <li class="dropdown">
                 <a href="#" class="dropdown-toggle navbar-link" data-toggle="dropdown">
                     <span class="link-label">
@@ -16,26 +15,22 @@ Partial for displaying the lens navigation and the sections within the lenses.
 
                 <ul class="dropdown-menu">
                     {% for item in primary_nav_items %}
-                    {% if primary_nav_item != item %}
-                    <li>
-                        <a href="{{ item.href }}">
-                            <span class="link-label"><i class="ico fa {{ item.icon }}"></i> {{ item.label }}</span>
-                        </a>
-                    </li>
-                    {% endif %}
+                      <li>
+                          <a href="{{ item.href }}">
+                              <span class="link-label"><i class="ico fa {{ item.icon }}"></i> {{ item.label }}</span>
+                          </a>
+                      </li>
                     {% endfor %}
                 </ul>
-
             </li>
 
-            {% for section in secondary_nav_items %}
-            <li class="{% if page_title == section.title %}active{% endif %} nav-section">
-                <a href="{{ section.href }}">
-                    <span class="link-label">{{ section.label }}</span>
+            {% for item in secondary_nav_items %}
+            <li class="{% if item.active %}active{% endif %} nav-section">
+                <a href="{{ item.href }}">
+                    <span class="link-label">{{ item.label }}</span>
                 </a>
             </li>
             {% endfor %}
-
         </ul>
     </div>
 </nav>


### PR DESCRIPTION
- Views must explicitly specify an active secondary nav item
- Mixin is now course-specific and includes href creation
- Extraneous dictionary keys are removed before rendering
- Ordering now set by order of items used in get_primary_nav_items

@rocha @dsjen
