### PR TITLE
Added cumulative/total enrollments.

### DIFF
--- a/acceptance_tests/test_course_enrollment.py
+++ b/acceptance_tests/test_course_enrollment.py
@@ -67,14 +67,13 @@ class CourseEnrollmentActivityTests(CoursePageTestsMixin, WebAppTest):
         enrollment = enrollment_data[-1]['count']
 
         # Verify the current enrollment metric tile.
-        tooltip = u'Students enrolled in the course.'
+        tooltip = u'Students currently enrolled in the course.'
         self.assertMetricTileValid('current_enrollment', enrollment, tooltip)
 
         # Verify the total enrollment change metric tile.
         i = 7
         enrollment = enrollment - enrollment_data[-(i + 1)]['count']
-        tooltip = u'The difference between the number of students enrolled at the end of the day ' \
-                  u'yesterday and one week before.'
+        tooltip = u'Net difference in current enrollment in the last week.'
         self.assertMetricTileValid('enrollment_change_last_%s_days' % i, enrollment, tooltip)
 
         if ENABLE_ENROLLMENT_MODES:
@@ -83,13 +82,8 @@ class CourseEnrollmentActivityTests(CoursePageTestsMixin, WebAppTest):
             if enrollment_modes.VERIFIED in valid_modes:
                 # Verify the verified enrollment metric tile.
                 verified_enrollment = enrollment_data[-1][enrollment_modes.VERIFIED]
-                tooltip = u'Number of enrolled students who are pursuing a verified certificate of achievement.'
+                tooltip = u'Number of currently enrolled students pursuing a verified certificate of achievement.'
                 self.assertMetricTileValid('verified_enrollment', verified_enrollment, tooltip)
-
-                verified_enrollment = verified_enrollment - enrollment_data[-(i + 1)][enrollment_modes.VERIFIED]
-                tooltip = u'The difference between the number of students pursuing verified certificates at the ' \
-                          u'end of the day yesterday and one week before.'
-                self.assertMetricTileValid('verified_change_last_%s_days' % i, verified_enrollment, tooltip)
 
         # Verify *something* rendered where the graph should be. We cannot easily verify what rendered
         self.assertElementHasContent("[data-section=enrollment-basics] #enrollment-trend-view")
@@ -100,7 +94,7 @@ class CourseEnrollmentActivityTests(CoursePageTestsMixin, WebAppTest):
         enrollment_data = sorted(self.get_enrollment_data(), reverse=True, key=lambda item: item['date'])
 
         table_selector = 'div[data-role=enrollment-table] table'
-        headings = ['Date', 'Total Enrollment']
+        headings = ['Date', 'Current Enrollment']
 
         if ENABLE_ENROLLMENT_MODES:
             headings.append('Honor Code')
@@ -180,7 +174,7 @@ class CourseEnrollmentGeographyTests(CoursePageTestsMixin, WebAppTest):
         """ Verify the geolocation enrollment table is loaded. """
 
         table_section_selector = "div[data-role=enrollment-location-table]"
-        self.assertTable(table_section_selector, ['Country', 'Percent', 'Total Enrollment'],
+        self.assertTable(table_section_selector, ['Country', 'Percent', 'Current Enrollment'],
                          'a[data-role=enrollment-location-csv]')
 
         rows = self.page.browser.find_elements_by_css_selector('{} tbody tr'.format(table_section_selector))

--- a/acceptance_tests/test_course_enrollment_demographics.py
+++ b/acceptance_tests/test_course_enrollment_demographics.py
@@ -114,7 +114,7 @@ class CourseEnrollmentDemographicsGenderTests(CourseDemographicsPageTestsMixin, 
     help_path = 'enrollment/Demographics_Gender.html'
 
     demographic_type = demographic.GENDER
-    table_columns = ['Date', 'Total Enrollment', 'Female', 'Male', 'Other', 'Not Reported']
+    table_columns = ['Date', 'Current Enrollment', 'Female', 'Male', 'Other', 'Not Reported']
 
     def setUp(self):
         super(CourseEnrollmentDemographicsGenderTests, self).setUp()

--- a/analytics_dashboard/courses/presenters/enrollment.py
+++ b/analytics_dashboard/courses/presenters/enrollment.py
@@ -138,7 +138,6 @@ class CourseEnrollmentPresenter(BasePresenter):
 
         if enrollment_modes.VERIFIED not in valid_modes:
             summary.pop('verified_enrollment')
-            summary.pop('verified_change_last_7_days')
 
         return summary, trends
 
@@ -184,6 +183,7 @@ class CourseEnrollmentPresenter(BasePresenter):
         trend = {'date': day.isoformat(), 'count': 0}
 
         if self.display_verified_enrollment:
+            trend['cumulative_count'] = 0
             for mode in enrollment_modes.ALL:
                 trend[mode] = 0
 
@@ -260,7 +260,7 @@ class CourseEnrollmentPresenter(BasePresenter):
             'current_enrollment': None,
             'enrollment_change_last_7_days': None,
             'verified_enrollment': None,
-            'verified_change_last_7_days': None,
+            'total_enrollment': None,
         }
 
         if api_trends:
@@ -276,26 +276,19 @@ class CourseEnrollmentPresenter(BasePresenter):
             verified_enrollment = recent_enrollment.get(enrollment_modes.VERIFIED,
                                                         0) if self.display_verified_enrollment else None
 
-            data = {
+            data.update({
                 'last_updated': last_enrollment_date,
                 'current_enrollment': current_enrollment,
-                'verified_enrollment': verified_enrollment
-            }
+                'verified_enrollment': verified_enrollment,
+                'total_enrollment': recent_enrollment.get('cumulative_count', None),
+            })
 
             # Get difference in enrollment for last week
             count = None
-            verified_count = None
-
             if len(api_trends) > days_in_week:
                 index = -days_in_week - 1
                 count = current_enrollment - api_trends[index]['count']
-                if self.display_verified_enrollment:
-                    verified_count = verified_enrollment - api_trends[index].get(enrollment_modes.VERIFIED, 0)
-
             data['enrollment_change_last_%s_days' % days_in_week] = count
-
-            if self.display_verified_enrollment:
-                data['verified_change_last_%s_days' % days_in_week] = verified_count
 
         return data
 

--- a/analytics_dashboard/courses/templates/courses/enrollment_activity.html
+++ b/analytics_dashboard/courses/templates/courses/enrollment_activity.html
@@ -51,18 +51,29 @@ Individual course-centric enrollment activity view.
     {% if summary %}
       <div class="section-content">
         <div class="row">
+
+          {% if not summary.total_enrollment == None %}
+            <div class="col-xs-12 col-sm-3" data-stat-type="cumulative_enrollment">
+              {# Translators: This is a label to identify the number of students who ever enrolled in the course. #}
+              {% trans "Total Enrollment" as label %}
+              {# Translators: This is a label indicating the number of students in a course. #}
+              {% trans "Students who ever enrolled in the course." as tooltip %}
+              {% summary_point summary.total_enrollment label tooltip=tooltip %}
+            </div>
+          {% endif %}
+
           <div class="col-xs-12 col-sm-3" data-stat-type="current_enrollment">
             {# Translators: This is a label to identify current student enrollment. #}
-            {% trans "Total Enrollment" as label %}
+            {% trans "Current Enrollment" as label %}
             {# Translators: This is a label indicating the number of students enrolled in a course. #}
-            {% trans "Students enrolled in the course." as tooltip %}
+            {% trans "Students currently enrolled in the course." as tooltip %}
             {% summary_point summary.current_enrollment label tooltip=tooltip %}
           </div>
 
           <div class="col-xs-12 col-sm-3" data-stat-type="enrollment_change_last_7_days">
             {# Translators: This is a label indicating the change in the number of students enrolled in a course since the previous week. #}
             {% trans "Change in Last Week" as label %}
-            {% trans "The difference between the number of students enrolled at the end of the day yesterday and one week before." as tooltip %}
+            {% trans "Net difference in current enrollment in the last week." as tooltip %}
             {% summary_point summary.enrollment_change_last_7_days label tooltip=tooltip %}
           </div>
 
@@ -72,17 +83,8 @@ Individual course-centric enrollment activity view.
                 {# Translators: This is a label to identify enrollment of students on the verified track. #}
                 {% trans "Verified Enrollment" as label %}
                 {# Translators: This is a label indicating the number of students enrolled in a course on the verified track. #}
-                {% trans "Number of enrolled students who are pursuing a verified certificate of achievement." as tooltip %}
+                {% trans "Number of currently enrolled students pursuing a verified certificate of achievement." as tooltip %}
                 {% summary_point summary.verified_enrollment label tooltip=tooltip %}
-              </div>
-            {% endif %}
-
-            {% if not summary.verified_change_last_7_days == None %}
-              <div class="col-xs-12 col-sm-3" data-stat-type="verified_change_last_7_days">
-                {# Translators: This is a label indicating the change in the number of students enrolled in the verified track of a course since the previous week. #}
-                {% trans "Change in Verified Enrollments Last Week" as label %}
-                {% trans "The difference between the number of students pursuing verified certificates at the end of the day yesterday and one week before." as tooltip %}
-                {% summary_point summary.verified_change_last_7_days label tooltip=tooltip %}
               </div>
             {% endif %}
           {% endswitch %}

--- a/analytics_dashboard/courses/tests/test_presenters.py
+++ b/analytics_dashboard/courses/tests/test_presenters.py
@@ -312,6 +312,7 @@ class CourseEnrollmentPresenterTests(SwitchMixin, TestCase):
         expected_summary = {
             'last_updated': None,
             'current_enrollment': None,
+            'total_enrollment': None,
             'enrollment_change_last_7_days': None,
         }
 

--- a/analytics_dashboard/courses/tests/utils.py
+++ b/analytics_dashboard/courses/tests/utils.py
@@ -34,6 +34,9 @@ def get_mock_api_enrollment_data(course_id, include_verified=True):
             'created': CREATED_DATETIME_STRING
         }
 
+        if include_verified:
+            datum['cumulative_count'] = datum['count'] * 2
+
         for mode in modes:
             datum[mode] = index
 
@@ -52,15 +55,16 @@ def get_mock_enrollment_summary(include_verified=True):
     summary = {
         'last_updated': CREATED_DATETIME,
         'current_enrollment': 60,
+        'total_enrollment': None,
         'enrollment_change_last_7_days': 14,
     }
 
     if include_verified:
         summary.update({
             'current_enrollment': 120,
+            'total_enrollment': 240,
             'enrollment_change_last_7_days': 28,
             'verified_enrollment': 30,
-            'verified_change_last_7_days': 7,
         })
 
     return summary
@@ -71,7 +75,7 @@ def get_mock_enrollment_summary_and_trend(course_id):
 
 
 def _get_empty_enrollment(date):
-    enrollment = {'count': 0, 'date': date}
+    enrollment = {'count': 0, 'cumulative_count': 0, 'date': date}
 
     for mode in enrollment_modes.ALL:
         enrollment[mode] = 0
@@ -123,9 +127,9 @@ def get_mock_presenter_enrollment_summary_small():
     return {
         'last_updated': CREATED_DATETIME,
         'current_enrollment': 120,
+        'total_enrollment': 240,
         'enrollment_change_last_7_days': None,
         'verified_enrollment': 30,
-        'verified_change_last_7_days': None,
     }
 
 

--- a/analytics_dashboard/static/js/enrollment-activity-main.js
+++ b/analytics_dashboard/static/js/enrollment-activity-main.js
@@ -19,7 +19,7 @@ require(['vendor/domReady!', 'load/init-page'], function (doc, page) {
                     },
                     {
                         key: 'count',
-                        title: gettext('Total Enrollment'),
+                        title: gettext('Current Enrollment'),
                         className: 'text-right',
                         type: 'number',
                         color: '#4BB4FB'

--- a/analytics_dashboard/static/js/enrollment-demographics-gender-main.js
+++ b/analytics_dashboard/static/js/enrollment-demographics-gender-main.js
@@ -31,7 +31,7 @@ require(['vendor/domReady!', 'load/init-page'], function(doc, page) {
                 modelAttribute: 'genderTrend',
                 columns: [
                     {key: 'date', title: gettext('Date'), type: 'date'},
-                    {key: 'total', title: gettext('Total Enrollment'), type: 'number', className: 'text-right'},
+                    {key: 'total', title: gettext('Current Enrollment'), type: 'number', className: 'text-right'},
                     {key: 'female', title: gettext('Female'), type: 'number', className: 'text-right'},
                     {key: 'male', title: gettext('Male'), type: 'number', className: 'text-right'},
                     {key: 'other', title: gettext('Other'), type: 'number', className: 'text-right'},

--- a/analytics_dashboard/static/js/enrollment-geography-main.js
+++ b/analytics_dashboard/static/js/enrollment-geography-main.js
@@ -26,7 +26,7 @@ require(['vendor/domReady!', 'load/init-page'], function (doc, page) {
                     {key: 'countryName', title: gettext('Country')},
                     {key: 'percent', title: gettext('Percent'), className: 'text-right', type: 'percent'},
                     // Translators: The noun count (e.g. number of students)
-                    {key: 'count', title: gettext('Total Enrollment'), className: 'text-right', type: 'number'}
+                    {key: 'count', title: gettext('Current Enrollment'), className: 'text-right', type: 'number'}
                 ],
                 sorting: ['-count']
             });


### PR DESCRIPTION
- renamed "total enrollments" to "current enrollments" instead.
- added "total enrollments" to represent cumulative enrollments.
- removed verified enrollment change metric.

![screen shot 2015-06-25 at 3 53 58 pm](https://cloud.githubusercontent.com/assets/5265058/8364205/6b663036-1b52-11e5-94c5-b91a83659b46.png)

@brianhw @mulby @jab5569 @lamagnifica @shnayder 
