### PR TITLE
Expanded demo target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,11 @@ validate_js: requirements.js
 validate: validate_python validate_js
 
 demo:
-	python manage.py switch show_engagement_forum_activity on --create
 	python manage.py switch display_verified_enrollment on --create
+	python manage.py switch show_engagement_forum_activity off --create
+	python manage.py switch enable_course_api off --create
+	python manage.py switch display_names_for_course_index off --create
+	python manage.py switch display_course_name_in_nav off --create
 
 compile_translations:
 	cd analytics_dashboard && i18n_tool generate -v


### PR DESCRIPTION
Creating additional switches when running the demo target to avoid extra work when setting up a new dev environment.

@dsjen
