### PR TITLE
Removed Course Info Placeholders

### DIFF
--- a/analytics_dashboard/courses/templates/courses/base-course.html
+++ b/analytics_dashboard/courses/templates/courses/base-course.html
@@ -1,3 +1,3 @@
 {% extends "base.html" %}
 
-{% block title %}{{ page_title }} - {{ course_number }} {{ course_title }} {{ block.super }}{% endblock title %}
+{% block title %}{{ page_title }} - {{ course_id }} {{ block.super }}{% endblock title %}

--- a/analytics_dashboard/courses/views.py
+++ b/analytics_dashboard/courses/views.py
@@ -39,14 +39,8 @@ class CourseContextMixin(object):
         """
         Returns default data for the pages (context and javascript data).
         """
-        # TODO: Use real course data
         user = self.request.user
         context = {
-            'user_name': user.get_full_name(),
-            'user_id': user.get_username(),
-            'user_email': user.email,
-            'course_number': 'MITx 7.3423',
-            'course_title': 'Introduction to Awesomeness',
             'course_id': self.course_id,
             'page_title': self.page_title,
             'js_data': {


### PR DESCRIPTION
We won't have this information for launch, so the placeholders need to go away.

@dsjen @rocha
