### PR TITLE
Setting Administrator Permissions via OIDC

### DIFF
--- a/analytics_dashboard/analytics_dashboard/backends.py
+++ b/analytics_dashboard/analytics_dashboard/backends.py
@@ -18,7 +18,7 @@ class EdXOpenIdConnect(OpenIdConnectAuth):
     REDIRECT_STATE = False
     ID_KEY = 'preferred_username'
 
-    DEFAULT_SCOPE = ['openid', 'profile', 'email'] + settings.COURSE_PERMISSIONS_SCOPE
+    DEFAULT_SCOPE = ['openid', 'profile', 'email', 'permissions'] + settings.COURSE_PERMISSIONS_SCOPE
     ID_TOKEN_ISSUER = settings.SOCIAL_AUTH_EDX_OIDC_URL_ROOT
     AUTHORIZATION_URL = '{0}/authorize/'.format(settings.SOCIAL_AUTH_EDX_OIDC_URL_ROOT)
     ACCESS_TOKEN_URL = '{0}/access_token/'.format(settings.SOCIAL_AUTH_EDX_OIDC_URL_ROOT)
@@ -80,6 +80,9 @@ class EdXOpenIdConnect(OpenIdConnectAuth):
         locale = response.get('locale')
         if locale:
             details[u'language'] = _to_language(response['locale'])
+
+        # Set superuser bit if the provider determines the user is an administrator
+        details[u'is_superuser'] = details[u'is_staff'] = response.get('administrator', False)
 
         return details
 

--- a/analytics_dashboard/analytics_dashboard/tests/test_views.py
+++ b/analytics_dashboard/analytics_dashboard/tests/test_views.py
@@ -178,6 +178,7 @@ class OpenIdConnectTests(UserTestCaseMixin, RedirectTestCaseMixin, TestCase):
     DEFAULT_USERNAME = 'edx'
     backend_name = 'edx-oidc'
     backend_class = EdXOpenIdConnect
+    user_is_administrator = False
 
     def setUp(self):
         super(OpenIdConnectTests, self).setUp()
@@ -219,7 +220,8 @@ class OpenIdConnectTests(UserTestCaseMixin, RedirectTestCaseMixin, TestCase):
             'name': 'Ed Xavier',
             'given_name': 'Ed',
             'family_name': 'Xavier',
-            'locale': 'en_US'
+            'locale': 'en_US',
+            'administrator': self.user_is_administrator
         }
 
         return id_token
@@ -301,6 +303,15 @@ class OpenIdConnectTests(UserTestCaseMixin, RedirectTestCaseMixin, TestCase):
         self.assertEqual(user.first_name, 'Ed')
         self.assertEqual(user.last_name, 'Xavier')
         self.assertEqual(user.language, 'en-us')
+
+    def test_administrator(self):
+        # Create an administrator via OAuth2
+        self.user_is_administrator = True
+        self._check_oauth2_handshake()
+
+        user = self.get_latest_user()
+        self.assertTrue(user.is_superuser)
+        self.assertTrue(user.is_staff)
 
 
 class AutoAuthTests(UserTestCaseMixin, TestCase):

--- a/analytics_dashboard/courses/permissions.py
+++ b/analytics_dashboard/courses/permissions.py
@@ -1,4 +1,3 @@
-
 import datetime
 import logging
 
@@ -137,6 +136,10 @@ def user_can_view_course(user, course_id):
         user (User)     --  User whose permissions are being checked
         course_id (str) --  Course to check
     """
+
+    if user.is_superuser:
+        return True
+
     courses = get_user_course_permissions(user)
 
     return course_id in courses

--- a/analytics_dashboard/courses/tests/test_permissions.py
+++ b/analytics_dashboard/courses/tests/test_permissions.py
@@ -64,6 +64,21 @@ class PermissionsTests(TestCase):
         permissions.set_user_course_permissions(self.user, [self.course_id])
         self.assertTrue(permissions.user_can_view_course(self.user, self.course_id))
 
+    def test_superuser_can_view_course(self):
+        """ Verify that superusers can view everything. """
+        user = self.user
+        user.is_superuser = True
+        user.save()
+
+        # With no permissions set, a superuser should still be able to view a course.
+        permissions.set_user_course_permissions(user, [])
+        self.assertTrue(permissions.user_can_view_course(user, self.course_id))
+
+        # With permissions set, a superuser should be able to view a course
+        # (although the individual permissions don't matter).
+        permissions.set_user_course_permissions(user, [self.course_id])
+        self.assertTrue(permissions.user_can_view_course(user, self.course_id))
+
     @mock.patch('courses.permissions.refresh_user_course_permissions', side_effect=set_empty_permissions)
     def test_user_can_view_course_refresh(self, mock_refresh):
         """


### PR DESCRIPTION
Users updated via OIDC can now be marked as administrators. These administrators will have access to the admin portal as well as permission to view all courses.

@rocha @dsjen
