### PR TITLE
Ignoring Empty Assignment Types in Grading Policy

### DIFF
--- a/analytics_dashboard/courses/presenters/performance.py
+++ b/analytics_dashboard/courses/presenters/performance.py
@@ -183,6 +183,10 @@ class CoursePerformancePresenter(BasePresenter):
         if not grading_policy:
             logger.debug('Retrieving grading policy for course: %s', self.course_id)
             grading_policy = self.course_api_client.grading_policies(self.course_id).get()
+
+            # Remove empty assignment types as they are not useful and will cause issues downstream.
+            grading_policy = [item for item in grading_policy if item['assignment_type']]
+
             cache.set(key, grading_policy)
 
         return grading_policy

--- a/analytics_dashboard/courses/tests/factories.py
+++ b/analytics_dashboard/courses/tests/factories.py
@@ -76,3 +76,7 @@ class CoursePerformanceDataFactory(CourseStructureFactory):
                 })
 
         return problems
+
+    @property
+    def present_grading_policy(self):
+        return self._cleaned_grading_policy

--- a/analytics_dashboard/courses/tests/test_presenters.py
+++ b/analytics_dashboard/courses/tests/test_presenters.py
@@ -334,9 +334,14 @@ class CoursePerformancePresenterTests(TestCase):
 
     @mock.patch('slumber.Resource.get', mock.Mock(return_value=CoursePerformanceDataFactory.grading_policy))
     def test_grading_policy(self):
-        """ Verify the presenter returns the correct grading policy. """
+        """
+        Verify the presenter returns the correct grading policy.
+
+        Empty (non-truthy) assignment types should be dropped.
+        """
+
         grading_policy = self.presenter.grading_policy()
-        self.assertListEqual(grading_policy, CoursePerformanceDataFactory.grading_policy)
+        self.assertListEqual(grading_policy, self.factory.present_grading_policy)
 
         percent = self.presenter.get_max_policy_display_percent(grading_policy)
         self.assertEqual(100, percent)
@@ -344,11 +349,11 @@ class CoursePerformancePresenterTests(TestCase):
         percent = self.presenter.get_max_policy_display_percent([{'weight': 0.0}, {'weight': 1.0}, {'weight': 0.04}])
         self.assertEqual(90, percent)
 
-    @mock.patch('courses.presenters.performance.CoursePerformancePresenter.grading_policy',
-                mock.Mock(return_value=CoursePerformanceDataFactory.grading_policy))
     def test_assignment_types(self):
         """ Verify the presenter returns the correct assignment types. """
-        self.assertListEqual(self.presenter.assignment_types(), CoursePerformanceDataFactory.assignment_types)
+        with mock.patch('courses.presenters.performance.CoursePerformancePresenter.grading_policy',
+                        mock.Mock(return_value=self.factory.present_grading_policy)):
+            self.assertListEqual(self.presenter.assignment_types(), CoursePerformanceDataFactory.assignment_types)
 
     def test_assignments(self):
         """ Verify the presenter returns the correct assignments and sets the last updated date. """

--- a/analytics_dashboard/courses/tests/test_views/test_performance.py
+++ b/analytics_dashboard/courses/tests/test_views/test_performance.py
@@ -50,7 +50,7 @@ class CoursePerformanceViewTestMixin(CourseAPIMixin, NavAssertMixin, ViewTestMix
         self._patch('courses.presenters.performance.CoursePerformancePresenter.assignments',
                     return_value=self.factory.present_assignments())
         self._patch('courses.presenters.performance.CoursePerformancePresenter.grading_policy',
-                    return_value=self.factory.grading_policy)
+                    return_value=self.factory.present_grading_policy)
         self.start_patching()
 
     def tearDown(self):
@@ -269,7 +269,7 @@ class CoursePerformanceGradedContentViewTests(CoursePerformanceViewTestMixin, Te
 
         expected = {
             'assignment_types': self.factory.assignment_types,
-            'grading_policy': self.factory.grading_policy,
+            'grading_policy': self.factory.present_grading_policy,
         }
         self.assertDictContainsSubset(expected, context)
 

--- a/common/tests/factories.py
+++ b/common/tests/factories.py
@@ -19,6 +19,18 @@ class CourseStructureFactory(object):
             "count": 4,
             "dropped": 0,
             "weight": 0.8
+        },
+        {
+            "assignment_type": "",
+            "count": 4,
+            "dropped": 0,
+            "weight": 0
+        },
+        {
+            "assignment_type": None,
+            "count": 1,
+            "dropped": 0,
+            "weight": 0
         }
     ]
 
@@ -54,9 +66,10 @@ class CourseStructureFactory(object):
         }
 
         self._assignments = []
-        for gp in self.grading_policy:
+        for gp in self._cleaned_grading_policy:
             count = gp['count']
             assignment_type = gp['assignment_type']
+
             for assignment_index in range(1, count + 1):
                 display_name = '{} {}'.format(assignment_type, assignment_index)
                 children = []
@@ -88,3 +101,7 @@ class CourseStructureFactory(object):
     @property
     def assignments(self):
         return copy.deepcopy(self._assignments)
+
+    @property
+    def _cleaned_grading_policy(self):
+        return [item for item in self.grading_policy if item['assignment_type']]


### PR DESCRIPTION
These non-truthy assignment types are not useful for our purposes, so they will be filtered out and ignored.

@dsjen 
