### PR TITLE
Defaulting to None for User Language

### DIFF
--- a/analytics_dashboard/analytics_dashboard/backends.py
+++ b/analytics_dashboard/analytics_dashboard/backends.py
@@ -71,5 +71,7 @@ class EdXOpenIdConnect(EdXOAuth2Mixin, OpenIdConnectAuth):
             u'full_name': response['name'],
             u'first_name': response['given_name'],
             u'last_name': response['family_name'],
-            u'language': response['language']
+
+            # Optional, scope-specific, data
+            u'language': response.get('language')
         }


### PR DESCRIPTION
Open ID Connect does not guarantee that requested info will be returned. Accounting for this fact by defaulting to None if the provider returns no language. (Also, my local test provider has not been updated to return a language. :/)

@rocha @dsjen
