### PR TITLE
Darkened Color of Sort Icons

### DIFF
--- a/analytics_dashboard/static/sass/_developer.scss
+++ b/analytics_dashboard/static/sass/_developer.scss
@@ -232,6 +232,7 @@ table.dataTable thead th.sorting_desc:after {
   display: inline;
   padding-left: 8px;
   font-family: FontAwesome;
+  color: $edx-gray;
 }
 
 //Sort Icon Color


### PR DESCRIPTION
Before (14px)
![screen shot 2014-09-25 at 6 18 12 pm](https://cloud.githubusercontent.com/assets/910510/4413240/2fb28d2c-4502-11e4-997c-3b4b7a693da5.png)

After (18px)
![screen shot 2014-09-25 at 6 17 45 pm](https://cloud.githubusercontent.com/assets/910510/4413238/2c9be296-4502-11e4-80a3-b0634f339fc0.png)
