### PR TITLE
Add devstack settings file

### DIFF
--- a/acceptance_tests/__init__.py
+++ b/acceptance_tests/__init__.py
@@ -11,7 +11,7 @@ def str2bool(s):
 # Dashboard settings
 DASHBOARD_SERVER_URL = os.environ.get('DASHBOARD_SERVER_URL', 'http://localhost:9000')
 DASHBOARD_FEEDBACK_EMAIL = os.environ.get('DASHBOARD_FEEDBACK_EMAIL', 'override.this.email@example.com')
-PLATFORM_NAME = os.environ.get('PLATFORM_NAME', 'edX')
+PLATFORM_NAME = os.environ.get('PLATFORM_NAME', 'Open edX')
 APPLICATION_NAME = os.environ.get('APPLICATION_NAME', 'Insights')
 SUPPORT_URL = os.environ.get('SUPPORT_URL', 'http://example.com/')
 OPEN_SOURCE_URL = os.environ.get('OPEN_SOURCE_URL', 'http://example.com/')

--- a/analytics_dashboard/settings/dev.py
+++ b/analytics_dashboard/settings/dev.py
@@ -1,0 +1,90 @@
+"""Common developpment settings"""
+import os
+
+from analytics_dashboard.settings.base import *
+from analytics_dashboard.settings.logger import get_logger_config
+
+
+########## DEBUG CONFIGURATION
+# See: https://docs.djangoproject.com/en/dev/ref/settings/#debug
+DEBUG = True
+
+# See: https://docs.djangoproject.com/en/dev/ref/settings/#template-debug
+TEMPLATE_DEBUG = DEBUG
+########## END DEBUG CONFIGURATION
+
+
+########## EMAIL CONFIGURATION
+# See: https://docs.djangoproject.com/en/dev/ref/settings/#email-backend
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+########## END EMAIL CONFIGURATION
+
+########## CACHE CONFIGURATION
+# See: https://docs.djangoproject.com/en/dev/ref/settings/#caches
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+    }
+}
+########## END CACHE CONFIGURATION
+
+
+########## TOOLBAR CONFIGURATION
+# See: http://django-debug-toolbar.readthedocs.org/en/latest/installation.html#explicit-setup
+
+if os.environ.get('ENABLE_DJANGO_TOOLBAR', '').lower() in ('true', 't', '1'):
+    INSTALLED_APPS += (
+        'debug_toolbar',
+    )
+
+    MIDDLEWARE_CLASSES += (
+        'debug_toolbar.middleware.DebugToolbarMiddleware',
+    )
+
+    DEBUG_TOOLBAR_PATCH_SETTINGS = False
+
+# http://django-debug-toolbar.readthedocs.org/en/latest/installation.html
+INTERNAL_IPS = ('127.0.0.1',)
+########## END TOOLBAR CONFIGURATION
+
+INSTALLED_APPS += (
+    'django_nose',
+)
+TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
+
+LMS_COURSE_SHORTCUT_BASE_URL = 'https://example.com/courses'
+
+########## BRANDING
+PLATFORM_NAME = 'Open edX'
+APPLICATION_NAME = 'Insights'
+FULL_APPLICATION_NAME = '{0} {1}'.format(PLATFORM_NAME, APPLICATION_NAME)
+########## END BRANDING
+
+
+########## AUTHENTICATION/AUTHORIZATION
+# Set these to the correct values for your OAuth2/OpenID Connect provider
+SOCIAL_AUTH_EDX_OIDC_KEY = 'replace-me'
+SOCIAL_AUTH_EDX_OIDC_SECRET = 'replace-me'
+SOCIAL_AUTH_EDX_OIDC_URL_ROOT = 'http://127.0.0.1:8000/oauth2'
+
+# This value should be the same as SOCIAL_AUTH_EDX_OIDC_SECRET
+SOCIAL_AUTH_EDX_OIDC_ID_TOKEN_DECRYPTION_KEY = SOCIAL_AUTH_EDX_OIDC_SECRET
+
+ENABLE_AUTO_AUTH = True
+
+# Uncomment the line below to avoid having to worry about course permissions
+ENABLE_COURSE_PERMISSIONS = False
+########## END AUTHENTICATION/AUTHORIZATION
+
+########## FEEDBACK AND SUPPORT
+HELP_URL = '#'
+########## END FEEDBACK
+
+########## SEGMENT.IO
+# 'None' disables tracking.  This will be turned on for test and production.
+SEGMENT_IO_KEY = os.environ.get('SEGMENT_WRITE_KEY')
+########## END SEGMENT.IO
+
+COURSE_API_URL = 'http://127.0.0.1:8000/api/course_structure/v0/'
+
+LOGGING = get_logger_config(debug=DEBUG, dev_env=True, local_loglevel='DEBUG')

--- a/analytics_dashboard/settings/devstack.py
+++ b/analytics_dashboard/settings/devstack.py
@@ -1,0 +1,7 @@
+"""django settings for development on devstack"""
+from analytics_dashboard.settings.dev import *
+from analytics_dashboard.settings.yaml_config import *
+
+
+DATA_API_URL = os.getenv('DATA_API_URL', DATA_API_URL)
+DATA_API_AUTH_TOKEN = os.getenv('DATA_API_AUTH_TOKEN', DATA_API_AUTH_TOKEN)

--- a/analytics_dashboard/settings/local.py
+++ b/analytics_dashboard/settings/local.py
@@ -5,24 +5,8 @@ from __future__ import absolute_import
 import os
 from os.path import join, normpath
 
-from analytics_dashboard.settings.base import *
+from analytics_dashboard.settings.dev import *
 from analytics_dashboard.settings.logger import get_logger_config
-
-
-
-########## DEBUG CONFIGURATION
-# See: https://docs.djangoproject.com/en/dev/ref/settings/#debug
-DEBUG = True
-
-# See: https://docs.djangoproject.com/en/dev/ref/settings/#template-debug
-TEMPLATE_DEBUG = DEBUG
-########## END DEBUG CONFIGURATION
-
-
-########## EMAIL CONFIGURATION
-# See: https://docs.djangoproject.com/en/dev/ref/settings/#email-backend
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
-########## END EMAIL CONFIGURATION
 
 
 ########## DATABASE CONFIGURATION
@@ -38,74 +22,3 @@ DATABASES = {
     }
 }
 ########## END DATABASE CONFIGURATION
-
-
-########## CACHE CONFIGURATION
-# See: https://docs.djangoproject.com/en/dev/ref/settings/#caches
-CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-    }
-}
-########## END CACHE CONFIGURATION
-
-
-########## TOOLBAR CONFIGURATION
-# See: http://django-debug-toolbar.readthedocs.org/en/latest/installation.html#explicit-setup
-
-if os.environ.get('ENABLE_DJANGO_TOOLBAR', False):
-    INSTALLED_APPS += (
-        'debug_toolbar',
-    )
-
-    MIDDLEWARE_CLASSES += (
-        'debug_toolbar.middleware.DebugToolbarMiddleware',
-    )
-
-    DEBUG_TOOLBAR_PATCH_SETTINGS = False
-
-# http://django-debug-toolbar.readthedocs.org/en/latest/installation.html
-INTERNAL_IPS = ('127.0.0.1',)
-########## END TOOLBAR CONFIGURATION
-
-INSTALLED_APPS += (
-    'django_nose',
-)
-TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
-
-LMS_COURSE_SHORTCUT_BASE_URL = 'https://courses.edx.org/courses'
-
-########## BRANDING
-PLATFORM_NAME = 'edX'
-APPLICATION_NAME = 'Insights'
-FULL_APPLICATION_NAME = '{0} {1}'.format(PLATFORM_NAME, APPLICATION_NAME)
-########## END BRANDING
-
-
-########## AUTHENTICATION/AUTHORIZATION
-# Set these to the correct values for your OAuth2/OpenID Connect provider
-SOCIAL_AUTH_EDX_OIDC_KEY = 'replace-me'
-SOCIAL_AUTH_EDX_OIDC_SECRET = 'replace-me'
-SOCIAL_AUTH_EDX_OIDC_URL_ROOT = 'http://127.0.0.1:8000/oauth2'
-
-# This value should be the same as SOCIAL_AUTH_EDX_OIDC_SECRET
-SOCIAL_AUTH_EDX_OIDC_ID_TOKEN_DECRYPTION_KEY = SOCIAL_AUTH_EDX_OIDC_SECRET
-
-ENABLE_AUTO_AUTH = True
-
-# Uncomment the line below to avoid having to worry about course permissions
-ENABLE_COURSE_PERMISSIONS = False
-########## END AUTHENTICATION/AUTHORIZATION
-
-########## FEEDBACK AND SUPPORT
-HELP_URL = '#'
-########## END FEEDBACK
-
-########## SEGMENT.IO
-# 'None' disables tracking.  This will be turned on for test and production.
-SEGMENT_IO_KEY = os.environ.get('SEGMENT_WRITE_KEY')
-########## END SEGMENT.IO
-
-COURSE_API_URL = 'http://127.0.0.1:8000/api/course_structure/v0/'
-
-LOGGING = get_logger_config(debug=DEBUG, dev_env=True, local_loglevel='DEBUG')

--- a/analytics_dashboard/settings/production.py
+++ b/analytics_dashboard/settings/production.py
@@ -1,14 +1,7 @@
 """Production settings and globals."""
 
-from os import environ
-
-# Normally you should not import ANYTHING from Django directly
-# into your settings, but ImproperlyConfigured is an exception.
-from django.core.exceptions import ImproperlyConfigured
-
-import yaml
-
 from analytics_dashboard.settings.base import *
+from analytics_dashboard.settings.yaml_config import *
 from analytics_dashboard.settings.logger import get_logger_config
 
 # Enable offline compression of CSS/JS
@@ -26,25 +19,10 @@ COMPRESS_CSS_FILTERS += [
 LOGGING = get_logger_config()
 
 
-def get_env_setting(setting):
-    """ Get the environment setting or return exception """
-    try:
-        return environ[setting]
-    except KeyError:
-        error_msg = "Set the %s env variable" % setting
-        raise ImproperlyConfigured(error_msg)
-
 # ######### HOST CONFIGURATION
 # See: https://docs.djangoproject.com/en/1.5/releases/1.5/#allowed-hosts-required-in-production
 ALLOWED_HOSTS = ['*']
 ########## END HOST CONFIGURATION
-
-CONFIG_FILE = get_env_setting('ANALYTICS_DASHBOARD_CFG')
-
-with open(CONFIG_FILE) as f:
-    config_from_yaml = yaml.load(f)
-
-vars().update(config_from_yaml)
 
 DB_OVERRIDES = dict(
     PASSWORD=environ.get('DB_MIGRATION_PASS', DATABASES['default']['PASSWORD']),

--- a/analytics_dashboard/settings/yaml_config.py
+++ b/analytics_dashboard/settings/yaml_config.py
@@ -1,0 +1,24 @@
+from os import environ
+
+import yaml
+
+# Normally you should not import ANYTHING from Django directly
+# into your settings, but ImproperlyConfigured is an exception.
+from django.core.exceptions import ImproperlyConfigured
+
+
+def get_env_setting(setting):
+    """ Get the environment setting or return exception """
+    try:
+        return environ[setting]
+    except KeyError:
+        error_msg = "Set the %s env variable" % setting
+        raise ImproperlyConfigured(error_msg)
+
+
+CONFIG_FILE = get_env_setting('ANALYTICS_DASHBOARD_CFG')
+
+with open(CONFIG_FILE) as f:
+    config_from_yaml = yaml.load(f)
+
+vars().update(config_from_yaml)


### PR DESCRIPTION
@mulby @dsjen I added a basic devstacks settings file.

I'd prefer if it didn't have to import selectively from `local.py`, but I didn't want to import the `DATABASES` setting, for example.

Furthermore, I tried to factor out common settings between `local.py` and `devstack.py` into a `dev.py` file, but this caused numerous issues for me where settings were not getting applied as expected. I think it had to do with the order in which these module-local variables are attached to the `django.conf.settings` object when imported.
