### PR TITLE
Import load_strategy from utils.

### DIFF
--- a/analytics_dashboard/courses/permissions.py
+++ b/analytics_dashboard/courses/permissions.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.core.cache import cache
 from django.dispatch import receiver
 
-from social.apps.django_app import load_strategy
+from social.apps.django_app.utils import load_strategy
 
 from auth_backends.backends import EdXOpenIdConnect
 


### PR DESCRIPTION
An upgrade of django-social-auth including https://github.com/omab/python-social-auth/pull/550 causing `from social.apps.django_app import load_strategy` to fail.  This change imports `load_strategy` from `utils` instead.
