### PR TITLE
Updated course homepage layout so question headers sit on top of content on small screens.

### DIFF
--- a/analytics_dashboard/courses/templates/courses/home.html
+++ b/analytics_dashboard/courses/templates/courses/home.html
@@ -32,21 +32,19 @@
   <div class="container course-home-table-outer">
     <div class="row">
       {% for column in table_items %}
+
         <div class="col-sm-4">
-          <header><div class="heading">{{ column.heading }}</div></header>
-        </div>
-      {% endfor %}
-    </div>
-    <div class="row">
-      {% for column in table_items %}
-        <div class="col-sm-4">
+          <header>
+            <div class="heading">{{ column.heading }}</div>
+          </header>
+
           <div class="row course-home-table">
-            <div class="col-sm-12 item name">
+            <div class="item name">
               <i class="ico fa {{ column.icon }}" aria-hidden="true"></i> {{ column.name }}
             </div>
 
             {% for item in column.items %}
-              <div class="col-sm-12 item">
+              <div class="item">
                 <div class="title"><a href="{% url item.view course_id=course_id %}">{{ item.title }}</a></div>
                 <div class="breadcrumbs">
                   <i class="ico fa {{ column.icon }}" aria-hidden="true"></i>
@@ -61,6 +59,7 @@
               </div>
             {% endfor %}
           </div>
+
         </div>
       {% endfor %}
 

--- a/analytics_dashboard/static/sass/_developer.scss
+++ b/analytics_dashboard/static/sass/_developer.scss
@@ -377,6 +377,11 @@ table.dataTable thead th.sorting_desc:after {
     color: $edx-blue;
     padding-bottom: $padding-large-vertical;
     @extend .text-center;
+
+    // increase line height for med-small screens so headers are same level for long lines
+    @media (max-width: $screen-md-max) and (min-width: $screen-sm-min) {
+      min-height: $font-size-large * 3.5;
+    }
   }
 
   .course-home-table {


### PR DESCRIPTION
Previous:
![previous](https://cloud.githubusercontent.com/assets/5265058/5531797/b53626d0-89fd-11e4-815c-362e5bc43b9d.png)

Updated:
![screen shot 2014-12-22 at 5 05 51 pm](https://cloud.githubusercontent.com/assets/5265058/5531804/c3a89c66-89fd-11e4-9b5f-7816fbfa041b.png)

![screen shot 2014-12-22 at 5 05 39 pm](https://cloud.githubusercontent.com/assets/5265058/5531806/c6d1c84a-89fd-11e4-95e7-45a66c90865f.png)

@rocha @clintonb 
