### PR TITLE
Upload build metrics to S3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,14 @@ script:
 after_success:
     - coveralls
     - bash ./scripts/build-stats-to-datadog.sh
+deploy:
+    - provider: s3
+      access_key_id: $S3_ACCESS_KEY_ID
+      secret_access_key: $S3_SECRET_ACCESS_KEY
+      bucket: $S3_BUCKET
+      skip_cleanup: true
+      local_dir: $TRAVIS_BUILD_DIR/build-metrics
+      upload_dir: edx-analytics-dashboard/master
+      acl: public_read
+      on:
+        branch: master

--- a/scripts/build-stats-to-datadog.sh
+++ b/scripts/build-stats-to-datadog.sh
@@ -27,6 +27,11 @@ END
 
     deactivate
 
+    # Create build-metrics directory and move stats files into it.
+    mkdir -p ../build-metrics
+    cp test_eng.unit.analtyics.dashboard ../build-metrics/
+    cp test_eng.javascript.analytics_dashboard ../build-metrics/
+
 else
     echo "Note: Not reporting stats to datadog. Those are only reported for builds on master, \
 and when the datadog api key is available."


### PR DESCRIPTION
@dsjen @mulby @jzoldak @clytwynec 

When the env vars are configured on Travis, this will upload flat files with the coverage percentage numbers to s3://edx-testeng-build-data/edx-analytics-dashboard/master/

Those can be crawled by our heroku-hosted dashboard for coverage data. (We're getting the data from coveralls in all cases except for the javascript coverage for dashboard, and that's the key piece we're uploading here. For completeness, I'm uploading both coverage metric files.)

Caveat here is that some of this config can only be tested when running on master, on Travis. I've vetted out most of it on a separate repo, but I may need some follow-up commits if I encounter issues....
