### PR TITLE
Ensure only master branch is run on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ script:
     - make validate
     - make generate_fake_translations
     - bash ./runAcceptance.sh
+branches:
+    only:
+      - master
 after_success:
     - coveralls
     - bash ./scripts/build-stats-to-datadog.sh


### PR DESCRIPTION
This, paired with Travis configuration, will ensure that only the following are built:
- PRs
- pushes to master

Currently we are seeing both the push event (feature branch) and pull event (PR change)
spawning builds on Travis. This change will correct that behavior. See TE-751.

@dsjen
