### PR TITLE
Updated Enrollment Trend Styling

### DIFF
--- a/analytics_dashboard/static/js/engagement-content-main.js
+++ b/analytics_dashboard/static/js/engagement-content-main.js
@@ -53,7 +53,6 @@ require(['vendor/domReady!', 'load/init-page'], function(doc, page){
             model: page.models.courseModel,
             modelAttribute: 'engagementTrends',
             trends: trendSettings,
-            title: gettext('Weekly Student Engagement'),
             x: {
                 // displayed on the axis
                 title: 'Date',
@@ -63,9 +62,10 @@ require(['vendor/domReady!', 'load/init-page'], function(doc, page){
             y: {
                 title: 'Students',
                 key: 'count'
-            }
+            },
+
             // TODO: add a tooltip for this graph (AN-3362)
-            // ,tooltip: gettext('TBD')
+            tooltip: gettext('This graph displays weekly course activity.')
         });
 
         // weekly engagement activities table

--- a/analytics_dashboard/static/js/enrollment-activity-main.js
+++ b/analytics_dashboard/static/js/enrollment-activity-main.js
@@ -16,18 +16,9 @@ require(['vendor/domReady!', 'load/init-page'], function(doc, page){
             el: '#enrollment-trend-view',
             model: page.models.courseModel,
             modelAttribute: 'enrollmentTrends',
-            trends: [{label: 'Students'}],
-            title: gettext('Daily Student Enrollment'),
-            x: {
-                // displayed on the axis
-                title: 'Date',
-                // key in the data
-                key: 'date'
-            },
-            y: {
-                title: 'Students',
-                key: 'count'
-            },
+            trends: [{title: 'Students'}],
+            x: { key: 'date' },
+            y: { key: 'count' },
             tooltip: gettext('This graph displays total enrollment for the course calculated at the end of each day. Total enrollment includes new enrollments as well as un-enrollments.')
         });
 
@@ -44,5 +35,4 @@ require(['vendor/domReady!', 'load/init-page'], function(doc, page){
             sorting: ['-date']
         });
     });
-
 });

--- a/analytics_dashboard/static/sass/_developer.scss
+++ b/analytics_dashboard/static/sass/_developer.scss
@@ -10,18 +10,40 @@
 
 .line-chart-container {
   background-color: white;
-  padding-top: 10px; // Give the title some breathing room.
+  border: $edx-gray 1px solid;
+
 
   .line-chart {
-    height: 300px;
+    height: 305px;  // Update the height of the graph in trends-view.js to be this height minus 5px.
   }
 
-  .chart-title {
-    text-align: center;
+  .chart-tooltip {
+    @extend .pull-right;
+    padding-right: $padding-small-horizontal;
+    padding-top: $padding-small-horizontal;
+  }
 
-    .chart-tooltip {
-      @extend .pull-right;
-      padding-right: $padding-large-horizontal;
+  .nvd3 {
+    .nv-axis {
+
+      &.nv-y {
+        fill: $edx-gray;
+
+        .nv-axislabel {
+          fill: $edx-blue;
+        }
+      }
+
+      &.nv-x {
+        text {
+          fill: $edx-gray-l1;
+          font-size: $font-size-small;
+        }
+
+        .x-axis-background {
+          fill: $gray-d2;
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
After far too many hours the enrollment chart has been updated to more closely resemble the design below. Note that some minor debt is introduced in the form of hard-coded heights and widths. This seems to be unavoidable as manipulating SVG is not a simple task.

Original
https://photos-4.dropbox.com/t/0/AAAnOqAg1LSrYw5wZ2bLYvrVvqhdxXXZ8gSynEi0pOC2SA/12/3716/png/1024x768/3/1410382800/0/2/Screenshot%202014-09-04%2012.33.22.png/u3kJepEEMloBRJ6AZYJv6rAc2c6FGrvJYKtFRcNPQe4

Design
https://photos-4.dropbox.com/t/0/AABqGNJGN2vr6MVtbhHsNPBzpcfbQbxSrOYlAUAMLQ3LOQ/12/3716/png/1024x768/3/1410382800/0/2/Screenshot%202014-09-04%2012.34.01.png/jX3EIhwFAMWX0rwzf2TS1QeoJsY-9H__znF6c-wYFf4

The design for review is shown below. Note that I opted to no longer force the minimum value for the Y-axis to zero. Doing so hides a lot of variability in the data.
![screen shot 2014-09-11 at 5 13 32 pm](https://cloud.githubusercontent.com/assets/910510/4242042/abaacd0e-39f9-11e4-8eed-8507f0541672.png)

Here is what the graph looks like when forced to zero.
![screen shot 2014-09-11 at 5 14 13 pm](https://cloud.githubusercontent.com/assets/910510/4242051/d80b65ac-39f9-11e4-8f4c-7194e6653bfd.png)

Finally, I propose (but have not implemented in the code for review) removing the "Enrollments" label. It's lonely and doesn't add any information to the graph.
![screen shot 2014-09-11 at 5 14 51 pm](https://cloud.githubusercontent.com/assets/910510/4242060/087009be-39fa-11e4-8c28-a97c82f33b68.png)

@marcotuts @shnayder @dsjen @rocha 
