### PR TITLE
Add page that shows problem history for a single user and course

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,4 @@
 Clinton Blackburn <cblackburn@edx.org>
 Dennis Jen <djen@edx.org>
 Carlos Andrés Rocha <rocha@edx.org>
+Tim Krones <t.krones@gmx.net>

--- a/analytics_dashboard/courses/templates/courses/home.html
+++ b/analytics_dashboard/courses/templates/courses/home.html
@@ -27,7 +27,7 @@
         {% endfor %}
       </ul>
       <ul id="mode-selectors" class="nav navbar-nav navbar-right">
-        <li class="active nav-section has-tooltip" data-toggle="tooltip" title="You're in course mode">
+        <li class="active nav-section has-tooltip" data-toggle="tooltip" title="{% trans "You're in course mode" %}">
           <a href="#">
             <span class="link-label">
               <i class="ico fa fa-users" aria-hidden="true"></i>
@@ -35,7 +35,7 @@
           </a>
           <span class="sr-only">({% trans "Active" %})</span>
         </li>
-        <li class="has-tooltip" data-toggle="tooltip" title="Click to switch to user mode">
+        <li class="has-tooltip" data-toggle="tooltip" title="{% trans "Click to switch to user mode" %}">
           <a href="{% url 'courses:users:list' course_id=course_id %}">
             <span class="link-label">
               <i class="ico fa fa-user" aria-hidden="true"></i>

--- a/analytics_dashboard/courses/templates/courses/home.html
+++ b/analytics_dashboard/courses/templates/courses/home.html
@@ -27,6 +27,7 @@
         {% endfor %}
       </ul>
       <ul id="mode-selectors" class="nav navbar-nav navbar-right">
+        {# Translators: Being in course mode means that the user is looking at a page that provides course-centric information. #}
         <li class="active nav-section has-tooltip" data-toggle="tooltip" title="{% trans "You're in course mode" %}">
           <a href="#">
             <span class="link-label">

--- a/analytics_dashboard/courses/templates/courses/home.html
+++ b/analytics_dashboard/courses/templates/courses/home.html
@@ -17,12 +17,31 @@
 
         {% for item in primary_nav_items %}
           <li>
-            <a href="{{ item.href }}"><span class="link-label">
+            <a href="{{ item.href }}">
+              <span class="link-label">
                 {% if item.icon %}<i class="ico fa {{ item.icon }}" aria-hidden="true"></i>{% endif %}
-              {{ item.label }}
-            </span></a>
+                {{ item.label }}
+              </span>
+            </a>
           </li>
         {% endfor %}
+      </ul>
+      <ul id="mode-selectors" class="nav navbar-nav navbar-right">
+        <li class="active nav-section has-tooltip" data-toggle="tooltip" title="You're in course mode">
+          <a href="#">
+            <span class="link-label">
+              <i class="ico fa fa-users" aria-hidden="true"></i>
+            </span>
+          </a>
+          <span class="sr-only">({% trans "Active" %})</span>
+        </li>
+        <li class="has-tooltip" data-toggle="tooltip" title="Click to switch to user mode">
+          <a href="{% url 'courses:users:list' course_id=course_id %}">
+            <span class="link-label">
+              <i class="ico fa fa-user" aria-hidden="true"></i>
+            </span>
+          </a>
+        </li>
       </ul>
     </div>
   </nav>

--- a/analytics_dashboard/courses/urls.py
+++ b/analytics_dashboard/courses/urls.py
@@ -109,6 +109,7 @@ COURSE_URLS = patterns(
     url(r'^engagement/', include(ENGAGEMENT_URLS, namespace='engagement')),
     url(r'^performance/', include(PERFORMANCE_URLS, namespace='performance')),
     url(r'^csv/', include(CSV_URLS, namespace='csv')),
+    url(r'^users/', include('users.urls', namespace='users')),
 )
 
 urlpatterns = patterns(

--- a/analytics_dashboard/courses/views/__init__.py
+++ b/analytics_dashboard/courses/views/__init__.py
@@ -298,7 +298,7 @@ class CourseNavBarMixin(object):
                 'view': 'courses:performance:graded_content',
                 'icon': 'fa-check-square-o',
                 'switch': 'enable_course_api',
-            },
+            }
 
         ]
 

--- a/analytics_dashboard/courses/views/__init__.py
+++ b/analytics_dashboard/courses/views/__init__.py
@@ -39,8 +39,18 @@ logger = logging.getLogger(__name__)
 class CourseAPIMixin(object):
     access_token = None
     course_api_enabled = False
+    course_api_client = None
     course_api = None
     course_id = None
+
+    @cached_property
+    def course_structure(self):
+        """
+        Returns course structure.
+
+        All requests for course structure should be made against this property to take advantage of caching.
+        """
+        return self.get_course_structure(self.course_id)
 
     @cached_property
     def course_info(self):
@@ -56,12 +66,40 @@ class CourseAPIMixin(object):
 
         if self.course_api_enabled and request.user.is_authenticated():
             self.access_token = settings.COURSE_API_KEY or request.user.access_token
-            self.course_api = CourseStructureApiClient(settings.COURSE_API_URL, self.access_token).courses
+            self.course_api_client = CourseStructureApiClient(settings.COURSE_API_URL, self.access_token)
+            self.course_api = self.course_api_client.courses
 
         return super(CourseAPIMixin, self).dispatch(request, *args, **kwargs)
 
+    def _course_structure_cache_key(self, course_id):
+        return sanitize_cache_key(u'course_{}_structure').format(course_id)
+
     def _course_detail_cache_key(self, course_id):
         return sanitize_cache_key(u'course_{}_details'.format(course_id))
+
+    def get_course_structure(self, course_id):
+        """
+        Retrieve course structure from the Course API.
+
+        Retrieved data is cached.
+
+        Arguments
+            course_id       -- ID of the course for which data should be retrieved
+        """
+        key = self._course_structure_cache_key(course_id)
+        structure = cache.get(key)
+
+        if not structure:
+            try:
+                logger.debug("Retrieving structure for course: %s", course_id)
+                structure = self.course_api_client.course_structures(course_id).get()
+                cache.set(key, structure)
+            except HttpClientError as e:
+                logger.error("Unable to retrieve course structure for %s: %s", course_id, e)
+                structure = {}
+
+        return structure
+        # return self.course_api_client.course_structures(course_id).get()
 
     def get_course_info(self, course_id):
         """

--- a/analytics_dashboard/courses/views/__init__.py
+++ b/analytics_dashboard/courses/views/__init__.py
@@ -298,7 +298,7 @@ class CourseNavBarMixin(object):
                 'view': 'courses:performance:graded_content',
                 'icon': 'fa-check-square-o',
                 'switch': 'enable_course_api',
-            }
+            },
 
         ]
 

--- a/analytics_dashboard/courses/views/__init__.py
+++ b/analytics_dashboard/courses/views/__init__.py
@@ -94,8 +94,8 @@ class CourseAPIMixin(object):
                 logger.debug("Retrieving structure for course: %s", course_id)
                 structure = self.course_api_client.course_structures(course_id).get()
                 cache.set(key, structure)
-            except HttpClientError as e:
-                logger.error("Unable to retrieve course structure for %s: %s", course_id, e)
+            except HttpClientError as err:
+                logger.error("Unable to retrieve course structure for %s: %s", course_id, err)
                 structure = {}
 
         return structure

--- a/analytics_dashboard/settings/base.py
+++ b/analytics_dashboard/settings/base.py
@@ -228,6 +228,7 @@ DJANGO_APPS = (
 LOCAL_APPS = (
     'core',
     'courses',
+    'users',
     'django_rjs',
     'help',
     'soapbox',

--- a/analytics_dashboard/settings/base.py
+++ b/analytics_dashboard/settings/base.py
@@ -421,3 +421,7 @@ COURSE_API_URL = None
 # If no key is specified, the authenticated user's OAuth2 access token will be used.
 COURSE_API_KEY = None
 ########## END COURSE API
+
+########## ENROLLMENT API
+ENROLLMENT_API_URL = None
+########## END ENROLLMENT API

--- a/analytics_dashboard/settings/local.py
+++ b/analytics_dashboard/settings/local.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 
 import os
 from os.path import join, normpath
+from urlparse import urljoin
 
 from analytics_dashboard.settings.base import *
 from analytics_dashboard.settings.logger import get_logger_config
@@ -73,7 +74,9 @@ INSTALLED_APPS += (
 )
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 
-LMS_COURSE_SHORTCUT_BASE_URL = 'https://courses.edx.org/courses'
+LMS_URL = 'http://127.0.0.1:8000/'
+
+LMS_COURSE_SHORTCUT_BASE_URL = urljoin(LMS_URL, 'courses')
 
 ########## BRANDING
 PLATFORM_NAME = 'edX'
@@ -86,7 +89,7 @@ FULL_APPLICATION_NAME = '{0} {1}'.format(PLATFORM_NAME, APPLICATION_NAME)
 # Set these to the correct values for your OAuth2/OpenID Connect provider
 SOCIAL_AUTH_EDX_OIDC_KEY = 'replace-me'
 SOCIAL_AUTH_EDX_OIDC_SECRET = 'replace-me'
-SOCIAL_AUTH_EDX_OIDC_URL_ROOT = 'http://127.0.0.1:8000/oauth2'
+SOCIAL_AUTH_EDX_OIDC_URL_ROOT = urljoin(LMS_URL, 'oauth2')
 
 # This value should be the same as SOCIAL_AUTH_EDX_OIDC_SECRET
 SOCIAL_AUTH_EDX_OIDC_ID_TOKEN_DECRYPTION_KEY = SOCIAL_AUTH_EDX_OIDC_SECRET
@@ -106,6 +109,7 @@ HELP_URL = '#'
 SEGMENT_IO_KEY = os.environ.get('SEGMENT_WRITE_KEY')
 ########## END SEGMENT.IO
 
-COURSE_API_URL = 'http://127.0.0.1:8000/api/course_structure/v0/'
+COURSE_API_URL = urljoin(LMS_URL, 'api/course_structure/v0/')
+ENROLLMENT_API_URL = urljoin(LMS_URL, 'api/enrollment/v1/')
 
 LOGGING = get_logger_config(debug=DEBUG, dev_env=True, local_loglevel='DEBUG')

--- a/analytics_dashboard/settings/test.py
+++ b/analytics_dashboard/settings/test.py
@@ -24,6 +24,7 @@ SOCIAL_AUTH_EDX_OIDC_URL_ROOT = 'http://example.com'
 
 LMS_COURSE_SHORTCUT_BASE_URL = 'http://lms-host'
 COURSE_API_URL = 'http://course-api-host'
+ENROLLMENT_API_URL = 'http://enrollment-api-host'
 
 LOGGING = get_logger_config(debug=DEBUG, dev_env=True, local_loglevel='DEBUG')
 

--- a/analytics_dashboard/static/js/load/init-models.js
+++ b/analytics_dashboard/static/js/load/init-models.js
@@ -8,14 +8,12 @@ define(['jquery', 'models/course-model', 'models/tracking-model', 'models/user-m
         'use strict';
         var courseModel = new CourseModel(),
             trackingModel = new TrackingModel(),
-            userModel = new UserModel();
+            userModel = new UserModel(),
+            modelData = window.initModelData || {}; // initModelData is set by the Django template at render time.
 
-        /* jshint ignore:start */
-        // initModelData is set by the Django template at render time.
-        courseModel.set(initModelData.course);
-        trackingModel.set(initModelData.tracking);
-        userModel.set(initModelData.user);
-        /* jshint ignore:end */
+        courseModel.set(modelData.course);
+        trackingModel.set(modelData.tracking);
+        userModel.set(modelData.user);
 
         return {
             courseModel: courseModel,

--- a/analytics_dashboard/static/sass/_developer.scss
+++ b/analytics_dashboard/static/sass/_developer.scss
@@ -377,6 +377,10 @@ body.view-course-list {
   }
 }
 
+.user-profile-courses .active-course {
+  font-weight: bold;
+}
+
 // DataTables
 // align the headings with the text in the rows
 table.dataTable thead > tr > th {

--- a/analytics_dashboard/static/sass/_developer.scss
+++ b/analytics_dashboard/static/sass/_developer.scss
@@ -168,6 +168,10 @@ button.chart-info {
   }
 }
 
+#mode-selectors {
+  margin-right: 0;
+}
+
 .navbar-nav {
 
   .nav-section.active {

--- a/analytics_dashboard/static/sass/_developer.scss
+++ b/analytics_dashboard/static/sass/_developer.scss
@@ -265,23 +265,72 @@ $lens-box-model: border-box;
   }
 }
 
-.course-list {
+.pagination-nav {
+  @include clearfix();
+
+  text-align: right;
+  padding-right: $padding-large-horizontal;
+
+  .nav {
+    width: 100%;
+  }
+
+  .nav li {
+    display: inline-block;
+    float: none;
+  }
+
+  .pagination-status {
+    padding: 0 10px;
+  }
+
+  .unavailable-page {
+    visibility: hidden;
+  }
+
+  li > a {
+    color: $link-color;
+    padding-top: 0px;
+    padding-bottom: $padding-small-vertical;
+
+    &:hover {
+      color: $link-hover-color;
+      background-color: transparent;
+    }
+  }
+}
+
+.pagination-nav + .paginated {
+  margin-top: 0;
+}
+
+.paginated + .pagination-nav {
+  margin-top: -15px;
+  margin-bottom: 15px;
+
+  li > a {
+    padding-top: $padding-small-vertical;
+    padding-bottom: 0;
+  }
+}
+
+.course-list, .user-list {
   margin-top: 10px;
   margin-bottom: 15px;
   background: white;
   border: 1px solid $edx-gray;
   border-width: 0 0 1px 1px;
 
-  .course {
+  .course, .user {
     padding: 15px;
     border: 1px solid $edx-gray;
     border-width: 1px 1px 0 0;
 
-    .course-name {
+    .course-name, .main-info {
       font-size: $font-size-large;
     }
 
-    .course-key {
+    .course-key, .sub-info {
       color: $edx-gray;
     }
   }
@@ -315,6 +364,12 @@ body.view-course-list {
       font-size: $font-size-small;
       margin-bottom: 50px;
     }
+  }
+}
+
+.user-profile-info {
+  .missing-data {
+    color: $edx-gray-l1;
   }
 }
 

--- a/analytics_dashboard/templates/lens-navigation.html
+++ b/analytics_dashboard/templates/lens-navigation.html
@@ -33,6 +33,24 @@ Partial for displaying the lens navigation and the sections within the lenses.
 
         {% include "submenu_navigation.html" with nav_items=secondary_nav_items%}
       </ul>
+
+      <ul id="mode-selectors" class="nav navbar-nav navbar-right">
+        <li class="active nav-section has-tooltip" data-toggle="tooltip" title="You're in course mode">
+          <a href="#">
+            <span class="link-label">
+              <i class="ico fa fa-users" aria-hidden="true"></i>
+            </span>
+          </a>
+          <span class="sr-only">({% trans "Active" %})</span>
+        </li>
+        <li class="has-tooltip" data-toggle="tooltip" title="Click to switch to user mode">
+          <a href="{% url 'courses:users:list' course_id=course_id %}">
+            <span class="link-label">
+              <i class="ico fa fa-user" aria-hidden="true"></i>
+            </span>
+          </a>
+        </li>
+      </ul>
     </div>
   </nav>
 {% endif %}

--- a/analytics_dashboard/templates/lens-navigation.html
+++ b/analytics_dashboard/templates/lens-navigation.html
@@ -35,7 +35,7 @@ Partial for displaying the lens navigation and the sections within the lenses.
       </ul>
 
       <ul id="mode-selectors" class="nav navbar-nav navbar-right">
-        <li class="active nav-section has-tooltip" data-toggle="tooltip" title="You're in course mode">
+        <li class="active nav-section has-tooltip" data-toggle="tooltip" title="{% trans "You're in course mode" %}">
           <a href="#">
             <span class="link-label">
               <i class="ico fa fa-users" aria-hidden="true"></i>
@@ -43,7 +43,7 @@ Partial for displaying the lens navigation and the sections within the lenses.
           </a>
           <span class="sr-only">({% trans "Active" %})</span>
         </li>
-        <li class="has-tooltip" data-toggle="tooltip" title="Click to switch to user mode">
+        <li class="has-tooltip" data-toggle="tooltip" title="{% trans "Click to switch to user mode" %}">
           <a href="{% url 'courses:users:list' course_id=course_id %}">
             <span class="link-label">
               <i class="ico fa fa-user" aria-hidden="true"></i>

--- a/analytics_dashboard/templates/lens-navigation.html
+++ b/analytics_dashboard/templates/lens-navigation.html
@@ -35,6 +35,7 @@ Partial for displaying the lens navigation and the sections within the lenses.
       </ul>
 
       <ul id="mode-selectors" class="nav navbar-nav navbar-right">
+        {# Translators: Being in course mode means that the user is looking at a page that provides course-centric information. #}
         <li class="active nav-section has-tooltip" data-toggle="tooltip" title="{% trans "You're in course mode" %}">
           <a href="#">
             <span class="link-label">

--- a/analytics_dashboard/templates/pagination.html
+++ b/analytics_dashboard/templates/pagination.html
@@ -1,0 +1,12 @@
+{% load i18n %}
+<div class="pagination-nav">
+    <ul class="nav navbar-nav">
+        <li {% if page <= 1 %} class="unavailable-page" aria-hidden="true"{% endif %}>
+        	<a href="?page={{page|add:-1}}">{% trans "Prev" %}</a>
+        </li>
+        <li class="pagination-status">{% blocktrans %}Page {{page}} of {{total_pages}}{% endblocktrans %}</li>
+        <li {% if page >= total_pages %} class="unavailable-page" aria-hidden="true"{% endif %}>
+        	<a href="?page={{page|add:1}}">{% trans "Next" %}</a>
+        </li>
+    </ul>
+</div>

--- a/analytics_dashboard/urls.py
+++ b/analytics_dashboard/urls.py
@@ -25,6 +25,7 @@ urlpatterns = patterns(
     url(r'^status/$', views.status, name='status'),
     url(r'^health/$', views.health, name='health'),
     url(r'^courses/', include('courses.urls', namespace='courses')),
+    url(r'^users/', include('users.urls', namespace='users')),
     url(r'^admin/', include(admin.site.urls)),
     url('', include('social.apps.django_app.urls', namespace='social')),
     url(r'^accounts/login/$',

--- a/analytics_dashboard/urls.py
+++ b/analytics_dashboard/urls.py
@@ -25,7 +25,6 @@ urlpatterns = patterns(
     url(r'^status/$', views.status, name='status'),
     url(r'^health/$', views.health, name='health'),
     url(r'^courses/', include('courses.urls', namespace='courses')),
-    url(r'^users/', include('users.urls', namespace='users')),
     url(r'^admin/', include(admin.site.urls)),
     url('', include('social.apps.django_app.urls', namespace='social')),
     url(r'^accounts/login/$',

--- a/analytics_dashboard/users/templates/users/api-error.html
+++ b/analytics_dashboard/users/templates/users/api-error.html
@@ -1,0 +1,16 @@
+{% extends "base-error.html" %}
+{% load i18n %}
+
+{% comment %}Translators: This message is displayed when the website is unable to retrieve data requested by the user{% endcomment %}
+{% block title %}{% trans "Data Retrieval Failed" %} {{ block.super }}{% endblock title %}
+
+{% block error-title %}{% trans "Data Retrieval Failed" %}{% endblock %}
+{% block error-copy %}
+  {% trans "There was a problem retrieving the data you requested. Please try again. If you continue to experience issues, please let us know." %}
+{% endblock %}
+
+{% block buttons %}
+  <a onclick="location.reload(true);" class="btn btn-lg btn-primary"> <i class="ico fa fa-refresh" aria-hidden="true"></i>
+    {% trans "Try Again" %}</a>
+  {{ block.super }}
+{% endblock %}

--- a/analytics_dashboard/users/templates/users/base.html
+++ b/analytics_dashboard/users/templates/users/base.html
@@ -1,0 +1,20 @@
+{% extends "base_dashboard.html" %}
+{% load dashboard_extras %}
+
+{% block title %}{{ page_title }} - {{ block.super }}{% endblock title %}
+
+{% block header-text %}
+{% endblock %}
+
+{% block content %}
+  {% block child_content %}
+  {% endblock %}
+  {% block data_messaging %}
+    {% if update_message %}
+      <div class="data-update-message">{{ update_message }}</div>
+    {% endif %}
+    {% if data_information_message %}
+      <div class="data-information-message">{{ data_information_message }}</div>
+    {% endif %}
+  {% endblock %}
+{% endblock %}

--- a/analytics_dashboard/users/templates/users/base.html
+++ b/analytics_dashboard/users/templates/users/base.html
@@ -1,10 +1,9 @@
 {% extends "base_dashboard.html" %}
 {% load dashboard_extras %}
 
-{% block title %}{{ page_title }} - {{ block.super }}{% endblock title %}
+{% block title %}{{ page_title }} - {{ course_key|format_course_key }} {{ block.super }}{% endblock title %}
 
-{% block header-text %}
-{% endblock %}
+{% block header-text %}{% endblock %}
 
 {% block content %}
   {% block child_content %}

--- a/analytics_dashboard/users/templates/users/list.html
+++ b/analytics_dashboard/users/templates/users/list.html
@@ -1,0 +1,55 @@
+{% extends "users/base.html" %}
+{% load i18n %}
+{% load staticfiles %}
+{% load dashboard_extras %}
+{% load firstof from future %}
+
+{% block view-name %}view-course-list{% endblock view-name %}
+
+{% block title %}{% trans "Users" %} {{ block.super }}{% endblock title %}
+
+{% block header-text %}
+  <h3>
+    {% blocktrans %}Registered Users{% endblocktrans %}
+  </h3>
+{% endblock %}
+
+{% block intro-text %}
+  {% blocktrans %}Here are all the registered users in the system:{% endblocktrans %}
+{% endblock intro-text %}
+
+{% block content %}
+  <div class="row">
+    <div class="col-md-8">
+
+      {% include "pagination.html" %}
+
+      <div class="user-list paginated">
+        {% for user in users %}
+          <div class="user">
+            <a href="{% url 'users:profile' user_id=user.id %}">
+              <span class="main-info">{{user.username}}</span>
+            </a>
+            <div class="sub-info">{{user.name}}</div>
+          </div>
+        {% endfor %}
+      </div>
+
+      {% include "pagination.html" %}
+
+    </div>
+
+    <div class="col-md-4">
+      <div class="help-msg">
+        <h4>{% blocktrans %}New to {{ application_name }}?{% endblocktrans %}</h4>
+
+        {% captureas email_link %}
+          <a class="feedback-email" href="mailto:{{ feedback_email }}?Subject=Feedback">
+            {{ feedback_email }}</a>{% endcaptureas %}
+
+        <p class="info-text">{% blocktrans trimmed %} Click Help in the upper-right corner to get more information
+          about {{ application_name }}. Send us feedback at {{ email_link }}.{% endblocktrans %}</p>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/analytics_dashboard/users/templates/users/list.html
+++ b/analytics_dashboard/users/templates/users/list.html
@@ -54,7 +54,7 @@
       <div class="user-list paginated">
         {% for user in users %}
           <div class="user">
-            <a href="{% url 'courses:users:profile' course_id=course_id user_id=user.id %}">
+            <a href="{% url 'courses:users:profile' course_id=course_id username=user.username %}">
               <span class="main-info">{{user.username}}</span>
             </a>
             <div class="sub-info">{{user.name}}</div>

--- a/analytics_dashboard/users/templates/users/list.html
+++ b/analytics_dashboard/users/templates/users/list.html
@@ -10,13 +10,40 @@
 
 {% block header-text %}
   <h3>
-    {% blocktrans %}Registered Users{% endblocktrans %}
+    {% blocktrans %}Enrolled Students{% endblocktrans %}
   </h3>
 {% endblock %}
 
 {% block intro-text %}
-  {% blocktrans %}Here are all the registered users in the system:{% endblocktrans %}
+  {% blocktrans %}Here are all the students enrolled in this course:{% endblocktrans %}
 {% endblock intro-text %}
+
+{% block lens_navigation %}
+  {#  This is a simplified version of lens-navigation.html. #}
+
+  {#  Translators: Application here refers to the web site/application being used (e.g. the dashboard). #}
+  <nav class="navbar navbar-default lens-nav" role="navigation" aria-label="{% trans "Application" %}">
+    <div class="container ">
+      <ul id="mode-selectors" class="nav navbar-nav navbar-right">
+        <li class="has-tooltip" data-toggle="tooltip" title="Click to switch to course mode">
+          <a href="{% url 'courses:home' course_id=course_id %}">
+            <span class="link-label">
+              <i class="ico fa fa-users" aria-hidden="true"></i>
+            </span>
+          </a>
+        </li>
+        <li class="active nav-section has-tooltip" data-toggle="tooltip" title="You're in user mode">
+          <a href="#">
+            <span class="link-label">
+              <i class="ico fa fa-user" aria-hidden="true"></i>
+            </span>
+          </a>
+          <span class="sr-only">({% trans "Active" %})</span>
+        </li>
+      </ul>
+    </div>
+  </nav>
+{% endblock %}
 
 {% block content %}
   <div class="row">
@@ -27,7 +54,7 @@
       <div class="user-list paginated">
         {% for user in users %}
           <div class="user">
-            <a href="{% url 'users:profile' user_id=user.id %}">
+            <a href="{% url 'courses:users:profile' course_id=course_id user_id=user.id %}">
               <span class="main-info">{{user.username}}</span>
             </a>
             <div class="sub-info">{{user.name}}</div>

--- a/analytics_dashboard/users/templates/users/list.html
+++ b/analytics_dashboard/users/templates/users/list.html
@@ -2,21 +2,8 @@
 {% load i18n %}
 {% load staticfiles %}
 {% load dashboard_extras %}
-{% load firstof from future %}
 
-{% block view-name %}view-course-list{% endblock view-name %}
-
-{% block title %}{% trans "Users" %} {{ block.super }}{% endblock title %}
-
-{% block header-text %}
-  <h3>
-    {% blocktrans %}Enrolled Students{% endblocktrans %}
-  </h3>
-{% endblock %}
-
-{% block intro-text %}
-  {% blocktrans %}Here are all the students enrolled in this course:{% endblocktrans %}
-{% endblock intro-text %}
+{% block view-name %}view-user-list{% endblock view-name %}
 
 {% block lens_navigation %}
   {#  This is a simplified version of lens-navigation.html. #}
@@ -44,6 +31,16 @@
     </div>
   </nav>
 {% endblock %}
+
+{% block header-text %}
+  <h3>
+    {% blocktrans %}Enrolled Students{% endblocktrans %}
+  </h3>
+{% endblock %}
+
+{% block intro-text %}
+  {% blocktrans %}Here are all the students enrolled in this course:{% endblocktrans %}
+{% endblock intro-text %}
 
 {% block content %}
   <div class="row">

--- a/analytics_dashboard/users/templates/users/problem_data.html
+++ b/analytics_dashboard/users/templates/users/problem_data.html
@@ -1,0 +1,82 @@
+{% extends "users/base.html" %}
+{% load i18n %}
+{% load staticfiles %}
+{% load dashboard_extras %}
+{% load firstof from future %}
+
+{% block view-name %}view-problem-data{% endblock view-name %}
+
+{% block title %}{{ username }} - {{ block.super }}{% endblock title %}
+
+{% block header-text %}
+  <h3>
+    {% blocktrans %}Problem History: {{ username }}{% endblocktrans %}
+  </h3>
+{% endblock %}
+
+{% block intro-text %}
+  {% blocktrans %}Here is a list of problems that this user completed:{% endblocktrans %}
+{% endblock intro-text %}
+
+{% block lens_navigation %}
+  {#  This is a simplified version of lens-navigation.html. #}
+
+  {#  Translators: Application here refers to the web site/application being used (e.g. the dashboard). #}
+  <nav class="navbar navbar-default lens-nav" role="navigation" aria-label="{% trans "Application" %}">
+    <div class="container ">
+      <ul id="mode-selectors" class="nav navbar-nav navbar-right">
+        <li class="has-tooltip" data-toggle="tooltip" title="Click to switch to course mode">
+          <a href="{% url 'courses:home' course_id=course_id %}">
+            <span class="link-label">
+              <i class="ico fa fa-users" aria-hidden="true"></i>
+            </span>
+          </a>
+        </li>
+        <li class="active nav-section has-tooltip" data-toggle="tooltip" title="You're in user mode. Click to go back to the list of all students enrolled in this course.">
+          <a href="{% url 'courses:users:list' course_id=course_id %}">
+            <span class="link-label">
+              <i class="ico fa fa-user" aria-hidden="true"></i>
+            </span>
+          </a>
+          <span class="sr-only">({% trans "Active" %})</span>
+        </li>
+      </ul>
+    </div>
+  </nav>
+{% endblock %}
+
+{% block content %}
+
+<!--
+
+Problem Name           | # of attempts          | Final Score
+-----------------------|------------------------|-----------------
+Testing your knowledge | 2                      | 4/6
+What did you learn?    | 3                      | 10/11
+
+-->
+
+  <div class="row">
+    <div class="col-xs-12 col-md-8">
+      <table class="table">
+        <thead>
+          <tr>
+            <th>{% trans "Problem Name" %}</th>
+            <th>{% trans "# of attempts" %}</th>
+            <th>{% trans "Final Score" %}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for problem in problem_data %}
+            <tr>
+              <td>{{ problem.name }}</td>
+              <td>{{ problem.num_attempts }}</td>
+              <td>{{ problem.final_score }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+{% endblock %}

--- a/analytics_dashboard/users/templates/users/problem_data.html
+++ b/analytics_dashboard/users/templates/users/problem_data.html
@@ -1,8 +1,5 @@
-{% extends "users/base.html" %}
+{% extends "users/user.html" %}
 {% load i18n %}
-{% load staticfiles %}
-{% load dashboard_extras %}
-{% load firstof from future %}
 
 {% block view-name %}view-problem-data{% endblock view-name %}
 
@@ -18,43 +15,7 @@
   {% blocktrans %}Here is a list of problems that this user completed:{% endblocktrans %}
 {% endblock intro-text %}
 
-{% block lens_navigation %}
-  {#  This is a simplified version of lens-navigation.html. #}
-
-  {#  Translators: Application here refers to the web site/application being used (e.g. the dashboard). #}
-  <nav class="navbar navbar-default lens-nav" role="navigation" aria-label="{% trans "Application" %}">
-    <div class="container ">
-      <ul id="mode-selectors" class="nav navbar-nav navbar-right">
-        <li class="has-tooltip" data-toggle="tooltip" title="Click to switch to course mode">
-          <a href="{% url 'courses:home' course_id=course_id %}">
-            <span class="link-label">
-              <i class="ico fa fa-users" aria-hidden="true"></i>
-            </span>
-          </a>
-        </li>
-        <li class="active nav-section has-tooltip" data-toggle="tooltip" title="You're in user mode. Click to go back to the list of all students enrolled in this course.">
-          <a href="{% url 'courses:users:list' course_id=course_id %}">
-            <span class="link-label">
-              <i class="ico fa fa-user" aria-hidden="true"></i>
-            </span>
-          </a>
-          <span class="sr-only">({% trans "Active" %})</span>
-        </li>
-      </ul>
-    </div>
-  </nav>
-{% endblock %}
-
 {% block content %}
-
-<!--
-
-Problem Name           | # of attempts          | Final Score
------------------------|------------------------|-----------------
-Testing your knowledge | 2                      | 4/6
-What did you learn?    | 3                      | 10/11
-
--->
 
   <div class="row">
     <div class="col-xs-12 col-md-8">

--- a/analytics_dashboard/users/templates/users/profile.html
+++ b/analytics_dashboard/users/templates/users/profile.html
@@ -1,0 +1,45 @@
+{% extends "users/base.html" %}
+{% load i18n %}
+{% load staticfiles %}
+{% load dashboard_extras %}
+{% load firstof from future %}
+
+{% block view-name %}view-course-list{% endblock view-name %}
+
+{% block title %}{{ profile.name }} {{ block.super }}{% endblock title %}
+
+{% block header-text %}
+  <h3>
+    {% blocktrans with name=profile.name %}User Profile: {{name}}{% endblocktrans %}
+  </h3>
+{% endblock %}
+
+{% block content %}
+  <div class="row">
+    <div class="col-xs-12 col-md-8">
+      <table class="table user-profile-info">
+        <tr><td>{% trans "Name" %}</td><td> {{profile.name}}</td></tr>
+        <tr><td>{% trans "Username" %}</td><td> {{profile.username}}</td></tr>
+        <tr><td>{% trans "Email" %}</td><td> {{profile.email}}</td></tr>
+        <tr><td>{% trans "Last Login" %}</td><td> {{profile.last_login|date:"DATETIME_FORMAT"}}</td></tr>
+        <tr><td>{% trans "Date Joined" %}</td><td> {{profile.date_joined|date:"DATETIME_FORMAT"}}</td></tr>
+        <tr>
+          <td>{% trans "Staff Status" %}</td>
+          <td>{%if profile.is_staff%}{%trans "Yes"%}{%else%}{%trans "No"%}{%endif%}</td>
+        </tr>
+        <tr>
+          <td>{% trans "Gender" %}</td>
+          {% if profile.gender == constants.gender.UNKNOWN %}<td class="missing-data">{% trans "Unknown" %}</td>{%else%}<td>{{profile.gender}}</td>{%endif%}
+        </tr>
+        <tr>
+          <td>{% trans "Year of Birth" %}</td>
+          {% if not profile.year_of_birth %}<td class="missing-data">{% trans "Unknown" %}</td>{%else%}<td>{{profile.year_of_birth}}</td>{%endif%}
+        </tr>
+        <tr>
+          <td>{% trans "Level of Education" %}</td>
+          {% if profile.gender == constants.education_level.UNKNOWN %}<td class="missing-data">{% trans "Unknown" %}</td>{%else%}<td>{{profile.level_of_education}}</td>{%endif%}
+        </tr>
+      </table>
+    </div>
+  </div>
+{% endblock %}

--- a/analytics_dashboard/users/templates/users/profile.html
+++ b/analytics_dashboard/users/templates/users/profile.html
@@ -14,6 +14,33 @@
   </h3>
 {% endblock %}
 
+{% block lens_navigation %}
+  {#  This is a simplified version of lens-navigation.html. #}
+
+  {#  Translators: Application here refers to the web site/application being used (e.g. the dashboard). #}
+  <nav class="navbar navbar-default lens-nav" role="navigation" aria-label="{% trans "Application" %}">
+    <div class="container ">
+      <ul id="mode-selectors" class="nav navbar-nav navbar-right">
+        <li class="has-tooltip" data-toggle="tooltip" title="Click to switch to course mode">
+          <a href="{% url 'courses:home' course_id=course_id %}">
+            <span class="link-label">
+              <i class="ico fa fa-users" aria-hidden="true"></i>
+            </span>
+          </a>
+        </li>
+        <li class="active nav-section has-tooltip" data-toggle="tooltip" title="You're in user mode. Click to go back to the list of all students enrolled in this course.">
+          <a href="{% url 'courses:users:list' course_id=course_id %}">
+            <span class="link-label">
+              <i class="ico fa fa-user" aria-hidden="true"></i>
+            </span>
+          </a>
+          <span class="sr-only">({% trans "Active" %})</span>
+        </li>
+      </ul>
+    </div>
+  </nav>
+{% endblock %}
+
 {% block content %}
   <div class="row">
     <div class="col-xs-12 col-md-8">

--- a/analytics_dashboard/users/templates/users/profile.html
+++ b/analytics_dashboard/users/templates/users/profile.html
@@ -68,4 +68,20 @@
       </table>
     </div>
   </div>
+  <div class="row">
+    <h4>Courses</h4>
+    <table class="table user-profile-courses">
+      <tr><th>Name</th><th>Enrollment Date</th><th>Start Date</th><th>End Date</th></tr>
+      {% for enrollment in enrollments %}
+      <tr{% if enrollment.course_details.course_id == course_id %} class="active-course"{% endif %}>
+        <td><a href="{% url 'courses:home' course_id=enrollment.course_details.course_id %}">
+            {% firstof enrollment.course_details.name enrollment.course_details.course_id|format_course_key %}
+        </a></td>
+        <td>{{enrollment.created|date:"DATETIME_FORMAT"}}</td>
+        <td>{{enrollment.course_details.course_start|date:"DATETIME_FORMAT"}}</td>
+        <td>{{enrollment.course_details.course_end|date:"DATETIME_FORMAT"}}</td>
+      </tr>
+      {% endfor %}
+    </table>
+  </div>
 {% endblock %}

--- a/analytics_dashboard/users/templates/users/profile.html
+++ b/analytics_dashboard/users/templates/users/profile.html
@@ -1,36 +1,8 @@
-{% extends "users/base.html" %}
+{% extends "users/user.html" %}
 {% load i18n %}
-{% load staticfiles %}
 {% load dashboard_extras %}
 
 {% block view-name %}view-user-profile{% endblock view-name %}
-
-{% block lens_navigation %}
-  {#  This is a simplified version of lens-navigation.html. #}
-
-  {#  Translators: Application here refers to the web site/application being used (e.g. the dashboard). #}
-  <nav class="navbar navbar-default lens-nav" role="navigation" aria-label="{% trans "Application" %}">
-    <div class="container ">
-      <ul id="mode-selectors" class="nav navbar-nav navbar-right">
-        <li class="has-tooltip" data-toggle="tooltip" title="Click to switch to course mode">
-          <a href="{% url 'courses:home' course_id=course_id %}">
-            <span class="link-label">
-              <i class="ico fa fa-users" aria-hidden="true"></i>
-            </span>
-          </a>
-        </li>
-        <li class="active nav-section has-tooltip" data-toggle="tooltip" title="You're in user mode. Click to go back to the list of all students enrolled in this course.">
-          <a href="{% url 'courses:users:list' course_id=course_id %}">
-            <span class="link-label">
-              <i class="ico fa fa-user" aria-hidden="true"></i>
-            </span>
-          </a>
-          <span class="sr-only">({% trans "Active" %})</span>
-        </li>
-      </ul>
-    </div>
-  </nav>
-{% endblock %}
 
 {% block title %}{{ profile.name }} - {{ block.super }}{% endblock title %}
 

--- a/analytics_dashboard/users/templates/users/profile.html
+++ b/analytics_dashboard/users/templates/users/profile.html
@@ -2,17 +2,8 @@
 {% load i18n %}
 {% load staticfiles %}
 {% load dashboard_extras %}
-{% load firstof from future %}
 
-{% block view-name %}view-course-list{% endblock view-name %}
-
-{% block title %}{{ profile.name }} {{ block.super }}{% endblock title %}
-
-{% block header-text %}
-  <h3>
-    {% blocktrans with name=profile.name %}User Profile: {{name}}{% endblocktrans %}
-  </h3>
-{% endblock %}
+{% block view-name %}view-user-profile{% endblock view-name %}
 
 {% block lens_navigation %}
   {#  This is a simplified version of lens-navigation.html. #}
@@ -39,6 +30,14 @@
       </ul>
     </div>
   </nav>
+{% endblock %}
+
+{% block title %}{{ profile.name }} - {{ block.super }}{% endblock title %}
+
+{% block header-text %}
+  <h3>
+    {% blocktrans with name=profile.name %}User Profile: {{name}}{% endblocktrans %}
+  </h3>
 {% endblock %}
 
 {% block content %}

--- a/analytics_dashboard/users/templates/users/user.html
+++ b/analytics_dashboard/users/templates/users/user.html
@@ -1,0 +1,57 @@
+{% extends "users/base.html" %}
+{% load i18n %}
+{% load staticfiles %}
+
+{% block lens_navigation %}
+
+  {% if primary_nav_items %}
+    {#  Translators: Application here refers to the web site/application being used (e.g. the dashboard). #}
+    <nav class="navbar navbar-default lens-nav" role="navigation" aria-label="{% trans "Application" %}">
+      <div class="container ">
+        <ul class="nav navbar-nav">
+          <li class="dropdown">
+            <a href="#" class="dropdown-toggle navbar-link" data-toggle="dropdown" role="button" id="lensPrimaryMenu">
+              <span class="link-label">
+              <i class="ico fa {{ primary_nav_item.icon }}" aria-hidden="true"></i>
+              {{ primary_nav_item.label }}
+              {# Translators: This refers to the active tab/navigation item. #}
+              <span class="sr-only">({% trans "Active" %})</span>
+              <i class="ico ico-indicator fa fa-caret-down"></i></span>
+            </a>
+
+            <ul class="dropdown-menu" role="menu" aria-labelledby="lensPrimaryMenu">
+              {% for item in primary_nav_items %}
+                <li>
+                  <a href="{{ item.href }}">
+                    <span class="link-label">
+                      <i class="ico fa {{ item.icon }}" aria-hidden="true"></i> {{ item.label }}
+                    </span>
+                  </a>
+                </li>
+              {% endfor %}
+            </ul>
+          </li>
+          {% include "submenu_navigation.html" with nav_items=secondary_nav_items%}
+        </ul>
+        <ul id="mode-selectors" class="nav navbar-nav navbar-right">
+          <li class="has-tooltip" data-toggle="tooltip" title="Click to switch to course mode">
+            <a href="{% url 'courses:home' course_id=course_id %}">
+              <span class="link-label">
+                <i class="ico fa fa-users" aria-hidden="true"></i>
+              </span>
+            </a>
+          </li>
+          <li class="active nav-section has-tooltip" data-toggle="tooltip" title="You're in user mode. Click to go back to the list of all students enrolled in this course.">
+            <a href="{% url 'courses:users:list' course_id=course_id %}">
+              <span class="link-label">
+                <i class="ico fa fa-user" aria-hidden="true"></i>
+              </span>
+            </a>
+            <span class="sr-only">({% trans "Active" %})</span>
+          </li>
+        </ul>
+      </div>
+    </nav>
+  {% endif %}
+
+{% endblock lens_navigation %}

--- a/analytics_dashboard/users/urls.py
+++ b/analytics_dashboard/users/urls.py
@@ -1,0 +1,11 @@
+# pylint: disable=no-value-for-parameter
+
+from django.conf.urls import url, patterns
+
+from users import views
+
+urlpatterns = patterns(
+    '',
+    url(r'^$', views.UserListView.as_view(), name='list'),
+    url(r'^(?P<user_id>\d+)/$', views.UserProfileView.as_view(), name='profile'),
+)

--- a/analytics_dashboard/users/urls.py
+++ b/analytics_dashboard/users/urls.py
@@ -7,5 +7,5 @@ from users import views
 urlpatterns = patterns(
     '',
     url(r'^$', views.UserListView.as_view(), name='list'),
-    url(r'^(?P<user_id>\d+)/$', views.UserProfileView.as_view(), name='profile'),
+    url(r'^(?P<username>[^/]+)/$', views.UserProfileView.as_view(), name='profile'),
 )

--- a/analytics_dashboard/users/urls.py
+++ b/analytics_dashboard/users/urls.py
@@ -8,4 +8,5 @@ urlpatterns = patterns(
     '',
     url(r'^$', views.UserListView.as_view(), name='list'),
     url(r'^(?P<username>[^/]+)/$', views.UserProfileView.as_view(), name='profile'),
+    url(r'^(?P<username>[^/]+)/problems/$', views.UserProblemDataView.as_view(), name='problems')
 )

--- a/analytics_dashboard/users/views/__init__.py
+++ b/analytics_dashboard/users/views/__init__.py
@@ -1,0 +1,2 @@
+from .users import UserListView
+from .profile import UserProfileView

--- a/analytics_dashboard/users/views/__init__.py
+++ b/analytics_dashboard/users/views/__init__.py
@@ -1,2 +1,3 @@
 from .users import UserListView
 from .profile import UserProfileView
+from .problem_data import UserProblemDataView

--- a/analytics_dashboard/users/views/base.py
+++ b/analytics_dashboard/users/views/base.py
@@ -1,0 +1,25 @@
+from analyticsclient.client import Client
+from analyticsclient.exceptions import ClientError
+from braces.views import LoginRequiredMixin
+from django.conf import settings
+from django import shortcuts
+from django.views.generic import TemplateView
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class UsersView(LoginRequiredMixin, TemplateView):
+    client = None
+
+    def dispatch(self, request, *args, **kwargs):
+        self.client = Client(
+            base_url=settings.DATA_API_URL,
+            auth_token=settings.DATA_API_AUTH_TOKEN,
+            timeout=5
+        )
+        try:
+            return super(UsersView, self).dispatch(request, *args, **kwargs)
+        except ClientError as e:
+            logger.error('API ClientError: %s (%s)', e, e.message)
+            return shortcuts.render(request, "users/api-error.html")

--- a/analytics_dashboard/users/views/base.py
+++ b/analytics_dashboard/users/views/base.py
@@ -1,15 +1,16 @@
 from analyticsclient.client import Client
 from analyticsclient.exceptions import ClientError
-from courses.views import CourseNavBarMixin, CourseView
+from courses.views import CourseTemplateWithNavView
 from django.conf import settings
 from django import shortcuts
+from django.utils.translation import ugettext_lazy as _
 import logging
 
 logger = logging.getLogger(__name__)
 
 
-class UsersView(CourseNavBarMixin, CourseView):
-    client = None
+class UsersView(CourseTemplateWithNavView):
+    page_title = _('Users')
 
     def dispatch(self, request, *args, **kwargs):
         self.client = Client(

--- a/analytics_dashboard/users/views/base.py
+++ b/analytics_dashboard/users/views/base.py
@@ -1,15 +1,14 @@
 from analyticsclient.client import Client
 from analyticsclient.exceptions import ClientError
-from braces.views import LoginRequiredMixin
+from courses.views import CourseNavBarMixin, CourseView
 from django.conf import settings
 from django import shortcuts
-from django.views.generic import TemplateView
 import logging
 
 logger = logging.getLogger(__name__)
 
 
-class UsersView(LoginRequiredMixin, TemplateView):
+class UsersView(CourseNavBarMixin, CourseView):
     client = None
 
     def dispatch(self, request, *args, **kwargs):

--- a/analytics_dashboard/users/views/base.py
+++ b/analytics_dashboard/users/views/base.py
@@ -20,6 +20,6 @@ class UsersView(CourseTemplateWithNavView):
         )
         try:
             return super(UsersView, self).dispatch(request, *args, **kwargs)
-        except ClientError as e:
-            logger.error('API ClientError: %s (%s)', e, e.message)
+        except ClientError as err:
+            logger.error('API ClientError: %s (%s)', err, err.message)
             return shortcuts.render(request, "users/api-error.html")

--- a/analytics_dashboard/users/views/problem_data.py
+++ b/analytics_dashboard/users/views/problem_data.py
@@ -2,10 +2,15 @@ from django.conf import settings
 
 from common.clients import CourseStructureApiClient
 from .base import UsersView
+from .user import SingleUserNavbarMixin
 
 
-class UserProblemDataView(UsersView):
+class UserProblemDataView(UsersView, SingleUserNavbarMixin):
+    course_api_client = None
+
     template_name = 'users/problem_data.html'
+
+    active_primary_nav_item = 'problems'
 
     def dispatch(self, request, *args, **kwargs):
         access_token = settings.COURSE_API_KEY or request.user.access_token
@@ -24,10 +29,6 @@ class UserProblemDataView(UsersView):
         user_id = profile['id']
 
         weekly_problem_data = self.client.user_problem_weekly_data(self.course_id, user_id).weekly_problem_data()
-
-        # High-level steps for each entry in weekly_problem_data:
-        # - Calculate total number of attempts from weekly number of attempts
-        # - Set final score to final score of most recent week
 
         problem_data = {}
 

--- a/analytics_dashboard/users/views/problem_data.py
+++ b/analytics_dashboard/users/views/problem_data.py
@@ -1,0 +1,59 @@
+from django.conf import settings
+
+from common.clients import CourseStructureApiClient
+from .base import UsersView
+
+
+class UserProblemDataView(UsersView):
+    template_name = 'users/problem_data.html'
+
+    def dispatch(self, request, *args, **kwargs):
+        access_token = settings.COURSE_API_KEY or request.user.access_token
+        self.course_api_client = CourseStructureApiClient(settings.COURSE_API_URL, access_token)
+
+        return super(UserProblemDataView, self).dispatch(request, *args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        context = super(UserProblemDataView, self).get_context_data(**kwargs)
+
+        course_structure = self.course_api_client.course_structures(self.course_id).get()
+        blocks = course_structure.get('blocks', {})
+
+        username = kwargs['username']
+        profile = self.client.users(username).profile()
+        user_id = profile['id']
+
+        weekly_problem_data = self.client.user_problem_weekly_data(self.course_id, user_id).weekly_problem_data()
+
+        # High-level steps for each entry in weekly_problem_data:
+        # - Calculate total number of attempts from weekly number of attempts
+        # - Set final score to final score of most recent week
+
+        problem_data = {}
+
+        for entry in weekly_problem_data:
+            week_ending = entry['week_ending']
+            problem_id = entry['problem_id']
+            num_attempts = entry['num_attempts']
+            final_score = '{}/{}'.format(entry['most_recent_score'], entry['max_score'])
+            problem_name = blocks[problem_id].get('display_name', problem_id)
+
+            if problem_id not in problem_data:
+                problem_data[problem_id] = {
+                    'week_ending': week_ending,
+                    'name': problem_name,
+                    'num_attempts': num_attempts,
+                    'final_score': final_score,
+                }
+            else:
+                problem = problem_data[problem_id]
+                problem['num_attempts'] += num_attempts
+                if week_ending > problem['week_ending']:
+                    problem['week_ending'] = week_ending
+                    problem['final_score'] = final_score
+                problem_data[problem_id] = problem
+
+        context['username'] = username
+        context['problem_data'] = problem_data.values()
+
+        return context

--- a/analytics_dashboard/users/views/problem_data.py
+++ b/analytics_dashboard/users/views/problem_data.py
@@ -1,8 +1,22 @@
+"""
+Module for views that provide info about user's interactions with problems.
+"""
+
 from .base import UsersView
 from .user import SingleUserNavbarMixin
 
 
 class UserProblemDataView(UsersView, SingleUserNavbarMixin):
+    """
+    View for page that displays a summary of a specific user's interactions with individual problems of a course.
+
+    The summary consists of a list of problems that the user has
+    attempted and specifies the total number of attempts and the final
+    score for each problem.
+
+    For each problem, the final score combines the most recent score
+    obtained with the maximum possible score (e.g., 7/10).
+    """
     course_api_client = None
 
     template_name = 'users/problem_data.html'
@@ -10,19 +24,28 @@ class UserProblemDataView(UsersView, SingleUserNavbarMixin):
     active_primary_nav_item = 'problems'
 
     def get_context_data(self, **kwargs):
+        """
+        Add summary of problem data for requested course and user to template context.
+
+        If enabled, make use of course API to obtain descriptive names for problems to list.
+        """
         context = super(UserProblemDataView, self).get_context_data(**kwargs)
 
+        # If course API is enabled, obtain info about blocks
         if self.course_api_enabled:
             blocks = self.course_structure.get('blocks', {})
         else:
             blocks = {}
 
+        # Prepare for retrieving weekly problem data by looking up user ID
         username = kwargs['username']
         profile = self.client.users(username).profile()
         user_id = profile['id']
 
+        # Retrieve weekly problem data
         weekly_problem_data = self.client.user_problem_weekly_data(self.course_id, user_id).weekly_problem_data()
 
+        # Summarize weekly problem data
         problem_data = {}
 
         for entry in weekly_problem_data:
@@ -30,9 +53,12 @@ class UserProblemDataView(UsersView, SingleUserNavbarMixin):
             problem_id = entry['problem_id']
             num_attempts = entry['num_attempts']
             final_score = '{}/{}'.format(entry['most_recent_score'], entry['max_score'])
+            # We'd like to display a descriptive name for the problem belonging to this entry.
+            # If that's not available, fall back on problem ID:
             problem_name = blocks.get(problem_id, {}).get('display_name', problem_id)
 
             if problem_id not in problem_data:
+                # Summary doesn't have an entry for this problem, so insert relevant data as is
                 problem_data[problem_id] = {
                     'week_ending': week_ending,
                     'name': problem_name,
@@ -40,8 +66,12 @@ class UserProblemDataView(UsersView, SingleUserNavbarMixin):
                     'final_score': final_score,
                 }
             else:
+                # Summary already has an entry for this problem, so:
                 problem = problem_data[problem_id]
+                # - Increment total number of attempts
                 problem['num_attempts'] += num_attempts
+                # - Update final score
+                #   (this is only necessary if the problem data we are looking at belongs to a more recent week)
                 if week_ending > problem['week_ending']:
                     problem['week_ending'] = week_ending
                     problem['final_score'] = final_score

--- a/analytics_dashboard/users/views/profile.py
+++ b/analytics_dashboard/users/views/profile.py
@@ -11,14 +11,12 @@ class UserProfileView(UsersView):
     def get_context_data(self, **kwargs):
         context = super(UserProfileView, self).get_context_data(**kwargs)
 
-        # TODO: Check permissions of self.request.user
-
         try:
-            user_id = int(kwargs['user_id'])
+            username = kwargs['username']
         except ValueError:
             raise Http404
 
-        response = self.client.users(user_id).profile()
+        response = self.client.users(username).profile()
         for date_field in ('last_login', 'date_joined'):
             if response[date_field]:
                 response[date_field] = dateutil.parser.parse(response[date_field])

--- a/analytics_dashboard/users/views/profile.py
+++ b/analytics_dashboard/users/views/profile.py
@@ -1,0 +1,28 @@
+import analyticsclient.constants
+import dateutil.parser
+from django.http import Http404
+
+from .base import UsersView
+
+
+class UserProfileView(UsersView):
+    template_name = 'users/profile.html'
+
+    def get_context_data(self, **kwargs):
+        context = super(UserProfileView, self).get_context_data(**kwargs)
+
+        # TODO: Check permissions of self.request.user
+
+        try:
+            user_id = int(kwargs['user_id'])
+        except ValueError:
+            raise Http404
+
+        response = self.client.users(user_id).profile()
+        for date_field in ('last_login', 'date_joined'):
+            if response[date_field]:
+                response[date_field] = dateutil.parser.parse(response[date_field])
+        context['profile'] = response
+        context['constants'] = analyticsclient.constants
+
+        return context

--- a/analytics_dashboard/users/views/profile.py
+++ b/analytics_dashboard/users/views/profile.py
@@ -1,8 +1,18 @@
 import analyticsclient.constants
 import dateutil.parser
+from django.conf import settings
 from django.http import Http404
+from waffle import switch_is_active
 
+from common.clients import EnrollmentApiClient
 from .base import UsersView
+
+
+def _parse_dates(dictionary, date_fields):
+    """Parse textual dates in dictionary values to datetime objects."""
+    for date_field in date_fields:
+        if dictionary[date_field]:
+            dictionary[date_field] = dateutil.parser.parse(dictionary[date_field])
 
 
 class UserProfileView(UsersView):
@@ -16,11 +26,20 @@ class UserProfileView(UsersView):
         except ValueError:
             raise Http404
 
-        response = self.client.users(username).profile()
-        for date_field in ('last_login', 'date_joined'):
-            if response[date_field]:
-                response[date_field] = dateutil.parser.parse(response[date_field])
-        context['profile'] = response
+        profile = self.client.users(username).profile()
+        _parse_dates(profile, ['last_login', 'date_joined'])
+
+        enrollment_api = EnrollmentApiClient(settings.ENROLLMENT_API_URL, self.request.user.access_token)
+        enrollments = enrollment_api.enrollment.get(user=profile['username'])
+        for enrollment in enrollments:
+            course_details = enrollment['course_details']
+            _parse_dates(enrollment, ['created'])
+            _parse_dates(course_details, ['course_start', 'course_end'])
+            if switch_is_active('display_names_for_course_index'):
+                course_details['name'] = self.get_course_info(course_details['course_id'])['name']
+
+        context['profile'] = profile
+        context['enrollments'] = enrollments
         context['constants'] = analyticsclient.constants
 
         return context

--- a/analytics_dashboard/users/views/profile.py
+++ b/analytics_dashboard/users/views/profile.py
@@ -6,6 +6,7 @@ from waffle import switch_is_active
 
 from common.clients import EnrollmentApiClient
 from .base import UsersView
+from .user import SingleUserNavbarMixin
 
 
 def _parse_dates(dictionary, date_fields):
@@ -15,8 +16,10 @@ def _parse_dates(dictionary, date_fields):
             dictionary[date_field] = dateutil.parser.parse(dictionary[date_field])
 
 
-class UserProfileView(UsersView):
+class UserProfileView(UsersView, SingleUserNavbarMixin):
     template_name = 'users/profile.html'
+
+    active_primary_nav_item = 'profile'
 
     def get_context_data(self, **kwargs):
         context = super(UserProfileView, self).get_context_data(**kwargs)

--- a/analytics_dashboard/users/views/user.py
+++ b/analytics_dashboard/users/views/user.py
@@ -1,0 +1,42 @@
+from django.core.urlresolvers import reverse
+from django.utils.translation import ugettext_lazy as _
+
+from courses.views import CourseNavBarMixin
+
+
+class SingleUserNavbarMixin(CourseNavBarMixin):
+    username = None
+
+    def get_primary_nav_items(self):
+        """
+        Return the primary nav items.
+        """
+
+        items = [
+            {'name': 'profile', 'label': _('User Profile'), 'view': 'courses:users:profile'},
+            {'name': 'problems', 'label': _('Problem Data'), 'view': 'courses:users:problems'},
+        ]
+
+        # Clean each item
+        map(self.clean_item, items)
+
+        return items
+
+    def clean_item(self, item):
+        """
+        Remove extraneous keys from item and set the href value.
+        """
+        # Prevent page reload if user clicks on the active navbar item, otherwise navigate to the new page.
+        if item.get('active', False):
+            href = '#'
+        else:
+            href = reverse(item['view'], kwargs={'course_id': self.course_id, 'username': self.username})
+
+        item['href'] = href
+
+        # Delete entries that are no longer needed
+        item.pop('view', None)
+
+    def dispatch(self, request, *args, **kwargs):
+        self.username = kwargs.get('username')
+        return super(SingleUserNavbarMixin, self).dispatch(request, *args, **kwargs)

--- a/analytics_dashboard/users/views/users.py
+++ b/analytics_dashboard/users/views/users.py
@@ -1,0 +1,31 @@
+from __future__ import division
+from django.http import Http404
+import math
+
+from .base import UsersView
+
+
+class UserListView(UsersView):
+    template_name = 'users/list.html'
+
+    def get_context_data(self, **kwargs):
+        context = super(UserListView, self).get_context_data(**kwargs)
+
+        # TODO: Check permissions of self.request.user
+
+        users_per_page = 100
+        try:
+            page = int(self.request.GET.get('page', 1))
+            if page < 1:
+                raise ValueError
+        except ValueError:
+            raise Http404
+
+        response = self.client.user_list().list_users(page=page, limit=users_per_page)
+        users_count = response['count']
+        context['count'] = users_count
+        context['page'] = page
+        context['total_pages'] = int(math.ceil(users_count / users_per_page))
+        context['users'] = response['results']
+
+        return context

--- a/analytics_dashboard/users/views/users.py
+++ b/analytics_dashboard/users/views/users.py
@@ -11,8 +11,6 @@ class UserListView(UsersView):
     def get_context_data(self, **kwargs):
         context = super(UserListView, self).get_context_data(**kwargs)
 
-        # TODO: Check permissions of self.request.user
-
         users_per_page = 100
         try:
             page = int(self.request.GET.get('page', 1))
@@ -21,7 +19,7 @@ class UserListView(UsersView):
         except ValueError:
             raise Http404
 
-        response = self.client.user_list().list_users(page=page, limit=users_per_page)
+        response = self.client.courses(self.course_id).list_users(page=page, limit=users_per_page)
         users_count = response['count']
         context['count'] = users_count
         context['page'] = page

--- a/common/clients.py
+++ b/common/clients.py
@@ -1,3 +1,8 @@
+"""
+Wrappers for REST APIs.
+
+The classes in this file subclass slumber.API (http://slumber.readthedocs.org/en/latest/).
+"""
 import logging
 
 import slumber
@@ -13,8 +18,7 @@ class CourseStructureApiClient(slumber.API):
     """
     Course Structure API Client
 
-    This class is a sub-class slumber.API (http://slumber.readthedocs.org/en/latest/). Details
-    about the API itself can be found at https://openedx.atlassian.net/wiki/display/AN/Course+Structure+API.
+    Details can be found at https://openedx.atlassian.net/wiki/display/AN/Course+Structure+API.
     """
     DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
@@ -45,3 +49,13 @@ class CourseStructureApiClient(slumber.API):
                 break
 
         return courses
+
+
+class EnrollmentApiClient(slumber.API):
+    """
+    Client wrapper for the enrollment API.
+
+    Details can be found at https://openedx.atlassian.net/wiki/display/ECOM/Enrollment+API+Design.
+    """
+    def __init__(self, url, access_token):
+        super(EnrollmentApiClient, self).__init__(url, auth=BearerAuth(access_token), append_slash=False)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,6 +9,7 @@ django-libsass==0.2			# BSD
 django-model-utils==1.5.0 	# BSD
 django-soapbox==1.1         # BSD
 django-waffle==0.10			# BSD
+python-dateutil==2.4.2      # BSD
 
 # other versions cause a segment fault when running compression
 libsass==0.5.1              # MIT


### PR DESCRIPTION
This PR adds a new page to the Insights dashboard that shows, for a specific user and course, the list of problems that the user has attempted, along with the total number of attempts and the final (i.e., most recent) score.

The new page can be accessed by choosing the "Problem Data" entry from the dropdown menu that is available in the navigation bar while viewing a user's profile. (The dropdown menu also provides a "User Profile" entry that allows to switch back to a user's profile after viewing problem information on the new page.)

While viewing problem data the dashboard is in "user mode": The course mode selector can be used to enable course mode and jump back to the home page of the parent course; the user mode selector points to the list of all users currently enrolled in the parent course. (See https://github.com/edx/edx-analytics-dashboard/pull/338 for more information about mode selectors, user mode, and course mode.)
### Screenshots

New page listing problems user has attempted:

![user-problem-history](https://cloud.githubusercontent.com/assets/961441/9408105/d57cb172-480f-11e5-900d-78298f748aa3.png)

The dashboard uses the Course Structure API to obtain display names for problems when generating this page. If the `course_api_enabled` switch is off, it falls back on problem IDs:

![user-problem-history-course-api-disabled](https://cloud.githubusercontent.com/assets/961441/9519915/4600a66c-4cc3-11e5-9b6c-02d921068e33.png)

Navigation lens on new page:

![navigation-lens-on-problem-history-page](https://cloud.githubusercontent.com/assets/961441/9408185/833ddd0e-4810-11e5-840d-9ce448f98b75.png)

Navigation lens on profile page:

![navigation-lens-on-profile-page](https://cloud.githubusercontent.com/assets/961441/9408187/8e42ff36-4810-11e5-8e11-60bfc641146f.png)
### Dependencies
- https://github.com/edx/edx-analytics-pipeline/pull/147
- https://github.com/edx/edx-analytics-data-api/pull/81
- https://github.com/edx/edx-analytics-data-api-client/pull/22
- https://github.com/edx/edx-analytics-dashboard/pull/338

Note that https://github.com/edx/edx-analytics-dashboard/pull/338 has data-api and data-api-client dependencies of its own. For the purpose of testing this PR you will therefore need to work with branches that contain relevant changes for both https://github.com/edx/edx-analytics-dashboard/pull/338 and this PR. You won't need to create these branches yourself; they have already been set up for you (cf. test instructions below).
### Testing
1. Test https://github.com/edx/edx-analytics-pipeline/pull/147 and confirm it's working.
2. Prepare the **data-api** repository by switching to [this branch](https://github.com/open-craft/edx-analytics-data-api/tree/user-problem-data) (`user-problem-data`).
3. Prepare the **data-api-client** repository by switching to [this branch](https://github.com/open-craft/edx-analytics-data-api-client/tree/user-problem-data) (`user-problem-data`). 
4. Install the updated data API client into the dashboard's virtualenv. Use these commands (as `analytics` user):
   
   ```
   cd ~/apps/data-api-client/
   deactivate
   source ~/venvs/dashboard/bin/activate
   pip install -e .
   ```
5. Start the data API server (as `analytics` user):
   
   ```
   cd ~/apps/data-api/ && ./manage.py runserver 0.0.0.0:9001
   ```
6. Start the dashboard (as `analytics` user):
   
   ```
   cd ~/apps/dashboard/ && ./manage.py runserver 0.0.0.0:9999
   ```
7. Access the Insights page for the demo course at http://192.168.33.11:9999/courses/edX/DemoX/Demo_Course/.
8. Follow these steps to try out the new functionality:
   - Click the user mode selector to switch to user mode and access the list of enrolled students.
   - Click the username of a student to access their profile.
   - Expand the dropdown menu in the navigation bar and click "Problem Data" to access the new page.
### Partner Information

Not an edX partner - 3rd party-hosted open edX instance
