### PR TITLE
Change values for "Week Ending" to be last day of week instead of interval_end.

### DIFF
--- a/analytics_dashboard/courses/presenters.py
+++ b/analytics_dashboard/courses/presenters.py
@@ -62,7 +62,10 @@ class CourseEngagementPresenter(BasePresenter):
         # the field if no data exists for it, so we fill in the zeros here)
         trends = []
         for datum in api_trends:
-            trend_week = {'weekEnding': self.strip_time(datum['interval_end'])}
+            # convert end of interval to ending day of week
+            interval_end = self.parse_api_datetime(datum['interval_end'])
+            week_ending = interval_end.date() - datetime.timedelta(days=1)
+            trend_week = {'weekEnding': week_ending.isoformat()}
             for trend_type in trend_types:
                 trend_week[trend_type] = datum[trend_type] or 0
             trends.append(trend_week)

--- a/analytics_dashboard/courses/tests/test_presenters.py
+++ b/analytics_dashboard/courses/tests/test_presenters.py
@@ -20,12 +20,12 @@ class CourseEngagementPresenterTests(TestCase):
     def get_expected_trends(self, include_forum_data):
         trends = [
             {
-                'weekEnding': '2014-09-01',
+                'weekEnding': '2014-08-31',
                 AT.ANY: 1000,
                 AT.ATTEMPTED_PROBLEM: 0,
                 AT.PLAYED_VIDEO: 10000
             }, {
-                'weekEnding': '2014-09-08',
+                'weekEnding': '2014-09-07',
                 AT.ANY: 100,
                 AT.ATTEMPTED_PROBLEM: 301,
                 AT.PLAYED_VIDEO: 1000,


### PR DESCRIPTION
Change appears in table and on graph for weekly engagement counts.  CSV
is unaffected, as it outputs interval_start and interval_end timestamps.

The "Week Ending" value is never explicitly mentioned in the
documentation, so no change is required there.

Fixes AN-3577.
