### PR TITLE
Fixed js lint error by adding 'use strict' in spec-runner.js.

### DIFF
--- a/analytics_dashboard/static/js/test/spec-runner.js
+++ b/analytics_dashboard/static/js/test/spec-runner.js
@@ -2,6 +2,7 @@
  * This is where your tests go.  It should happen automatically when you
  * add files to the karma configuration.
  */
+'use strict';
 
 var isBrowser = window.__karma__ === undefined,
     specs = [],
@@ -28,7 +29,6 @@ if (isBrowser) {
     // the text so tests can be run if modules reference gettext
     if (!window.gettext) {
         window.gettext = function(text) {
-            'use strict';
             return text;
         };
     }
@@ -56,7 +56,6 @@ if (isBrowser) {
     // a hack
     // http://stackoverflow.com/questions/19240302/does-jasmine-2-0-really-not-work-with-require-js
     require(['boot'], function () {
-        'use strict';
         require(specs,
             function () {
                 window.onload();


### PR DESCRIPTION
`spec-runner.js` is now being linted--seems like it wasn't earlier oddly.  This should fix the errors on https://github.com/edx/edx-analytics-dashboard/pull/347 and https://github.com/edx/edx-analytics-dashboard/pull/345.

@jab5569 @brianhw @mulby 
