### PR TITLE
Using a Frozen Version of Globalize

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "tests"
   ],
   "dependencies": {
-    "globalize": "~1.0.0-alpha.12",
+    "globalize": "1.0.0-alpha.13",
     "requirejs-plugins": "~1.0.2",
     "bootstrap-sass-official": "v3.2.0+2",
     "jquery": "~1.11.1",
@@ -27,5 +27,8 @@
     "datatables": "~1.10.2",
     "font-awesome": "~4.2.0",
     "natural-sort": "overset/javascript-natural-sort#dbf4ca259b327a488bd1d7897fd46d80c414a7e0"
+  },
+  "resolutions": {
+    "cldrjs": "0.3.10"
   }
 }


### PR DESCRIPTION
The edX AMI build continues to have issues with the unfixed version. Also, setting the resolution once more.
