### PR TITLE
Don't translate the name of Studio

### DIFF
--- a/analytics_dashboard/courses/views/__init__.py
+++ b/analytics_dashboard/courses/views/__init__.py
@@ -577,8 +577,7 @@ class CourseHome(CourseTemplateWithNavView):
             })
         if settings.CMS_COURSE_SHORTCUT_BASE_URL:
             external_tools.append({
-                # Translators: This is the name of the edX Course Editor (the CMS)
-                'title': _('Studio'),
+                'title': 'Studio',  # As a brand name, "Studio" is not translated.
                 'url': "{}/{}".format(settings.CMS_COURSE_SHORTCUT_BASE_URL, self.course_id),
                 'icon': 'fa-sliders',
             })


### PR DESCRIPTION
Quick follow-up to #334. The brand name "Studio" should not be translated.

See [previous discussion 1](https://github.com/edx/edx-analytics-dashboard/pull/334#discussion_r42902024) and [previous discussion 2](https://github.com/edx/edx-analytics-dashboard/pull/334#discussion_r43816249)

CC @sarina @dsjen 
