### PR TITLE
Fix i18n error

### DIFF
--- a/analytics_dashboard/courses/templates/courses/index.html
+++ b/analytics_dashboard/courses/templates/courses/index.html
@@ -15,7 +15,7 @@
 {% endblock %}
 
 {% block intro-text %}
-  {% blocktrans %}Here are the courses you currently have access to in Insights:{% endblocktrans %}
+  {% blocktrans %}Here are the courses you currently have access to in {{ application_name }}:{% endblocktrans %}
 {% endblock intro-text %}
 
 {% block content %}

--- a/analytics_dashboard/settings/production.py
+++ b/analytics_dashboard/settings/production.py
@@ -37,7 +37,7 @@ for override, value in DB_OVERRIDES.iteritems():
     DATABASES['default'][override] = value
 
 # Re-declare the full application name in case the components have been overridden.
-FULL_APPLICATION_NAME = '{0} {1}'.format(PLATFORM_NAME, APPLICATION_NAME)
+FULL_APPLICATION_NAME = u'{0} {1}'.format(PLATFORM_NAME, APPLICATION_NAME)
 
 # Depends on DOCUMENTATION_LOAD_ERROR_URL, so evaluate at the end
 DOCUMENTATION_LOAD_ERROR_MESSAGE = 'This data may not be available for your course. ' \


### PR DESCRIPTION
1. When `PLATFORM_NAME` or `APPLICATION_NAME` contains non-ascii characters, production.py casuse an UnicodeDecode exception.
2. Use `{{ application_name }}` rather than hard-code `Insights` in index.html.
