### PR TITLE
Fixes for Course Index Page

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ The following switches are available:
 |-----------------------------------|----------------------------------------------------------|
 | show_engagement_forum_activity    | Show the forum activity on the course engagement page    |
 | enable_course_api                 | Retrieve course details from the course API              |
+| display_names_for_course_index    | Display course names on course index page.               |
+| display_course_name_in_nav        | Display course name in navigation bar.                   |
 
 Authentication & Authorization
 ------------------------------

--- a/analytics_dashboard/courses/tests/test_views/__init__.py
+++ b/analytics_dashboard/courses/tests/test_views/__init__.py
@@ -28,7 +28,7 @@ class CourseAPIMixin(SwitchMixin):
     Mixin with methods to help mock the course API.
     """
 
-    COURSE_API_COURSE_LIST = {'results': [
+    COURSE_API_COURSE_LIST = {'next': None, 'results': [
         {'id': course_key, 'name': 'Test ' + course_key} for course_key in [DEMO_COURSE_ID, DEPRECATED_DEMO_COURSE_ID]
     ]}
 
@@ -184,6 +184,7 @@ class CourseViewTestMixin(CourseAPIMixin, NavAssertMixin, ViewTestMixin):
     @data(DEMO_COURSE_ID, DEPRECATED_DEMO_COURSE_ID)
     def test_valid_course(self, course_id):
         self.toggle_switch('enable_course_api', True)
+        self.toggle_switch('display_course_name_in_nav', True)
         self.mock_course_detail(course_id)
         self.assertViewIsValid(course_id)
 

--- a/analytics_dashboard/courses/tests/test_views/test_pages.py
+++ b/analytics_dashboard/courses/tests/test_views/test_pages.py
@@ -66,6 +66,7 @@ class CourseIndexViewTests(CourseAPIMixin, ViewTestMixin, MiddlewareAssertionMix
     def test_get_with_course_api(self):
         """ Verify that the view properly retrieves data from the course API. """
         self.toggle_switch('enable_course_api', True)
+        self.toggle_switch('display_names_for_course_index', True)
         self.mock_course_list()
         courses = self._create_course_list(DEMO_COURSE_ID, DEPRECATED_DEMO_COURSE_ID, with_name=True)
         self.assertIsNotNone(httpretty.last_request())


### PR DESCRIPTION
- Added switches to control retrieval of course info for landing page and nav bar
- Caching course info used on landing page
- Properly iterating over paged results
- Removed unnecessary course ID filter

@mulby @brianhw @jab5569 @e0d 
