### PR TITLE
Darkened gray on summary card subtitle.

### DIFF
--- a/analytics_dashboard/templates/summary_point.html
+++ b/analytics_dashboard/templates/summary_point.html
@@ -5,7 +5,7 @@
     {% endwith %}
     <div class="summary-point-label">{{ label }}</div>
     {% if subheading %}
-      <span class="summary-point-note text-muted">{{ subheading }}</span>
+      <span class="summary-point-note">{{ subheading }}</span>
     {% endif %}
     {% if tooltip %}
       <div class="summary-point-help">


### PR DESCRIPTION
@rocha @clintonb 

Request is to use the same gray as in the headers:
![same-gray-as-header](https://cloud.githubusercontent.com/assets/5265058/4395247/35fcfb56-4429-11e4-83fc-4cdf6b3ecb7b.png)
