### PR TITLE
Removed enrollment warnings, fixes DOC-1126

### DIFF
--- a/docs/en_us/dashboard/source/Reference.rst
+++ b/docs/en_us/dashboard/source/Reference.rst
@@ -53,11 +53,6 @@ Enrollment Computations
 The number of enrolled students is computed every day, and the values reported
 on the Enrollment Activity page in edX Insights are updated every day.
 
-.. important:: EdX changed the method used to track student enrollments on 
- 3 December 2013. As a result, enrollment activity data is not computed for
- courses created in Studio prior to December 4, 2013. Geographic data relating
- to enrollment is available for those courses.
-
 For information about viewing enrollment activity data in edX Insights, see
 :ref:`Enrollment_Activity`.
 
@@ -353,10 +348,6 @@ Error Conditions
 
 The data that edX collects from student interactions has expanded over time to
 capture increasingly specific information, and continues to expand as we add
-new features to the platform. As a result, more data is available for more
-courses that ran recently. Not all data for every value reported by edX
-Insights is available for every course run.
-
-EdX changed the method used to track student enrollments on 3 December 2013. As
-a result, enrollment activity data is not computed for courses created in
-Studio prior to 4 December 2013. Other data is available for those courses.
+new features to the platform. As a result, more data is available for courses
+that are running now, or that ran recently. Not all data for every value
+reported by edX Insights is available for every course run.

--- a/docs/en_us/dashboard/source/change_log.rst
+++ b/docs/en_us/dashboard/source/change_log.rst
@@ -2,16 +2,15 @@
 Change Log
 ############
 
-*****************
-September, 2014
-*****************
-
 .. list-table::
    :widths: 10 70
    :header-rows: 1
 
    * - Date
      - Change
+   * - 11/24/14
+     - Enrollment history is now available for all courses. See
+       :ref:`Enrollment_Activity` and :ref:`Reference`.
    * - 11/05/14
      - Added :ref:`Enrollment_Demographics`.
    * - 09/30/14

--- a/docs/en_us/dashboard/source/enrollment/Enrollment_Activity.rst
+++ b/docs/en_us/dashboard/source/enrollment/Enrollment_Activity.rst
@@ -11,9 +11,6 @@ changes over time.
 Enrollment activity data is updated every day to include changes in enrollment
 through the end of the previous day (23:59 UTC).
 
-.. note:: Enrollment activity data is not available for courses created in
- Studio before December 4, 2013.
-
 ********************************************
 Gaining Insight into Course Enrollment
 ********************************************


### PR DESCRIPTION
After discussion with @brianhw , most information about providing enrollment events for courses that started before 12/3/13 will go in release notes (separate repo and PR).
This PR removes the notes about enrollment for those courses, as all (+/-) courses will now display enrollment data.
@shnayder @mhoeber @WatsonEmily @catong @srpearce 
