### PR TITLE
Explicitly set the version of logilab-common to prevent pylint error.

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -15,6 +15,7 @@ nose==1.3.4
 pep257==0.4.1
 pep8==1.6.0
 pylint==1.4.1
+logilab-common==0.61.0
 selenium>=2.44.0
 sure==1.2.7
 testfixtures==4.1.2


### PR DESCRIPTION
This PR is in response to https://github.com/edx/edx-analytics-dashboard/issues/328 and prevents an import error.

@jab5569 @brianhw @mulby @jeremy55662004
