### PR TITLE
Fixed JWT Issue in Python Social Auth

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,14 @@ django-model-utils==1.5.0 	# BSD
 django_compressor==1.4		# MIT
 django-appconf==0.6
 logutils==0.3.3				# BSD
-python-social-auth==0.2.0   # BSD
+
+# Needed to subclass the OIDC test in python-social-auth
+unittest2==0.8.0            # BSD
+
+# TODO Use PyPi once package has been updated
+#python-social-auth==0.2.0   # BSD
+git+https://github.com/edx/python-social-auth.git@freeze-pyjwt#egg=python-social-auth
+
 django-waffle==0.10			# BSD
 
 # TODO Use PyPi once package has been updated
@@ -15,6 +22,7 @@ git+https://github.com/SmileyChris/django-countries.git@ece149d706aaf812afd6b398
 
 # TODO Use the PyPi package once it is updated.
 -e git+https://github.com/edx/django-announcements.git@django-1.7#egg=django-announcements # MIT
+
 -e git+https://github.com/edx/edx-analytics-data-api-client.git@0.3.0#egg=edx-analytics-data-api-client # edX
 -e git+https://github.com/edx/django-lang-pref-middleware.git@0.1.0#egg=django-lang-pref-middleware
 -e git+https://github.com/edx/i18n-tools.git@0d7847f9dfa2281640527b4dc51f5854f950f9b7#egg=i18n_tools


### PR DESCRIPTION
PyJWT 0.3.0 introduced a validation that is not needed by PSA. Our fork of PSA has been updated to freeze PyJWT at 0.2.3, and a [pull request has been opened](https://github.com/omab/python-social-auth/pull/486).

@rocha @dsjen @benpatterson 
