### PR TITLE
Don't use -e in requirements.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ git+https://github.com/edx/python-social-auth.git@pyjwt-fix#egg=python-social-au
 git+https://github.com/pinax/django-announcements.git@bda39727f2c9158c0bb5eba1604b44f14deae5b0#egg=django-announcements # MIT
 
 git+https://github.com/edx/django-lang-pref-middleware.git@0.1.0#egg=django-lang-pref-middleware
-git+https://github.com/edx/edx-analytics-data-api-client.git@0.4.0#egg=edx-analytics-data-api-client # edX
+-e git+https://github.com/edx/edx-analytics-data-api-client.git@0.4.0#egg=edx-analytics-data-api-client # edX
 git+https://github.com/edx/edx-server-api-client.git@0.1.0#egg=edx-server-api-client
 git+https://github.com/edx/i18n-tools.git@0d7847f9dfa2281640527b4dc51f5854f950f9b7#egg=i18n_tools
 git+https://github.com/edx/opaque-keys.git@d45d0bd8d64c69531be69178b9505b5d38806ce0#egg=opaque-keys

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,10 +17,10 @@ unittest2==0.8.0            # BSD
 git+https://github.com/edx/python-social-auth.git@pyjwt-fix#egg=python-social-auth
 
 # TODO Use the PyPi package once it is updated.
--e git+https://github.com/pinax/django-announcements.git@bda39727f2c9158c0bb5eba1604b44f14deae5b0#egg=django-announcements # MIT
+git+https://github.com/pinax/django-announcements.git@bda39727f2c9158c0bb5eba1604b44f14deae5b0#egg=django-announcements # MIT
 
--e git+https://github.com/edx/django-lang-pref-middleware.git@0.1.0#egg=django-lang-pref-middleware
--e git+https://github.com/edx/edx-analytics-data-api-client.git@0.4.0#egg=edx-analytics-data-api-client # edX
+git+https://github.com/edx/django-lang-pref-middleware.git@0.1.0#egg=django-lang-pref-middleware
+git+https://github.com/edx/edx-analytics-data-api-client.git@0.4.0#egg=edx-analytics-data-api-client # edX
 git+https://github.com/edx/edx-server-api-client.git@0.1.0#egg=edx-server-api-client
--e git+https://github.com/edx/i18n-tools.git@0d7847f9dfa2281640527b4dc51f5854f950f9b7#egg=i18n_tools
--e git+https://github.com/edx/opaque-keys.git@d45d0bd8d64c69531be69178b9505b5d38806ce0#egg=opaque-keys
+git+https://github.com/edx/i18n-tools.git@0d7847f9dfa2281640527b4dc51f5854f950f9b7#egg=i18n_tools
+git+https://github.com/edx/opaque-keys.git@d45d0bd8d64c69531be69178b9505b5d38806ce0#egg=opaque-keys


### PR DESCRIPTION
The -e is only needed for requirements that need to be locally editable, I don't think any of the
requirements here fall into that category.

Review: @dsjen @clintonb 
