### PR TITLE
Fill engagement activity trend with zeros if null is returned for type.

### DIFF
--- a/analytics_dashboard/courses/presenters.py
+++ b/analytics_dashboard/courses/presenters.py
@@ -64,7 +64,7 @@ class CourseEngagementPresenter(BasePresenter):
         for datum in api_trends:
             trend_week = {'weekEnding': self.strip_time(datum['interval_end'])}
             for trend_type in trend_types:
-                trend_week[trend_type] = datum[trend_type] if trend_type in datum else 0
+                trend_week[trend_type] = datum[trend_type] or 0
             trends.append(trend_week)
 
         return trends

--- a/analytics_dashboard/courses/tests/utils.py
+++ b/analytics_dashboard/courses/tests/utils.py
@@ -137,7 +137,7 @@ def mock_course_activity(start_date=None, end_date=None):
         {
             'interval_end': '2014-09-01T000000',
             AT.ANY: 1000,
-            AT.ATTEMPTED_PROBLEM: 0,
+            AT.ATTEMPTED_PROBLEM: None,
             AT.PLAYED_VIDEO: 10000,
             AT.POSTED_FORUM: 45,
             'created': CREATED_DATETIME_STRING
@@ -147,7 +147,7 @@ def mock_course_activity(start_date=None, end_date=None):
             AT.ANY: 100,
             AT.ATTEMPTED_PROBLEM: 301,
             AT.PLAYED_VIDEO: 1000,
-            AT.POSTED_FORUM: 0,
+            AT.POSTED_FORUM: None,
             'created': CREATED_DATETIME_STRING
         },
     ]


### PR DESCRIPTION
@rocha @clintonb 

FYI: @shnayder 

Before:
![before](https://cloud.githubusercontent.com/assets/5265058/4449770/b801fe82-481e-11e4-98a3-5dd115073d8f.png)

After:
![after](https://cloud.githubusercontent.com/assets/5265058/4449771/ba0b2bf4-481e-11e4-9450-b6daecadef2b.png)
