### PR TITLE
Removed outline when hovering over links.

### DIFF
--- a/analytics_dashboard/static/sass/_base.scss
+++ b/analytics_dashboard/static/sass/_base.scss
@@ -21,6 +21,19 @@ a {
   @include transition(color ease-in-out .25s);
 }
 
+
+// removes the outline around links when hovering
+a {
+  &:active, &:hover {
+    outline: none;
+  }
+}
+
+// removes the outline around nav links when hovering
+.nav > li > a {
+  @extend a;
+}
+
 hr.has-emphasis {
   margin-top: $padding-base-vertical;
   border-color: $gray-dark;

--- a/analytics_dashboard/static/sass/_developer.scss
+++ b/analytics_dashboard/static/sass/_developer.scss
@@ -217,6 +217,11 @@ $lens-box-model: border-box;
     color: $lens-nav-text-color;
     padding-top: 0px;
     padding-bottom: $padding-small-vertical;
+
+    // use darkest gray when hovering over sub-lens nav (e.g. age, education, gender)
+    &:hover {
+      color: $edx-gray-d2
+    }
   }
 
   li.active > a {


### PR DESCRIPTION
- outline is removed when hovering over links
- outline still exists in the drop down (unfortunately)

Previously with outline:
![outline](https://cloud.githubusercontent.com/assets/5265058/4958866/22b6d2a4-66b3-11e4-9924-33f4984584d8.png)

Proposed update without outline:
![no-outline](https://cloud.githubusercontent.com/assets/5265058/4958867/22b78e60-66b3-11e4-9b7d-ce5f62ffc3e3.png)

I didn't spend too much time on this and made a small improvement in removing the outline when hovering over links.

@rocha @clintonb @marcotuts @shnayder 
