### PR TITLE
Send unit and JS test coverage data to datadog

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,4 @@ script:
     - bash ./runAcceptance.sh
 after_success:
     - coveralls
+    - bash ./report-coverage-to-datadog.sh

--- a/scripts/report-coverage-to-datadog.sh
+++ b/scripts/report-coverage-to-datadog.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+#
+# This script will report various coverage metrics to datadog.
+#
+#
+
+if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ -n $DATADOG_API_KEY ]
+
+    echo "Reporting coverage stats to datadog"
+    git clone test-metrics https://github.com/wedaly/test-metrics
+
+    cd test-metrics
+    virtualenv venv
+    source ./venv/bin/activate
+    pip install -r requirements.txt
+
+    cat > unit_test_groups.json <<END
+    {
+        "unit.analytics_dashboard": "analytics_dashboard/*.py",
+        "javascript.analytics_dashboard": "*.js"
+    }
+    END
+
+    cat > acceptance_test_group.json <<END
+    {
+        "acceptance.analytics_dashboard": "analytics_dashboard/*.py"
+    }
+    END
+
+    python -m metrics.coverage unit_test_groups.json `find ../build -name "coverage.xml"`
+    python -m metrics.coverage acceptance_test_group.json `find ../acceptance_tests/build -name "coverage.xml"`
+
+    deactivate
+
+fi

--- a/scripts/report-coverage-to-datadog.sh
+++ b/scripts/report-coverage-to-datadog.sh
@@ -7,30 +7,28 @@
 
 if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ -n $DATADOG_API_KEY ]
 
+    then
     echo "Reporting coverage stats to datadog"
-    git clone test-metrics https://github.com/wedaly/test-metrics
+    git clone https://github.com/wedaly/test-metrics
 
     cd test-metrics
     virtualenv venv
     source ./venv/bin/activate
-    pip install -r requirements.txt
+    pip install -q -r requirements.txt
 
     cat > unit_test_groups.json <<END
-    {
-        "unit.analytics_dashboard": "analytics_dashboard/*.py",
-        "javascript.analytics_dashboard": "*.js"
-    }
-    END
-
-    cat > acceptance_test_group.json <<END
-    {
-        "acceptance.analytics_dashboard": "analytics_dashboard/*.py"
-    }
-    END
+{
+    "unit.analytics_dashboard": "analytics_dashboard/*.py",
+    "javascript.analytics_dashboard": "*.js"
+}
+END
 
     python -m metrics.coverage unit_test_groups.json `find ../build -name "coverage.xml"`
-    python -m metrics.coverage acceptance_test_group.json `find ../acceptance_tests/build -name "coverage.xml"`
 
     deactivate
+
+else
+    echo "Note: Not reporting stats to datadog. Those are only reported for builds on master, \
+and when the datadog api key is available."
 
 fi


### PR DESCRIPTION
Note the metric names:

Reporting metrics to DataDog...
Sending test_eng.coverage.unit.analytics_dashboard ==> 84.3137254902%
Sending test_eng.coverage.javascript.analytics_dashboard ==> 70.2127659574%
Done.

Travis config still needs to be done, but this PR provides the capability. CC @jzoldak @clintonb @dsjen 
