### PR TITLE
Packaging RequireJS Dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ Desktop.ini
 analytics_dashboard/assets/
 node_modules/
 analytics_dashboard/static/bower_components/
+analytics_dashboard/static/dist/
 .coverage
 nosetests.xml
 reports/

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 ROOT = $(shell echo "$$PWD")
 COVERAGE = $(ROOT)/build/coverage
-PACKAGES = analytics_dashboard courses
+PACKAGES = analytics_dashboard courses django_rjs
 NUM_PROCESSES = 2
 
 .PHONY: requirements clean
@@ -71,3 +71,8 @@ generate_fake_translations:
 	cd analytics_dashboard && i18n_tool extract
 	cd analytics_dashboard && i18n_tool dummy
 	compile_translations
+
+static:
+	r.js -o build.js
+	cd analytics_dashboard && ./manage.py collectstatic --noinput
+	cd analytics_dashboard && ./manage.py compress

--- a/README.md
+++ b/README.md
@@ -105,6 +105,19 @@ Note that only the following files (for each language) should be committed to th
 * djangojs.po
 
 
+Asset Pipeline
+--------------
+Static files are managed via [django-compressor](http://django-compressor.readthedocs.org/) and [RequireJS](http://requirejs.org/).
+RequireJS (and r.js) are used to manage JavaScript dependencies. django-compressor compiles SASS, minifies JavaScript,
+and handles naming files to facilitate cache busting during deployment.
+
+Both tools should operate seamlessly in a local development environment. When deploying to production, call
+`make static` to compile all static assets and move them to the proper location to be served.
+
+When creating new pages that utilize RequireJS dependencies, remember to use the `static_rjs` templatetag to load
+the script, and to add a new module to `build.js`.
+
+
 License
 -------
 The code in this repository is licensed under version 3 of the AGPL unless otherwise noted.

--- a/analytics_dashboard/analytics_dashboard/settings/base.py
+++ b/analytics_dashboard/analytics_dashboard/settings/base.py
@@ -221,6 +221,7 @@ DJANGO_APPS = (
 LOCAL_APPS = (
     'analytics_dashboard',
     'courses',
+    'django_rjs',
 )
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#installed-apps
@@ -380,3 +381,6 @@ COURSE_PERMISSIONS_CLAIMS = ['staff_courses']
 PLATFORM_NAME = 'Your Platform Name Here'
 APPLICATION_NAME = 'Insights'
 FULL_APPLICATION_NAME = '{0} {1}'.format(PLATFORM_NAME, APPLICATION_NAME)
+
+RJS_OUTPUT_DIR = 'dist'
+RJS_OPTIMIZATION_ENABLED = False

--- a/analytics_dashboard/analytics_dashboard/settings/production.py
+++ b/analytics_dashboard/analytics_dashboard/settings/production.py
@@ -15,6 +15,9 @@ from analytics_dashboard.settings.logger import get_logger_config
 COMPRESS_ENABLED = True
 COMPRESS_OFFLINE = True
 
+# Use r.js to combine RequireJS files
+RJS_OPTIMIZATION_ENABLED = True
+
 # Minify CSS
 COMPRESS_CSS_FILTERS += [
     'compressor.filters.cssmin.CSSMinFilter',

--- a/analytics_dashboard/courses/templates/courses/engagement_content.html
+++ b/analytics_dashboard/courses/templates/courses/engagement_content.html
@@ -4,6 +4,7 @@
 {% load staticfiles %}
 {% load waffle_tags %}
 {% load dashboard_extras %}
+{% load rjs %}
 
 {% comment %}
 Individual course-centric engagement content view.
@@ -13,7 +14,7 @@ Individual course-centric engagement content view.
 
 {% block javascript %}
   {{ block.super }}
-  <script src="{% static 'js/engagement-content-main.js' %}"></script>
+  <script src="{% static_rjs 'js/engagement-content-main.js' %}"></script>
 {% endblock javascript %}
 
 {% block child_content %}

--- a/analytics_dashboard/courses/templates/courses/enrollment_activity.html
+++ b/analytics_dashboard/courses/templates/courses/enrollment_activity.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% load dashboard_extras %}
 {% load staticfiles %}
+{% load rjs %}
 
 {% comment %}
 Individual course-centric enrollment activity view.
@@ -11,7 +12,7 @@ Individual course-centric enrollment activity view.
 
 {% block javascript %}
   {{ block.super }}
-  <script src="{% static 'js/enrollment-activity-main.js' %}"></script>
+  <script src="{% static_rjs 'js/enrollment-activity-main.js' %}"></script>
 {% endblock javascript %}
 
 

--- a/analytics_dashboard/courses/templates/courses/enrollment_demographics_age.html
+++ b/analytics_dashboard/courses/templates/courses/enrollment_demographics_age.html
@@ -2,12 +2,13 @@
 {% load i18n %}
 {% load dashboard_extras %}
 {% load staticfiles %}
+{% load rjs %}
 
 {% block view-name %}view-course-enrollment view-dashboard{% endblock view-name %}
 
 {% block javascript %}
 {{ block.super }}
-<script src="{% static 'js/enrollment-demographics-age-main.js' %}"></script>
+<script src="{% static_rjs 'js/enrollment-demographics-age-main.js' %}"></script>
 {% endblock javascript %}
 
 

--- a/analytics_dashboard/courses/templates/courses/enrollment_demographics_education.html
+++ b/analytics_dashboard/courses/templates/courses/enrollment_demographics_education.html
@@ -2,12 +2,13 @@
 {% load i18n %}
 {% load dashboard_extras %}
 {% load staticfiles %}
+{% load rjs %}
 
 {% block view-name %}view-course-enrollment view-dashboard{% endblock view-name %}
 
 {% block javascript %}
 {{ block.super }}
-<script src="{% static 'js/enrollment-demographics-education-main.js' %}"></script>
+<script src="{% static_rjs 'js/enrollment-demographics-education-main.js' %}"></script>
 {% endblock javascript %}
 
 

--- a/analytics_dashboard/courses/templates/courses/enrollment_demographics_gender.html
+++ b/analytics_dashboard/courses/templates/courses/enrollment_demographics_gender.html
@@ -2,12 +2,13 @@
 {% load i18n %}
 {% load dashboard_extras %}
 {% load staticfiles %}
+{% load rjs %}
 
 {% block view-name %}view-course-enrollment view-dashboard{% endblock view-name %}
 
 {% block javascript %}
 {{ block.super }}
-<script src="{% static 'js/enrollment-demographics-gender-main.js' %}"></script>
+<script src="{% static_rjs 'js/enrollment-demographics-gender-main.js' %}"></script>
 {% endblock javascript %}
 
 

--- a/analytics_dashboard/courses/templates/courses/enrollment_geography.html
+++ b/analytics_dashboard/courses/templates/courses/enrollment_geography.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% load staticfiles %}
 {% load dashboard_extras %}
+{% load rjs %}
 
 {% comment %}
 Individual course-centric enrollment geography view.
@@ -11,7 +12,7 @@ Individual course-centric enrollment geography view.
 
 {% block javascript %}
   {{ block.super }}
-  <script src="{% static 'js/enrollment-geography-main.js' %}"></script>
+  <script src="{% static_rjs 'js/enrollment-geography-main.js' %}"></script>
 {% endblock javascript %}
 
 {% block child_content %}

--- a/analytics_dashboard/django_rjs/models.py
+++ b/analytics_dashboard/django_rjs/models.py
@@ -1,0 +1,1 @@
+# This app does not require any models.

--- a/analytics_dashboard/django_rjs/templatetags/rjs.py
+++ b/analytics_dashboard/django_rjs/templatetags/rjs.py
@@ -1,0 +1,45 @@
+from django import template
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from django.templatetags.static import StaticNode
+from django.contrib.staticfiles.storage import staticfiles_storage
+
+
+register = template.Library()
+
+
+def get_rjs_path(path):
+    if getattr(settings, 'RJS_OPTIMIZATION_ENABLED', False):
+        rjs_output_dir = getattr(settings, 'RJS_OUTPUT_DIR')
+
+        if rjs_output_dir:
+            return '{0}/{1}'.format(rjs_output_dir, path)
+
+        raise ImproperlyConfigured('RJS_OPTIMIZATION_ENABLED is set to True, but RJS_OUTPUT_DIR has not been set.')
+
+    return path
+
+
+class RjsStaticFilesNode(StaticNode):
+    def url(self, context):
+        path = self.path.resolve(context)
+        path = get_rjs_path(path)
+        return staticfiles_storage.url(path)
+
+
+@register.tag('static_rjs')
+def do_static(parser, token):
+    """
+    A template tag that returns the URL to a file (that has been optimized by r.js)
+    using staticfiles' storage backend
+
+    Usage::
+
+        {% static_rjs path [as varname] %}
+
+    Examples::
+
+        {% static_rjs "myapp/js/main.js" %}
+
+    """
+    return RjsStaticFilesNode.handle_token(parser, token)

--- a/analytics_dashboard/django_rjs/tests.py
+++ b/analytics_dashboard/django_rjs/tests.py
@@ -1,0 +1,25 @@
+from django.core.exceptions import ImproperlyConfigured
+from django.test import TestCase
+
+from django_rjs.templatetags.rjs import get_rjs_path
+
+
+class RjsTests(TestCase):
+    def test_get_rjs_path(self):
+        rjs_dir = 'rjs-test'
+        path = 'js/test.js'
+
+        # The path should not be modified if r.js optimization is disabled.
+        with self.settings(RJS_OPTIMIZATION_ENABLED=False):
+            actual = get_rjs_path(path)
+            self.assertEqual(actual, path)
+
+        with self.settings(RJS_OPTIMIZATION_ENABLED=True):
+            # An exception should be raised if optimization is enabled but no output directory is configured.
+            with self.settings(RJS_OUTPUT_DIR=None):
+                self.assertRaises(ImproperlyConfigured, get_rjs_path, path)
+
+            # If optimization is enabled and a directory configured, the directory should be prepended to the path.
+            with self.settings(RJS_OUTPUT_DIR=rjs_dir):
+                actual = get_rjs_path(path)
+                self.assertEqual(actual, rjs_dir + '/' + path)

--- a/analytics_dashboard/static/js/common.js
+++ b/analytics_dashboard/static/js/common.js
@@ -1,85 +1,10 @@
-/**
- * This defines our libraries across the application.  Each page
- * should load this file.
- */
-
-var require_config = {
-    baseUrl: '/static/',
-    waitSeconds: 60,
-    paths: {
-        jquery: 'bower_components/jquery/dist/jquery.min',
-        underscore: 'bower_components/underscore/underscore-min',
-        backbone: 'bower_components/backbone/backbone',
-        bootstrap: 'bower_components/bootstrap-sass-official/assets/javascripts/bootstrap',
-        bootstrap_accessibility: 'bower_components/bootstrapaccessibilityplugin/plugins/js/bootstrap-accessibility.min',
-        models: 'js/models',
-        views: 'js/views',
-        utils: 'js/utils',
-        load: 'js/load',
-        dataTables: 'bower_components/datatables/media/js/jquery.dataTables.min',
-        dataTablesBootstrap: 'vendor/dataTables/dataTables.bootstrap',
-        d3: 'bower_components/d3/d3.min',
-        nvd3: 'bower_components/nvd3/nv.d3.min',
-        topojson: 'bower_components/topojson/topojson',
-        datamaps: 'bower_components/datamaps/dist/datamaps.world.min',
-        moment: 'bower_components/moment/min/moment-with-locales.min',
-        text: 'bower_components/requirejs-plugins/lib/text',
-        json: 'bower_components/requirejs-plugins/src/json',
-        cldr: 'bower_components/cldrjs/dist/cldr',
-        'cldr-data': 'bower_components/cldr-data',
-        globalize: 'bower_components/globalize/dist/globalize',
-        globalization: 'js/utils/globalization'
-    },
-    shim: {
-        bootstrap: {
-            deps: ['jquery']
-        },
-        bootstrap_accessibility: {
-            deps: ['bootstrap']
-        },
-        underscore: {
-            exports: '_'
-        },
-        backbone: {
-            deps: ['underscore', 'jquery'],
-            exports: 'Backbone',
-            init: function (_, $) {
-                'use strict';
-                Backbone.$ = $;
-                return Backbone;
-            }
-        },
-        dataTablesBootstrap: {
-            deps: ['jquery', 'dataTables']
-        },
-        d3: {
-            exports: 'd3'
-        },
-        nvd3: {
-            deps: ['d3'],
-            exports: 'nv'
-        },
-        datamaps: {
-            deps: ['topojson', 'd3'],
-            exports: 'datamap'
-        },
-        moment: {
-            noGlobal: true
-        },
-        json: {
-            deps: ['text']
-        },
-        globalize: {
-            deps: ['jquery', 'cldr'],
-            exports: 'Globalize'
-        },
-        globalization: {
-            deps: ['globalize'],
-            exports: 'Globalize'
-        }
-    },
-    // load jquery automatically
-    deps: ['jquery']
-};
-
-requirejs.config(require_config);
+require([
+    'jquery',
+    'underscore',
+    'backbone',
+    'bootstrap',
+    'bootstrap_accessibility',
+    'vendor/domReady!',
+    'load/init-page'
+], function () {
+});

--- a/analytics_dashboard/static/js/config.js
+++ b/analytics_dashboard/static/js/config.js
@@ -1,0 +1,81 @@
+/**
+ * This defines our libraries across the application.  Each page
+ * should load this file.
+ */
+
+require.config({
+    baseUrl: '/static/',
+    waitSeconds: 60,
+    paths: {
+        jquery: 'bower_components/jquery/dist/jquery',
+        underscore: 'bower_components/underscore/underscore',
+        backbone: 'bower_components/backbone/backbone',
+        bootstrap: 'bower_components/bootstrap-sass-official/assets/javascripts/bootstrap',
+        bootstrap_accessibility: 'bower_components/bootstrapaccessibilityplugin/plugins/js/bootstrap-accessibility',
+        models: 'js/models',
+        views: 'js/views',
+        utils: 'js/utils',
+        load: 'js/load',
+        dataTables: 'bower_components/datatables/media/js/jquery.dataTables',
+        dataTablesBootstrap: 'vendor/dataTables/dataTables.bootstrap',
+        d3: 'bower_components/d3/d3',
+        nvd3: 'bower_components/nvd3/nv.d3',
+        topojson: 'bower_components/topojson/topojson',
+        datamaps: 'bower_components/datamaps/dist/datamaps.world',
+        moment: 'bower_components/moment/min/moment-with-locales.min',
+        text: 'bower_components/requirejs-plugins/lib/text',
+        json: 'bower_components/requirejs-plugins/src/json',
+        cldr: 'bower_components/cldrjs/dist/cldr',
+        'cldr-data': 'bower_components/cldr-data',
+        globalize: 'bower_components/globalize/dist/globalize',
+        globalization: 'js/utils/globalization'
+    },
+    shim: {
+        bootstrap: {
+            deps: ['jquery']
+        },
+        bootstrap_accessibility: {
+            deps: ['bootstrap']
+        },
+        underscore: {
+            exports: '_'
+        },
+        backbone: {
+            deps: ['underscore', 'jquery'],
+            exports: 'Backbone',
+            init: function (_, $) {
+                'use strict';
+                Backbone.$ = $;
+                return Backbone;
+            }
+        },
+        dataTablesBootstrap: {
+            deps: ['jquery', 'dataTables']
+        },
+        d3: {
+            exports: 'd3'
+        },
+        nvd3: {
+            deps: ['d3'],
+            exports: 'nv'
+        },
+        datamaps: {
+            deps: ['topojson', 'd3'],
+            exports: 'datamap'
+        },
+        moment: {
+            noGlobal: true
+        },
+        json: {
+            deps: ['text']
+        },
+        globalize: {
+            deps: ['jquery', 'cldr'],
+            exports: 'Globalize'
+        },
+        globalization: {
+            deps: ['globalize'],
+            exports: 'Globalize'
+        }
+    }
+});

--- a/analytics_dashboard/static/js/test/spec-runner.js
+++ b/analytics_dashboard/static/js/test/spec-runner.js
@@ -5,8 +5,7 @@
 
 var isBrowser = window.__karma__ === undefined,
     specs = [],
-    // Loaded from js/common.js
-    config = require_config;    // jshint ignore:line
+    config = {};
 
 // Two execution paths: browser or gulp
 if (isBrowser) {

--- a/analytics_dashboard/templates/base.html
+++ b/analytics_dashboard/templates/base.html
@@ -2,6 +2,7 @@
 {% load staticfiles %}
 {% load compress %}
 {% load dashboard_extras %}
+{% load rjs %}
 
 <!DOCTYPE html>
 <!--[if lte IE 9]><html class="no-js lt-ie10" lang="en"><![endif]-->
@@ -99,11 +100,15 @@
 
     {% compress js %}
       <script src="{% static 'bower_components/requirejs/require.js' %}"></script>
-      <script src="{% static 'js/common.js' %}"></script>
+      <script src="{% static_rjs 'js/config.js' %}"></script>
 
       {# Note: django-compressor does not recognize the data-main attribute. Load the main script separately. #}
-      <script src="{% static 'js/application-main.js' %}"></script>
+      <script src="{% static_rjs 'js/common.js' %}"></script>
+    {% endcompress %}
 
+
+    {% compress js %}
+      {# Note: This block is purposely separated from the one above so that browsers cache the common JS instead of downloading a single, large file for each page. #}
       {% block javascript %}
       {% endblock javascript %}
     {% endcompress %}

--- a/build.js
+++ b/build.js
@@ -1,0 +1,48 @@
+/* jshint asi: true, expr:true */
+({
+    mainConfigFile: 'analytics_dashboard/static/js/config.js',
+    baseUrl: 'analytics_dashboard/static',
+    dir: 'analytics_dashboard/static/dist',
+    removeCombined: true,
+    findNestedDependencies: true,
+
+    // Disable all optimization. django-compressor will handle that for us.
+    optimizeCss: false,
+    optimize: 'none',
+    normalizeDirDefines: 'all',
+    skipDirOptimize: true,
+
+    preserveLicenseComments: true,
+    modules: [
+        {
+            name: 'js/common'
+        },
+        {
+            name: 'js/config'
+        },
+        {
+            name: 'js/engagement-content-main',
+            exclude: ['js/common']
+        },
+        {
+            name: 'js/enrollment-activity-main',
+            exclude: ['js/common']
+        },
+        {
+            name: 'js/enrollment-geography-main',
+            exclude: ['js/common']
+        },
+        {
+            name: 'js/enrollment-demographics-age-main',
+            exclude: ['js/common']
+        },
+        {
+            name: 'js/enrollment-demographics-education-main',
+            exclude: ['js/common']
+        },
+        {
+            name: 'js/enrollment-demographics-gender-main',
+            exclude: ['js/common']
+        }
+    ]
+})

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,6 +13,7 @@
                 'analytics_dashboard/static/js/test/**/*.js'
             ],
             lint: [
+                'build.js',
                 'gulpfile.js',
                 'analytics_dashboard/static/js/**/*.js',
                 'analytics_dashboard/static/js/test/**/*.js'

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -22,7 +22,7 @@ module.exports = function (config) {
             {pattern: 'analytics_dashboard/static/js/views/**/*.js', included: false},
             {pattern: 'analytics_dashboard/static/js/utils/**/*.js', included: false},
             {pattern: 'analytics_dashboard/static/js/test/specs/*.js', included: false},
-            'analytics_dashboard/static/js/common.js',
+            'analytics_dashboard/static/js/config.js',
             'analytics_dashboard/static/js/test/spec-runner.js'
         ],
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "browser-sync": "^1.1.2",
-    "gulp": "^3.8.1",
+    "gulp": "^3.8.8",
     "gulp-jscs": "^1.2.1",
     "gulp-jshint": "^1.6.3",
     "gulp-karma": "0.0.4",


### PR DESCRIPTION
RequireJS is used normally (dependencies loaded individually) in development.
Flipping the RJS_OPTIMIZATION_ENABLED bit and running r.js (before compress)
will result in all dependencies being bundled and downloaded together.

@rocha @dsjen @andy-armstrong
