### PR TITLE
Remove zone offset from trend date display.

### DIFF
--- a/analytics_dashboard/static/js/views/trends-view.js
+++ b/analytics_dashboard/static/js/views/trends-view.js
@@ -24,7 +24,7 @@ define(['moment', 'nvd3', 'underscore', 'views/chart-view'],
 
             formatXTick: function (d) {
                 // overriding default to display a formatted date
-                return moment(d).zone('+0000').format('M/D');
+                return moment(d).format('M/D');
             },
 
             parseXData: function (d) {


### PR DESCRIPTION
@jeremy55662004 (developer in Taiwan) found an issue with date displays on charts when running tests.  The time was set, then the offset set, which resulted in an incorrect date.

The error was caught with https://github.com/edx/edx-analytics-dashboard/blob/dsjen/date-display/analytics_dashboard/static/js/test/specs/trends-view-spec.js#L15.

@brianhw @mulby @jab5569 
