### PR TITLE
Minifying JS with Closure Compiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
     - make test.acceptance
     - pip install coveralls
 script:
+    - make static -e DJANGO_SETTINGS_MODULE="analytics_dashboard.settings.test"
     - make validate
     - make generate_fake_translations
     - bash ./runAcceptance.sh

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Prerequisites
 * Python 2.7.x (not tested with Python 3.x)
 * [gettext](http://www.gnu.org/software/gettext/)
 * [npm](https://www.npmjs.org/) 
+* [JDK 7+](http://openjdk.java.net/)
 
 Getting Started
 ---------------
@@ -116,8 +117,9 @@ Note that only the following files (for each language) should be committed to th
 Asset Pipeline
 --------------
 Static files are managed via [django-compressor](http://django-compressor.readthedocs.org/) and [RequireJS](http://requirejs.org/).
-RequireJS (and r.js) are used to manage JavaScript dependencies. django-compressor compiles SASS, minifies JavaScript,
-and handles naming files to facilitate cache busting during deployment.
+RequireJS (and r.js) are used to manage JavaScript dependencies. django-compressor compiles SASS, minifies JavaScript (
+using [Closure Compiler](https://developers.google.com/closure/compiler/)), and handles naming files to facilitate 
+cache busting during deployment.
 
 Both tools should operate seamlessly in a local development environment. When deploying to production, call
 `make static` to compile all static assets and move them to the proper location to be served.

--- a/analytics_dashboard/settings/base.py
+++ b/analytics_dashboard/settings/base.py
@@ -116,6 +116,9 @@ COMPRESS_PRECOMPILERS = (
 )
 
 COMPRESS_CSS_FILTERS = ['compressor.filters.css_default.CssAbsoluteFilter']
+COMPRESS_JS_FILTERS = ['compressor.filters.closure.ClosureCompilerFilter']
+COMPRESS_CLOSURE_COMPILER_BINARY = 'java -jar scripts/closure-compiler.jar'
+COMPRESS_CLOSURE_JS_ARGUMENTS = {'compilation_level': 'ADVANCED_OPTIMIZATIONS', }
 ########## END STATIC FILE CONFIGURATION
 
 

--- a/analytics_dashboard/settings/test.py
+++ b/analytics_dashboard/settings/test.py
@@ -27,5 +27,7 @@ COURSE_API_URL = 'http://course-api-host'
 
 LOGGING = get_logger_config(debug=DEBUG, dev_env=True, local_loglevel='DEBUG')
 
-# Compressing assets slows down view rendering. Since we don't actually need assets, don't bother compressing them.
-COMPRESS_ENABLED = False
+# Use production settings for asset compression so that asset compilation can be tested on the CI server.
+COMPRESS_ENABLED = True
+COMPRESS_OFFLINE = True
+RJS_OPTIMIZATION_ENABLED = True


### PR DESCRIPTION
Usage of Closure Compiler decreases the uncompressed JS size by ~200KB per page.
