### PR TITLE
Slugifying Assignment Types in URLs

### DIFF
--- a/analytics_dashboard/core/templatetags/dashboard_extras.py
+++ b/analytics_dashboard/core/templatetags/dashboard_extras.py
@@ -1,8 +1,10 @@
 from django import template
 from django.conf import settings
+from django.template.defaultfilters import stringfilter
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 from opaque_keys.edx.keys import CourseKey
+from slugify import slugify
 
 register = template.Library()
 
@@ -112,3 +114,9 @@ def format_course_key(course_key, separator=u'/'):
         course_key = CourseKey.from_string(course_key)
 
     return separator.join([course_key.org, course_key.course, course_key.run])
+
+
+@register.filter(is_safe=True)
+@stringfilter
+def unicode_slugify(value):
+    return slugify(value)

--- a/analytics_dashboard/core/tests/test_templatetags.py
+++ b/analytics_dashboard/core/tests/test_templatetags.py
@@ -58,3 +58,7 @@ class DashboardExtraTests(TestCase):
         self.assertEqual(dashboard_extras.metric_percentage(0.009), '< 1%')
         self.assertEqual(dashboard_extras.metric_percentage(0.5066), '50.7%')
         self.assertEqual(dashboard_extras.metric_percentage(0.5044), '50.4%')
+
+    def test_unicode_slugify(self):
+        self.assertEqual(dashboard_extras.unicode_slugify('hello world'), 'hello-world')
+        self.assertEqual(dashboard_extras.unicode_slugify(u'straße road'), u'strasse-road')

--- a/analytics_dashboard/courses/templates/courses/_graded_content_nav.html
+++ b/analytics_dashboard/courses/templates/courses/_graded_content_nav.html
@@ -25,7 +25,7 @@
               {% for assignment_type in assignment_types %}
                 <li role="presentation">
                   <a role="menuitem"
-                     href="{% url "courses:performance:graded_content_by_type" course_id=course_id assignment_type=assignment_type %}">
+                     href="{% url "courses:performance:graded_content_by_type" course_id=course_id assignment_type=assignment_type|unicode_slugify %}">
                     {{ assignment_type }}
                   </a>
                 </li>

--- a/analytics_dashboard/courses/templates/courses/performance_graded_content.html
+++ b/analytics_dashboard/courses/templates/courses/performance_graded_content.html
@@ -24,7 +24,7 @@
 
           {% widthratio item.weight 1 max_policy_display_percent as bar_ratio %}
           <div style="width: {{bar_ratio}}%; min-width: {{min_policy_display_percent}}%" class="policy-item has-tooltip" title="{{policy_description}}">
-            <a href="{% url 'courses:performance:graded_content_by_type' course_id=course_id assignment_type=item.assignment_type %}">
+            <a href="{% url 'courses:performance:graded_content_by_type' course_id=course_id assignment_type=item.assignment_type|unicode_slugify %}">
               <div class="policy-item-box">
                 {% captureas policy_percent %}
                   {# Translators: This describes the percent of a learner's grade (e.g. 60%). #}

--- a/analytics_dashboard/courses/urls.py
+++ b/analytics_dashboard/courses/urls.py
@@ -33,7 +33,7 @@ ENGAGEMENT_URLS = patterns(
 PERFORMANCE_URLS = patterns(
     '',
     url(r'^graded_content/$', performance.PerformanceGradedContent.as_view(), name='graded_content'),
-    url(r'^graded_content/(?P<assignment_type>[\w ]+)/$',
+    url(r'^graded_content/(?P<assignment_type>[\w-]+)/$',
         performance.PerformanceGradedContentByType.as_view(),
         name='graded_content_by_type'),
     url(answer_distribution_regex, performance.PerformanceAnswerDistributionView.as_view(), name='answer_distribution'),

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,4 @@
+awesome-slugify==1.6.2      # GPLv3
 bpython==0.12				# MIT License
 Django==1.7.4				# BSD License
 django-appconf==0.6


### PR DESCRIPTION
This will ensure that unknown assignment types won't cause issues with the regex in the future.

@dsjen @mulby @brianhw @jab5569 
