### PR TITLE
Update trend x-axis selector

### DIFF
--- a/analytics_dashboard/static/js/views/trends-view.js
+++ b/analytics_dashboard/static/js/views/trends-view.js
@@ -46,7 +46,8 @@ define(['bootstrap', 'd3', 'jquery', 'moment', 'nvd3', 'underscore', 'views/attr
 
             styleChart: function () {
                 var canvas = d3.select(this.el),
-                    translateRegex = /translate\((\d+),\s*(\d+)\)/g,
+                    // ex. translate(200, 200) or translate(200 200)
+                    translateRegex = /translate\((\d+)[,\s]\s*(\d+)\)/g,
                     xAxisMargin = 6,
                     axisEl,
                     matches;
@@ -73,8 +74,7 @@ define(['bootstrap', 'd3', 'jquery', 'moment', 'nvd3', 'underscore', 'views/attr
                 // Get the existing X-axis translation and shift it down a few more pixels.
                 axisEl = canvas.select('.nvd3 .nv-axis.nv-x');
                 matches = translateRegex.exec(axisEl.attr('transform'));
-                axisEl.attr('transform', 'translate(' + matches[1] + ',' + (parseInt(matches[2], 10) + xAxisMargin) + ')')
-
+                axisEl.attr('transform', 'translate(' + matches[1] + ',' + (parseInt(matches[2], 10) + xAxisMargin) + ')');
             },
 
             /**


### PR DESCRIPTION
- Selector regex looks for whitespace or comma
- Fixes the x-axis positioning in IE
- Fixes cascading errors that caused the table not to load

Error:
![ie-error](https://cloud.githubusercontent.com/assets/5265058/4362305/cd02d722-428b-11e4-8971-ba98115dc5b8.png)

@rocha @clintonb 
