### PR TITLE
Set the timezone to GMT for display of dates in the trends.

### DIFF
--- a/analytics_dashboard/static/js/views/trends-view.js
+++ b/analytics_dashboard/static/js/views/trends-view.js
@@ -102,7 +102,9 @@ define(['bootstrap', 'd3', 'jquery', 'moment', 'nvd3', 'underscore', 'views/attr
 
                 chart.xAxis
                     .tickFormat(function (d) {
-                        return moment(d).format('M/D');
+                        // date is converted to unix timestamp from our original mm-dd-yyyy format
+                        // and setting the timezone to gmt displays the correct date
+                        return moment(d).zone('+0000').format('M/D');
                     });
 
                 chart.yAxis.showMaxMin(false);


### PR DESCRIPTION
The displayed dates were off by a day (see screenshots of the old vs. new).

![date-old](https://cloud.githubusercontent.com/assets/5265058/4292105/47657586-3dca-11e4-89d2-7bbcf8b5ac35.png)
![date-updated](https://cloud.githubusercontent.com/assets/5265058/4292106/4773b18c-3dca-11e4-9273-c9300a484387.png)

@clintonb @rocha 
