### PR TITLE
Display Basic Course Information on Course Home Page

### DIFF
--- a/analytics_dashboard/courses/templates/courses/home.html
+++ b/analytics_dashboard/courses/templates/courses/home.html
@@ -60,4 +60,36 @@
       </div>
     {% endfor %}
   </div>
+
+  {% if course_overview or external_course_tools %}
+    <div class="row">
+      <div class="col-sm-12"><hr></div>
+    </div>
+
+    <div class="row">
+      <div class="col-sm-8">
+        {% if course_overview %}
+          <h4 class="section-title">{% trans "Basic Course Information" %}</h4>
+          <table class="table course-overview" role="presentation">
+            <tbody>
+              {% for label, value in course_overview %}
+                <tr><th>{{label}}</th><td>{{value|safe}}</td></tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        {% endif %}
+      </div>
+      {% if external_course_tools %}
+        <div class="col-sm-4">
+          {# Translators: This title describes a list of links to outside tools for this course. #}
+          <h4 class="section-title">{% trans "External Tools" %}</h4>  
+          <ul class="course-external-tools">
+            {% for tool in external_course_tools %}
+              <li><a href="{{tool.url}}"><i class="ico fa {{tool.icon}}" aria-hidden="true"></i>{{tool.title}}</a></li>
+            {% endfor %}
+          </ul>
+        </div>
+      {% endif %}
+    </div>
+  {% endif %}
 {% endblock %}

--- a/analytics_dashboard/courses/tests/test_views/__init__.py
+++ b/analytics_dashboard/courses/tests/test_views/__init__.py
@@ -63,9 +63,11 @@ class CourseAPIMixin(SwitchMixin):
         httpretty.register_uri(httpretty.GET, url, **default_kwargs)
         logger.debug('Mocking Course API URL: %s', url)
 
-    def mock_course_detail(self, course_id):
+    def mock_course_detail(self, course_id, extra=None):
         path = 'courses/{}'.format(course_id)
         body = {'id': course_id, 'name': mock_course_name(course_id)}
+        if extra:
+            body.update(extra)
         self.mock_course_api(path, body)
 
     def mock_course_list(self):

--- a/analytics_dashboard/settings/base.py
+++ b/analytics_dashboard/settings/base.py
@@ -318,6 +318,9 @@ LMS_COURSE_VALIDATION_BASE_URL = None
 # used to construct the shortcut link to course modules
 LMS_COURSE_SHORTCUT_BASE_URL = None
 
+# used to construct shortcusts to view/edit courses in Studio
+CMS_COURSE_SHORTCUT_BASE_URL = None
+
 # Used to determine how dates are displayed in templates
 DATE_FORMAT = 'F d, Y'
 

--- a/analytics_dashboard/settings/dev.py
+++ b/analytics_dashboard/settings/dev.py
@@ -53,6 +53,7 @@ INSTALLED_APPS += (
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 
 LMS_COURSE_SHORTCUT_BASE_URL = 'https://example.com/courses'
+CMS_COURSE_SHORTCUT_BASE_URL = 'https://studio.example.com/course'
 
 ########## BRANDING
 PLATFORM_NAME = 'Open edX'

--- a/analytics_dashboard/settings/test.py
+++ b/analytics_dashboard/settings/test.py
@@ -23,6 +23,7 @@ ENABLE_AUTO_AUTH = True
 SOCIAL_AUTH_EDX_OIDC_URL_ROOT = 'http://example.com'
 
 LMS_COURSE_SHORTCUT_BASE_URL = 'http://lms-host'
+CMS_COURSE_SHORTCUT_BASE_URL = 'http://cms-host'
 COURSE_API_URL = 'http://course-api-host'
 
 LOGGING = get_logger_config(debug=DEBUG, dev_env=True, local_loglevel='DEBUG')

--- a/analytics_dashboard/static/sass/_developer.scss
+++ b/analytics_dashboard/static/sass/_developer.scss
@@ -395,6 +395,32 @@ table.dataTable thead th.sorting_desc:after {
   }
 }
 
+.table.course-overview {
+  th, td {
+    border-top: none;
+  }
+
+  th {
+    font-weight: normal;
+    white-space: nowrap;
+  }
+
+  td {
+    width: 99%; // Expand as much as possible
+  }
+}
+
+.course-external-tools {
+  list-style: none;
+  padding: 0;
+
+  li {
+    padding: 8px 10px;
+  }
+
+  .ico { margin-right: 6px; }
+}
+
 .course-home-table-outer {
   header.heading-outer {
     display: table;


### PR DESCRIPTION
**Description**: This adds a new optional UI component to the "Home" page of each course in the Insights Dashboard, in order to display useful information about the course. This supersedes an earlier proposal, #331.

It displays:
- Course Name or ID (whichever is not shown already in the header)
- Course Start Date
- Course End Date
- Course Status (in progress, started, or ended)
- Links to the LMS and Studio (when configured)

**JIRA**: [OSPR-721](https://openedx.atlassian.net/browse/OSPR-721)

**Partner Info**: 3rd party Open edX instance. Submitting to minimize code drift but no merge requirement.

**Merge deadline**: Not an edX partner, so best effort.

**Screenshots**:
1. enable_course_overview on, display_course_name_in_nav on, course that hasn't yet started:
   ![not started yet](https://cloud.githubusercontent.com/assets/945577/8868589/22edd00e-318f-11e5-8367-0a1b2e8f1c93.png)
2. enable_course_overview on, display_course_name_in_nav off, course with no end date:
   ![in progress display_course_name_in_nav off](https://cloud.githubusercontent.com/assets/945577/8868590/2cb361a8-318f-11e5-839f-c153ce3672e5.png)
3. With enable_course_overview off, the page appears exactly the same as before.
   ![enable_course_overview off](https://cloud.githubusercontent.com/assets/945577/8868674/d1919b18-318f-11e5-89f7-974dbe2f10fb.png)

**Configuration**:
The new component is only shown if the waffle switch `enable_course_overview` is active. The information on the left side also requires `enable_course_api` to be active. The links on the right require two django settings, `LMS_COURSE_SHORTCUT_BASE_URL` (existing) and `CMS_COURSE_SHORTCUT_BASE_URL` (new).

**Test Instructions**:
1. Get a running copy of the dashboard.
2. In `settings/local.py`, set the values of `LMS_COURSE_SHORTCUT_BASE_URL` and `CMS_COURSE_SHORTCUT_BASE_URL`. If testing with devstack (e.g. if using the analytics devstack), set:

``` python
LMS_COURSE_SHORTCUT_BASE_URL = 'http://localhost:8000/courses'
CMS_COURSE_SHORTCUT_BASE_URL = 'http://localhost:8001/course'
```
1. Go to {dashboard url}/admin/waffle/switch/ and activate various combinations of `enable_course_overview`, `display_course_name_in_nav`, and `enable_course_api`. Observe the effect on the home page of any course in the dashboard.

**Reviewers**: @mtyaka and TBD
