### PR TITLE
Display empty previous data point on trend line when only one data point exists.

### DIFF
--- a/analytics_dashboard/courses/tests/utils.py
+++ b/analytics_dashboard/courses/tests/utils.py
@@ -42,6 +42,24 @@ def get_mock_enrollment_summary_and_trend(course_id):
     return get_mock_enrollment_summary(), get_mock_enrollment_data(course_id)
 
 
+def get_mock_presenter_enrollment_data_small(course_id):
+    single_enrollment = get_mock_enrollment_data(course_id)[-1]
+    empty_enrollment = {
+        'count': 0,
+        'date': '2014-01-30'
+    }
+
+    return [empty_enrollment, single_enrollment]
+
+
+def get_mock_presenter_enrollment_summary_small():
+    return {
+        'last_updated': CREATED_DATETIME,
+        'current_enrollment': 30,
+        'enrollment_change_last_7_days': None,
+    }
+
+
 def get_mock_api_enrollment_geography_data(course_id):
     data = []
     items = ((u'USA', u'United States', 500), (None, UNKNOWN_COUNTRY_CODE, 300),


### PR DESCRIPTION
@rocha @clintonb @marcotuts 

FYI: @shnayder 

Example of engagement trend display with empty data point:
![screen shot 2014-10-06 at 1 39 43 pm](https://cloud.githubusercontent.com/assets/5265058/4530325/c8cf8cbe-4d7f-11e4-8c18-8c17f0e120db.png)

Please note that the data table includes this empty data (not in CSV download).
