### PR TITLE
Using Latest Version of Python Social Auth

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,7 +7,7 @@ django-model-utils==1.5.0 	# BSD
 django_compressor==1.4		# MIT
 django-appconf==0.6
 logutils==0.3.3				# BSD
--e git+git@github.com:edx/python-social-auth.git@edx#egg=python-social-auth 	# BSD
+python-social-auth==0.2.0   # BSD
 -e git+git@github.com:edx/edx-analytics-data-api-client.git@0.2.3#egg=edx-analytics-data-api-client # edX
 -e git+https://github.com/edx/django-lang-pref-middleware.git@0.1.0#egg=django-lang-pref-middleware
 django-waffle==0.10			# BSD


### PR DESCRIPTION
Our fork is no longer needed as the merged changes have now been released.

@rocha @dsjen
