### PR TITLE
Fix inconsistant Chinese language codes of cldr and moment

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,3 +3,4 @@ Dennis Jen <djen@edx.org>
 Carlos Andrés Rocha <rocha@edx.org>
 Braden MacDonald <braden@opencraft.com>
 Daniel Friedman <dfriedman@edx.org>
+Yihua Lou <supermouselyh@hotmail.com>

--- a/analytics_dashboard/static/js/test/specs/globalization-spec.js
+++ b/analytics_dashboard/static/js/test/specs/globalization-spec.js
@@ -10,8 +10,18 @@ define(['utils/globalization'], function () {
             expect(fixLanguageCode(true)).toEqual('en');
         });
 
-        it('should return zh if the given language code is zh-cn', function () {
+        it('should return zh if the given language code is either zh-cn, zh-sg and zh-hans(-*) ', function () {
             expect(fixLanguageCode('zh-cn')).toEqual('zh');
+            expect(fixLanguageCode('zh-sg')).toEqual('zh');
+            expect(fixLanguageCode('zh-hans')).toEqual('zh');
+            expect(fixLanguageCode('zh-hans-cn')).toEqual('zh');
+        });
+
+        it('should return zh-hant if the given language code is either zh-tw, zh-hk, zh-mo and zh-hant-* ', function () {
+            expect(fixLanguageCode('zh-tw')).toEqual('zh-hant');
+            expect(fixLanguageCode('zh-hk')).toEqual('zh-hant');
+            expect(fixLanguageCode('zh-mo')).toEqual('zh-hant');
+            expect(fixLanguageCode('zh-hant-tw')).toEqual('zh-hant');
         });
 
         it('should return en if the given language code is not known to CLDR', function () {

--- a/analytics_dashboard/static/js/utils/globalization.js
+++ b/analytics_dashboard/static/js/utils/globalization.js
@@ -7,9 +7,15 @@ function fixLanguageCode(languageCode) {
 
     languageCode = languageCode.toLowerCase();
 
-    // Django uses zh-cn. CLDR uses zh.
-    if (languageCode === 'zh-cn') {
+    // CLDR uses zh for Simplified Chinese, while Django may use different strings.
+    if (languageCode === 'zh-cn' || languageCode === 'zh-sg' ||
+        languageCode.indexOf('zh-hans') === 0) {
         return 'zh';
+    }
+    // CLDR uses zh-hant for Traditional Chinese, while Django may use different strings.
+    if (languageCode === 'zh-tw' || languageCode === 'zh-hk' ||
+        languageCode === 'zh-mo' || languageCode.indexOf('zh-hant') === 0) {
+        return 'zh-hant';
     }
 
     // There doesn't seem to be an onFailure event for the text! plugin. Make sure we only pass valid language codes

--- a/analytics_dashboard/static/js/utils/utils.js
+++ b/analytics_dashboard/static/js/utils/utils.js
@@ -39,7 +39,14 @@ define(['moment', 'underscore', 'utils/globalization'], function (moment, _, Glo
          * @returns {string} Returns a formatted date (ex. January 31, 2014)
          */
         formatDate: function (date) {
-            moment.locale(window.language);
+            // moment accepts 'zh-cn' rather than 'zh' and 'zh-tw' rather than 'zh-hant'
+            if (window.language === 'zh') {
+                moment.locale('zh-cn');
+            } else if (window.language === 'zh-hant') {
+                moment.locale('zh-tw');
+            } else {
+                moment.locale(window.language);
+            }
             return moment(date).format('LL');
         },
 


### PR DESCRIPTION
The Chinese language codes have many variants, and different components may use different values.
For example, DJANGO < 1.7 and moment uses 'zh-cn' && 'zh-tw' for Simplified Chinese and Traditional Chinese, while CLDR uses 'zh' && 'zh-hant' and DJANGO >= 1.7 uses 'zh-hans' && 'zh-hant'.

In current dashboard, dates in tables are always displayed in English on a Chinese language settings, because the fixed language code 'zh' does not match the value 'zh-cn' used in moment.
This fix corrects the things and it will adapt further situations because all the variants of Chinese language codes are considered.
