### PR TITLE
Engagement call end date increased by a day.

### DIFF
--- a/analytics_dashboard/courses/presenters.py
+++ b/analytics_dashboard/courses/presenters.py
@@ -179,7 +179,9 @@ class CourseEngagementPresenter(BasePresenter):
         """
         Retrieve recent summary and all historical trend data.
         """
-        api_trends = self.course.activity(start_date=None, end_date=self.get_current_date())
+        # setting the end date (exclusive) to the next day retrieves data as soon as it's available
+        end_date = (datetime.datetime.utcnow() + datetime.timedelta(days=1)).strftime(Client.DATE_FORMAT)
+        api_trends = self.course.activity(start_date=None, end_date=end_date)
         summary = self._build_summary(api_trends)
         trends = self._build_trend(api_trends)
         return summary, trends

--- a/analytics_dashboard/courses/tests/test_presenters.py
+++ b/analytics_dashboard/courses/tests/test_presenters.py
@@ -107,6 +107,10 @@ class BasePresenterTests(TestCase):
     def test_strip_time(self):
         self.assertEqual(self.presenter.strip_time('2014-01-01T000000'), '2014-01-01')
 
+    def test_get_current_date(self):
+        dt_format = '%Y-%m-%d'
+        self.assertEqual(self.presenter.get_current_date(), datetime.datetime.utcnow().strftime(dt_format))
+
 
 class CourseEnrollmentPresenterTests(SwitchMixin, TestCase):
     @classmethod


### PR DESCRIPTION
The engagement end date has been shifted a day ahead so that when data the latest weekly data is available on Monday, rather than having to wait until the next day to view it.  AN-4150

@rocha @clintonb 
