### PR TITLE
Add percentages and updated colors for video bars.

### DIFF
--- a/analytics_dashboard/static/js/engagement-video-content-main.js
+++ b/analytics_dashboard/static/js/engagement-video-content-main.js
@@ -6,20 +6,20 @@ require(['vendor/domReady!', 'load/init-page'], function (doc, page) {
             var model = page.models.courseModel,
                 graphSubmissionColumns = [
                     {
-                        key: 'start_only_views',
-                        percent_key: 'start_only_percent',
-                        title: gettext('Started Watching'),
-                        className: 'text-right',
-                        type: 'number',
-                        color: '#4BB4FB'
-                    },
-                    {
                         key: 'end_views',
                         percent_key: 'end_percent',
-                        title: gettext('Finished Watching'),
+                        title: gettext('Complete Plays'),
                         className: 'text-right',
                         type: 'number',
-                        color: '#CA0061'
+                        color: '#58BC4B'
+                    },
+                    {
+                        key: 'start_only_views',
+                        percent_key: 'start_only_percent',
+                        title: gettext('Incomplete Plays'),
+                        className: 'text-right',
+                        type: 'number',
+                        color: '#9B9B9B'
                     }
                 ],
                 tableColumns = [


### PR DESCRIPTION
![percent-tips](https://cloud.githubusercontent.com/assets/5265058/7659972/0d3df948-fb14-11e4-9cc7-088ce54f7ae7.png)

The percentages are fixed in another PR.  This PR only addresses the colors and tooltip display.

@lamagnifica @brianhw @jab5569 @mulby 
