### PR TITLE
Made Interactive Tooltip Header Configurable

### DIFF
--- a/analytics_dashboard/static/js/engagement-content-main.js
+++ b/analytics_dashboard/static/js/engagement-content-main.js
@@ -63,7 +63,10 @@ require(['vendor/domReady!', 'load/init-page'], function(doc, page){
                 title: 'Students',
                 key: 'count'
             },
-            tooltip: gettext('The number of active students, and the number of students who engaged in specific activities, over time.')
+            tooltip: gettext('The number of active students, and the number of students who engaged in specific activities, over time.'),
+
+            // Translators: %(value)s will be replaced with a date.
+            interactiveTooltipHeader: gettext('Week Ending %(value)s')
         });
 
         // weekly engagement activities table

--- a/analytics_dashboard/static/js/views/trends-view.js
+++ b/analytics_dashboard/static/js/views/trends-view.js
@@ -119,6 +119,12 @@ define(['bootstrap', 'd3', 'jquery', 'moment', 'nvd3', 'underscore', 'views/attr
 
                 chart.yAxis.showMaxMin(false);
 
+                if(_(self.options).has('interactiveTooltipHeader')) {
+                    chart.interactiveLayer.tooltip.headerFormatter(function (d) {
+                        return interpolate(self.options.interactiveTooltipHeader, {value: d}, true);
+                    });
+                }
+
                 // Add the tooltip
                 if (_(self.options).has('tooltip')) {
                     $tooltip = $(self.tooltipTemplate({text: self.options.tooltip}));


### PR DESCRIPTION
Consuming code can now configure the header of the interactive tooltip. This has been configured for the engagement content view.

![screen shot 2014-09-30 at 8 05 05 pm](https://cloud.githubusercontent.com/assets/910510/4468655/9649bdbe-4901-11e4-9496-56f7149025ee.png)

@shnayder @dsjen @rocha 
