### PR TITLE
Add a link to view the courseware from a course homepage

### DIFF
--- a/analytics_dashboard/courses/templates/courses/home.html
+++ b/analytics_dashboard/courses/templates/courses/home.html
@@ -24,6 +24,17 @@
           </li>
         {% endfor %}
       </ul>
+      {# External link[s] that only appear on the course home page: #}
+      <ul class="nav navbar-nav navbar-right">
+        {% if view_courseware_url %}
+          <li>
+            <a href="{{ view_courseware_url }}"><span class="link-label">
+              <i class="ico fa fa-external-link" aria-hidden="true"></i>
+              {% trans "Go to Courseware" %}
+            </span></a>
+          </li>
+        {% endif %}
+      </ul>
     </div>
   </nav>
 {% endblock %}

--- a/analytics_dashboard/courses/views/__init__.py
+++ b/analytics_dashboard/courses/views/__init__.py
@@ -524,6 +524,13 @@ class CourseHome(CourseTemplateWithNavView):
         })
 
         context['page_data'] = self.get_page_data(context)
+
+        if settings.LMS_COURSE_SHORTCUT_BASE_URL:
+            context['view_courseware_url'] = "{}/{}/courseware/".format(
+                settings.LMS_COURSE_SHORTCUT_BASE_URL,
+                self.course_id
+            )
+
         return context
 
 

--- a/analytics_dashboard/static/sass/_developer.scss
+++ b/analytics_dashboard/static/sass/_developer.scss
@@ -199,6 +199,9 @@ $lens-box-model: border-box;
   ul.navbar-nav {
     margin-left: 15px;
   }
+  ul.navbar-nav.navbar-right {
+    margin-right: 0;
+  }
 
   .navbar-nav {
 


### PR DESCRIPTION
**Description**: This PR adds a simple link from the Insights Dashboard to the LMS. It is only shown on the homepage of each course, and it is only visible if the `LMS_COURSE_SHORTCUT_BASE_URL` setting is configured.

**Rationale**: The Instructor dashboard in the LMS has links to the Insights Dashboard, so there should be a link in reverse.

**Screenshot**:
See new link on the right of the dark nav bar:
![screen shot 2015-07-16 at 1 02 41 pm](https://cloud.githubusercontent.com/assets/945577/8733877/0aa77d12-2bbb-11e5-93ec-939eed01483d.png)

**Discussion**:
I have a few alternative ideas / questions:
- Phrasing of the link: "Go to Courseware", "Show in LMS", "Open Courseware", "Instructor View", ... ?
- It may be more useful to link to the "Instructor Dashboard" rather than the Courseware. I think I would actually prefer a link to "Instructor Tools" over a link to the courseware, but I've gone this route for now since I think it's more clear to users.
- Is it useful to add this to all the course pages, or just keep it on the homepage as I've done here?

Here's an alternative UI proposal, which I think is much better. I haven't implemented this but would be happy to do so if people are on board:
![screen shot 2015-07-16 at 1 50 37 pm](https://cloud.githubusercontent.com/assets/945577/8734859/ad37471e-2bc1-11e5-9c39-e5c0a76c828d.png)

**Reviewers**: @mtyaka and TBD
