### PR TITLE
Added CCX library and tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The following switches are available:
 |-----------------------------------|----------------------------------------------------------|
 | show_engagement_forum_activity    | Show the forum activity on the course engagement page    |
 | enable_course_api                 | Retrieve course details from the course API              |
+| enable_ccx_courses                | Display CCX Courses in the course listing page.          |
 | enable_engagement_videos_pages    | Enable engagement video pages.                           |
 | display_names_for_course_index    | Display course names on course index page.               |
 | display_course_name_in_nav        | Display course name in navigation bar.                   |

--- a/analytics_dashboard/core/tests/test_templatetags.py
+++ b/analytics_dashboard/core/tests/test_templatetags.py
@@ -44,7 +44,8 @@ class DashboardExtraTests(TestCase):
 
     def test_format_course_key(self):
         values = [('edX/DemoX/Demo_Course', 'edX/DemoX/Demo_Course'),
-                  ('course-v1:edX+DemoX+Demo_2014', 'edX/DemoX/Demo_2014')]
+                  ('course-v1:edX+DemoX+Demo_2014', 'edX/DemoX/Demo_2014'),
+                  ('ccx-v1:edx+1.005x-CCX+rerun+ccx@15', 'edx/1.005x-CCX/rerun')]
         for course_id, expected in values:
             # Test with CourseKey
             course_key = CourseKey.from_string(course_id)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -27,3 +27,5 @@ git+https://github.com/edx/django-lang-pref-middleware.git@0.1.0#egg=django-lang
 git+https://github.com/edx/edx-analytics-data-api-client.git@0.6.1#egg=edx-analytics-data-api-client==0.6.1  # edX
 git+https://github.com/edx/i18n-tools.git@0d7847f9dfa2281640527b4dc51f5854f950f9b7#egg=i18n_tools
 git+https://github.com/edx/opaque-keys.git@d45d0bd8d64c69531be69178b9505b5d38806ce0#egg=opaque-keys
+# custom opaque-key implementations for ccx
+git+https://github.com/jazkarta/ccx-keys.git@e6b03704b1bb97c1d2f31301ecb4e3a687c536ea#egg=ccx-keys


### PR DESCRIPTION
Adding the ccx-keys package enables Insights to parse CCX course keys.

@dan-f @mulby @brianhw @ormsbee @nasthagiri 

FYI: @shnayder @mikigoyal 
