### PR TITLE
Added soapbox announcements to display per-page messages.

### DIFF
--- a/analytics_dashboard/settings/base.py
+++ b/analytics_dashboard/settings/base.py
@@ -230,6 +230,7 @@ LOCAL_APPS = (
     'courses',
     'django_rjs',
     'help',
+    'soapbox',
 )
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#installed-apps

--- a/analytics_dashboard/templates/_announcement.html
+++ b/analytics_dashboard/templates/_announcement.html
@@ -1,0 +1,34 @@
+{% load i18n %}
+
+<div class="announcement-container"
+     data-dismiss-url="{{ dismiss_url }}"
+     data-view="announcement">
+    <div class="container">
+        <div class="row">
+            <div class="hidden-xs col-sm-1">
+                <div class="icon"><i class="fa fa-bullhorn"></i></div>
+            </div>
+
+            <div class="col-xs-10">
+                {% if message %}
+                    {{ message|safe }}
+                {% else %}
+                    <div class="message">
+                        <h1>{{ title }}</h1>
+                        <p>{{ body|safe }}</p>
+                    </div>
+                {% endif %}
+            </div>
+
+            {% if dismiss_url %}
+                <div class="col-xs-2 col-sm-1">
+                    {% csrf_token %}
+                    <a class="dismiss">
+                        <span aria-hidden="true"><i class="fa fa-times"></i></span>
+                        <span class="sr-only">{% trans "Close" %}</span>
+                    </a>
+                </div>
+            {% endif %}
+        </div>
+    </div>
+</div>

--- a/analytics_dashboard/templates/announcements.html
+++ b/analytics_dashboard/templates/announcements.html
@@ -1,32 +1,14 @@
-{% load announcements_tags i18n %}
+{% load soapbox %}
+{% load announcements_tags %}
+
+{% get_messages_for_page view.page_name as soapbox_messages %}
+{% for message in soapbox_messages %}
+  {% include "_announcement.html" with message=message %}
+{% endfor %}
 
 {% announcements as announcements_list %}
-
 {% with announcements_list|first as announcement %}
   {% if announcement %}
-    <div class="announcement-container" data-dismiss-url="{{ announcement.dismiss_url }}"
-         data-view="announcement">
-      <div class="container">
-        {% csrf_token %}
-        <a class="dismiss">
-          <span aria-hidden="true"><i class="fa fa-times"></i></span><span class="sr-only">{% trans "Close" %}</span>
-        </a>
-
-        <div class="container">
-          <div class="row">
-            <div class="col-xs-1 col-md-1">
-              <div class="icon"><i class="fa fa-bullhorn"></i></div>
-            </div>
-
-            <div class="col-xs-9 col-md-9">
-              <div class="message">
-                <div class="title">{{ announcement.title }}</div>
-                <div class="body">{{ announcement.content|safe }}</div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
+    {% include "_announcement.html" with body=announcement.content title=announcement.title dismiss_url=announcement.dismiss_url %}
   {% endif %}
 {% endwith %}

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,6 +7,7 @@ django_compressor==1.4		# MIT
 django-countries==3.1.1     # MIT
 django-libsass==0.2			# BSD
 django-model-utils==1.5.0 	# BSD
+django-soapbox==1.1         # BSD
 django-waffle==0.10			# BSD
 
 # other versions cause a segment fault when running compression


### PR DESCRIPTION
In order to display announcements for specific pages, we are using django-soapbox.  These messages are not dismissible and can be activated and deactivated.  They are displayed similar to the typical dismissible announcements.

![screen shot 2015-06-18 at 5 04 19 pm](https://cloud.githubusercontent.com/assets/5265058/8242247/19cdb27e-15dc-11e5-84e6-d0e9ae996251.png)

@brianhw @jab5569 @mulby @shnayder @lamagnifica 
