### PR TITLE
Stacked bars will show all labels unless space is limited.

### DIFF
--- a/analytics_dashboard/static/js/views/bar-view.js
+++ b/analytics_dashboard/static/js/views/bar-view.js
@@ -44,11 +44,14 @@ define(['d3', 'nvd3', 'underscore', 'utils/utils', 'views/chart-view'],
 
                 var barWidth = d3.select(self.options.barSelector).attr('width'),  // jshint ignore:line
                 // this is a rough estimate of how wide a character is
-                    chartWidth = 5,
-                    characterLimit = Math.floor(barWidth / chartWidth),
+                    charWidth = 6,
+                    characterLimit = Math.floor(barWidth / charWidth),
                     formattedLabel = d;
 
-                if (_(formattedLabel).size() > characterLimit) {
+                if (characterLimit < 3) {
+                    // no labels will be displayed if label space is limited
+                    formattedLabel = '';
+                } else if (_(formattedLabel).size() > characterLimit) {
                     formattedLabel = Utils.truncateText(d, characterLimit);
                 }
 

--- a/analytics_dashboard/static/js/views/stacked-bar-view.js
+++ b/analytics_dashboard/static/js/views/stacked-bar-view.js
@@ -19,7 +19,8 @@ define(['nvd3', 'underscore', 'views/discrete-bar-view'],
 
                 chart.stacked(true)
                     .showControls(false)
-                    .showLegend(false);
+                    .showLegend(false)
+                    .reduceXTicks(false);  // shows all ticks
 
                 chart.tooltipContent(function(key, x, y, e) {
                     var tips = [];


### PR DESCRIPTION
- Default to show all labels for stacked bar chart.
- If fewer than three characters can be shown, hide labels.

Updated with No Labels
![no-labels](https://cloud.githubusercontent.com/assets/5265058/6508143/e3663242-c324-11e4-8f4e-0caac5af9170.png)

Previous Sparse Labels
![labels](https://cloud.githubusercontent.com/assets/5265058/6508148/ee140a0c-c324-11e4-8733-a5c12046cd36.png)

@clintonb 

FYI: @andywaldrop @shnayder @lamagnifica 
