### PR TITLE
Removed enable_oidc_permissions_scope switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ The following switches are available:
 | Switch                            | Purpose                                                  |
 |-----------------------------------|----------------------------------------------------------|
 | show_engagement_forum_activity    | Show the forum activity on the course engagement page    |
-| enable_oidc_permissions_scope     | Retrieve general permissions from the OIDC provider.     |
 | enable_course_api                 | Retrieve course details from the course API              |
 
 Authentication & Authorization

--- a/analytics_dashboard/core/backends.py
+++ b/analytics_dashboard/core/backends.py
@@ -7,7 +7,6 @@ import json
 from django.conf import settings
 import django.dispatch
 from social.backends.open_id import OpenIdConnectAuth
-from waffle import switch_is_active
 
 
 # pylint: disable=abstract-method
@@ -18,7 +17,7 @@ class EdXOpenIdConnect(OpenIdConnectAuth):
     REDIRECT_STATE = False
     ID_KEY = 'preferred_username'
 
-    DEFAULT_SCOPE = ['openid', 'profile', 'email'] + settings.COURSE_PERMISSIONS_SCOPE
+    DEFAULT_SCOPE = ['openid', 'profile', 'email', 'permissions'] + settings.COURSE_PERMISSIONS_SCOPE
     ID_TOKEN_ISSUER = settings.SOCIAL_AUTH_EDX_OIDC_URL_ROOT
     AUTHORIZATION_URL = '{0}/authorize/'.format(settings.SOCIAL_AUTH_EDX_OIDC_URL_ROOT)
     ACCESS_TOKEN_URL = '{0}/access_token/'.format(settings.SOCIAL_AUTH_EDX_OIDC_URL_ROOT)
@@ -100,14 +99,6 @@ class EdXOpenIdConnect(OpenIdConnectAuth):
                 dest[dest_key] = value
 
         return dest
-
-    def get_scope(self):
-        scope = super(EdXOpenIdConnect, self).get_scope()
-
-        if switch_is_active('enable_oidc_permissions_scope'):
-            scope.append('permissions')
-
-        return scope
 
 
 def _to_language(locale):


### PR DESCRIPTION
This switch is no longer needed since LMS has been updated multiple times since we added this scope.

@dsjen 

@jbau @dylanrhodes This could cause issues for you if your LMS hasn't been updated since October. Let me know if that is the case and we can keep the switch.

FYI @rlucioni 
