### PR TITLE
Fixed demographic gender acceptance test when None type is returned for gender.

### DIFF
--- a/acceptance_tests/test_course_enrollment_demographics.py
+++ b/acceptance_tests/test_course_enrollment_demographics.py
@@ -135,7 +135,7 @@ class CourseEnrollmentDemographicsGenderTests(CourseDemographicsPageTestsMixin, 
 
         expected = [expected_date, self.format_number(gender_total)]
         for gender in genders:
-            expected.append(self.format_number(datum.get(gender, 0)))
+            expected.append(self.format_number(datum.get(gender, 0) or 0))
 
         actual = []
         for i in range(6):


### PR DESCRIPTION
- gender test was intermittently failing because `datum.get(gender, 0)` was returning `None` whereas the generated expected result should be 0

@rocha @clintonb 
