### PR TITLE
Optional feature to show engagement as percent of enrollment

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,4 @@
 Clinton Blackburn <cblackburn@edx.org>
 Dennis Jen <djen@edx.org>
 Carlos Andrés Rocha <rocha@edx.org>
+Braden MacDonald <braden@opencraft.com>

--- a/acceptance_tests/test_course_engagement.py
+++ b/acceptance_tests/test_course_engagement.py
@@ -95,6 +95,7 @@ class CourseEngagementContentTests(CourseEngagementPageTestsMixin, WebAppTest):
         headings = [u'Week Ending', u'Active Students', u'Watched a Video', u'Tried a Problem']
         if ENABLE_FORUM_POSTS:
             headings.append(u'Posted in Forum')
+        headings.append(u'Percent of Current Students')
 
         self.assertTableColumnHeadingsEqual(table_selector, headings)
 

--- a/analytics_dashboard/core/templatetags/dashboard_extras.py
+++ b/analytics_dashboard/core/templatetags/dashboard_extras.py
@@ -69,11 +69,12 @@ class CaptureasNode(template.Node):
 
 
 @register.inclusion_tag('summary_point.html')
-def summary_point(value, label, subheading=None, tooltip=None):
+def summary_point(value, label, subheading=None, tooltip=None, additional_value=None):
     return {
         'value': value,
         'label': label,
         'subheading': subheading,
+        'additional_value': additional_value,
         'tooltip': tooltip
     }
 

--- a/analytics_dashboard/courses/templates/courses/engagement_content.html
+++ b/analytics_dashboard/courses/templates/courses/engagement_content.html
@@ -52,21 +52,21 @@ Individual course-centric engagement content view.
           <div class="col-xs-12 col-sm-3" data-activity-type="any">
             {% trans "Active Students Last Week" as label %}
             {% trans "Students who visited at least one page in the course content." as tooltip %}
-            {% summary_point summary.any label tooltip=tooltip %}
+            {% summary_point summary.any label tooltip=tooltip additional_value=summary.any_percent_str %}
           </div>
 
           <div class="col-xs-12 col-sm-3" data-activity-type="played_video">
             {# Translators: This is a label indicating the number of students who watched a video. #}
             {% trans "Watched a Video Last Week" as label %}
             {% trans "Students who played one or more videos." as tooltip %}
-            {% summary_point summary.played_video label tooltip=tooltip %}
+            {% summary_point summary.played_video label tooltip=tooltip additional_value=summary.played_video_percent_str %}
           </div>
 
           <div class="col-xs-12 col-sm-3" data-activity-type="attempted_problem">
             {# Translators: This is a label indicating the number of students who tried a problem. #}
             {% trans "Tried a Problem Last Week" as label %}
             {% trans "Students who submitted an answer for a standard problem. Not all problem types are included." as tooltip %}
-            {% summary_point summary.attempted_problem label tooltip=tooltip %}
+            {% summary_point summary.attempted_problem label tooltip=tooltip additional_value=summary.attempted_problem_percent_str %}
           </div>
 
           {% switch show_engagement_forum_activity %}
@@ -74,7 +74,7 @@ Individual course-centric engagement content view.
               {# Translators: This is a label indicating the number of students who posted in a forum discussion. #}
               {% trans "Posted in a Discussion Last Week" as label %}
               {% trans "Students who contributed to any discussion topic." as tooltip %}
-              {% summary_point summary.posted_forum label tooltip=tooltip %}
+              {% summary_point summary.posted_forum label tooltip=tooltip additional_value=summary.posted_forum_percent_str %}
             </div>
           {% endswitch %}
         </div>

--- a/analytics_dashboard/courses/tests/test_views/test_engagement.py
+++ b/analytics_dashboard/courses/tests/test_views/test_engagement.py
@@ -26,6 +26,10 @@ class CourseEngagementViewTestMixin(PatchMixin, CourseAPIMixin):  # pylint: disa
     def setUp(self):
         super(CourseEngagementViewTestMixin, self).setUp()
         self.toggle_switch('enable_engagement_videos_pages', True)
+        # This view combines the activity API with the enrollment API, so we need to mock both.
+        patcher = mock.patch('analyticsclient.course.Course.enrollment', return_value=utils.mock_course_enrollment())
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
     def get_mock_data(self, course_id):
         return utils.mock_course_activity(course_id)

--- a/analytics_dashboard/courses/tests/utils.py
+++ b/analytics_dashboard/courses/tests/utils.py
@@ -525,6 +525,32 @@ def get_mock_api_answer_distribution_multiple_questions_first_last_data(course_i
     return answers
 
 
+def get_mock_api_course_enrollment(course_id):
+    """ Mock enrollment data corresponding to mock activity data above """
+    aug = [{
+        'course_id': course_id,
+        'date': '2014-08-31',
+        'count': 10000,
+        'created': CREATED_DATETIME_STRING
+    }]
+    sept = [
+        {
+            'course_id': course_id,
+            'date': '2014-09-{:02d}'.format(day),
+            'count': 10000 + day,
+            'created': CREATED_DATETIME_STRING
+        }
+        for day in range(1, 10)
+    ]
+    return aug + sept
+
+
+# pylint: disable=unused-argument
+def mock_course_enrollment(start_date=None, end_date=None):
+    """ Mock API enrollment data """
+    return get_mock_api_course_enrollment(u'edX/DemoX/Demo_Course')
+
+
 def get_mock_api_answer_distribution_multiple_questions_data(course_id):
     answers = []
     total_first_count = 10

--- a/analytics_dashboard/static/js/engagement-content-main.js
+++ b/analytics_dashboard/static/js/engagement-content-main.js
@@ -42,6 +42,13 @@ require(['vendor/domReady!', 'load/init-page'], function (doc, page) {
                     color: '#E78AC3',
                     className: 'text-right',
                     type: 'number'
+                },
+                {
+                    key: 'active_percent',
+                    title: gettext('Percent of Current Students'),
+                    color: '#FFFFFF',
+                    className: 'text-right',
+                    type: 'percent'
                 }
             ],
             trendSettings;
@@ -53,7 +60,7 @@ require(['vendor/domReady!', 'load/init-page'], function (doc, page) {
 
         // trend settings don't need weekEnding
         trendSettings = _(settings).filter(function (setting) {
-            return setting.key !== 'weekEnding';
+            return setting.key !== 'weekEnding' && setting.key !== 'active_percent';
         });
 
         // weekly engagement activities graph
@@ -82,7 +89,8 @@ require(['vendor/domReady!', 'load/init-page'], function (doc, page) {
             model: page.models.courseModel,
             modelAttribute: 'engagementTrends',
             columns: settings,
-            sorting: ['-weekEnding']
+            sorting: ['-weekEnding'],
+            replaceNull: '-'
         });
     });
 });

--- a/analytics_dashboard/static/js/views/data-table-view.js
+++ b/analytics_dashboard/static/js/views/data-table-view.js
@@ -173,6 +173,8 @@ define(['dataTablesBootstrap', 'jquery', 'naturalSort', 'underscore', 'utils/uti
                     if (type === 'display') {
                         if (_(self.options).has('replaceZero') && value === 0) {
                             display = self.options.replaceZero;
+                        } else if (_(self.options).has('replaceNull') && value === null) {
+                            display = self.options.replaceNull;
                         } else {
                             display = Utils.formatDisplayPercentage(value);
                         }

--- a/analytics_dashboard/static/sass/_base.scss
+++ b/analytics_dashboard/static/sass/_base.scss
@@ -272,6 +272,10 @@ hr.has-emphasis {
     margin-top: 0;
   }
 
+  .summary-point-addtional-value {
+    color: $gray;
+  }
+
   .summary-point-label {
     @extend h4;
   }

--- a/analytics_dashboard/templates/summary_point.html
+++ b/analytics_dashboard/templates/summary_point.html
@@ -9,6 +9,9 @@
     {% if subheading %}
       <span class="summary-point-note">{{ subheading }}</span>
     {% endif %}
+    {% if additional_value %}
+      <span class="summary-point-addtional-value">{{ additional_value }}</span>
+    {% endif %}
     {% if tooltip %}
       <div class="summary-point-help">
         <span class="sr-only">{{ tooltip }}</span>


### PR DESCRIPTION
**Description**: This PR adds a little bit more information to the course engagement summary screen in the dashboard: When enabled, it displays the weekly active student count as a percentage, in addition to the absolute number.

The percentage of active students for a week is approximated as ([# of active students that week] ÷ [# of enrolled students on the last day of the week] × 100).

In order to keep the code change simple for now, the new data is only displayed in the tables and summaries, and is not shown on the chart.

**JIRA**: [OSPR-720](https://openedx.atlassian.net/browse/OSPR-720)

**Partner Info**: 3rd party Open edX instance. Submitting to minimize code drift but no merge requirement.

**Merge deadline**: Not an edX partner, so best effort.

**Screenshots**:
1. With the new feature enabled:
   ![engagement percentages](https://cloud.githubusercontent.com/assets/945577/8891835/c00e0c78-32ed-11e5-826e-d4d1276d2ac0.png)
2. With the new feature disabled:
   ![engagement percentages disabled](https://cloud.githubusercontent.com/assets/945577/8891833/baf9f7c4-32ed-11e5-9955-5a501eea0803.png)

**Configuration**:
The percentage/enrollment data is only computed and shown if the waffle switch `show_stats_vs_enrollment` is active.

**Test Instructions**:
1. Get a running copy of the dashboard.
2. Import at least a few weeks' worth of engagement and enrollment data from an LMS instance such as your own devstack (for instructions on steps 1 and 2 see [here](https://github.com/open-craft/edx-analytics-devstack#running-the-pipeline))
3. Go to {dashboard url}/admin/waffle/switch/ and enable `show_stats_vs_enrollment`.
4. View a course's engagement summary in the dashboard

**Reviewers**: @mtyaka and TBD
