### PR TITLE
Darkened performance nav text.

### DIFF
--- a/analytics_dashboard/static/sass/_developer.scss
+++ b/analytics_dashboard/static/sass/_developer.scss
@@ -672,7 +672,7 @@ table.dataTable thead th.sorting_desc:after {
 
     .dropdown, .separator {
       padding: $nav-link-padding;
-      color: $lens-nav-text-color;
+      color: $edx-gray;
     }
 
     .dropdown {


### PR DESCRIPTION
Darkened (new)
![darkened](https://cloud.githubusercontent.com/assets/5265058/6535875/64c1e1f0-c416-11e4-8c7c-51b7b35db67e.png)

Lighter (old)
![lighter](https://cloud.githubusercontent.com/assets/5265058/6535889/91fd523a-c416-11e4-9f14-ef40d56ae804.png)

@clintonb @shnayder @lamagnifica @andywaldrop 
