### PR TITLE
Cleaned Acceptance Tests

### DIFF
--- a/acceptance_tests/pages.py
+++ b/acceptance_tests/pages.py
@@ -53,13 +53,6 @@ class LoginPage(DashboardPage):
         return True
 
 
-class LogoutPage(DashboardPage):
-    path = 'accounts/logout'
-
-    def is_browser_on_page(self):
-        return self.browser.title.startswith('Logged Out')
-
-
 class CourseEnrollmentGeographyPage(CoursePage):
     def __init__(self, browser, course_id=None):
         super(CourseEnrollmentGeographyPage, self).__init__(browser, course_id)

--- a/acceptance_tests/test_auth.py
+++ b/acceptance_tests/test_auth.py
@@ -1,7 +1,7 @@
 from bok_choy.web_app_test import WebAppTest
 
 from acceptance_tests import USERNAME, PASSWORD, ENABLE_OAUTH_AUTHORIZE
-from pages import LoginPage, LogoutPage
+from pages import LoginPage
 
 
 class OAuthFlowTests(WebAppTest):
@@ -12,7 +12,6 @@ class OAuthFlowTests(WebAppTest):
         super(OAuthFlowTests, self).setUp()
 
         self.login_page = LoginPage(self.browser)
-        self.logout_page = LogoutPage(self.browser)
 
         self.username = USERNAME
         self.password = PASSWORD


### PR DESCRIPTION
The course page tests now all inherit CoursePageTestsMixin and have a single test method. All tests are called from this method to avoid the overhead of launching a new browser instance for each test. This results in a drastic decrease in test runtime (75s to 16s).

Merging now, but opening a PR for @benpatterson to offer feedback later.
