### PR TITLE
All performance pages point to "performance/Performance_Answers.html"

### DIFF
--- a/acceptance_tests/test_course_performance.py
+++ b/acceptance_tests/test_course_performance.py
@@ -14,6 +14,9 @@ _multiprocess_can_split_ = True
 
 
 class CoursePerformancePageTestsMixin(CoursePageTestsMixin):
+
+    help_path = 'performance/Performance_Answers.html'
+
     def test_page(self):
         super(CoursePerformancePageTestsMixin, self).test_page()
         self._test_chart()
@@ -251,8 +254,6 @@ class CoursePerformanceAnswerDistributionTests(CoursePerformancePageTestsMixin, 
     """
     Tests for the course problem answer distribution page.
     """
-
-    help_path = 'performance/index.html'
 
     def setUp(self):
         super(CoursePerformanceAnswerDistributionTests, self).setUp()

--- a/docs/config.ini
+++ b/docs/config.ini
@@ -20,7 +20,11 @@ engagement_content = engagement/Engagement_Content.html
 enrollment_demographics_age = enrollment/Demographics_Age.html
 enrollment_demographics_education = enrollment/Demographics_Education.html
 enrollment_demographics_gender = enrollment/Demographics_Gender.html
-performance_answer_distribution = performance/index.html
+performance_assignment = performance/Performance_Answers.html
+performance_answer_distribution = performance/Performance_Answers.html
+performance_graded_content = performance/Performance_Answers.html
+performance_graded_content_by_type = performance/Performance_Answers.html
+
 
 # below are the language directory names for the different locales
 [locales]


### PR DESCRIPTION
This updates the "Help" link to point to http://edx.readthedocs.org/projects/edx-insights/en/latest/performance/Performance_Answers.html on all performance pages.

@jab5569 @brianhw @mulby @lamagnifica
