### PR TITLE
Loading application-main separately from RequireJS

### DIFF
--- a/analytics_dashboard/templates/base.html
+++ b/analytics_dashboard/templates/base.html
@@ -92,7 +92,10 @@
 
     {% compress js %}
       <script src="{% static 'js/common.js' %}"></script>
-      <script data-main="{% static 'js/application-main.js' %}"  src="{% static 'vendor/require.js' %}"></script>
+      <script src="{% static 'vendor/require.js' %}"></script>
+
+      {# Note: django-compressor does not recognize the data-main attribute. Load the main script separately. #}
+      <script src="{% static 'js/application-main.js' %}"></script>
 
       {% block javascript %}
       {% endblock javascript %}


### PR DESCRIPTION
django-compressor doesn't recognize the data-main attribute. Thus, at compression time this attribute is eliminated and the main script is not loaded.

@dsjen @e0d @rocha 
