### PR TITLE
Configurable time display format

### DIFF
--- a/analytics_dashboard/courses/views/__init__.py
+++ b/analytics_dashboard/courses/views/__init__.py
@@ -426,7 +426,8 @@ class CourseTemplateView(ContextSensitiveHelpMixin, CourseContextMixin, CourseVi
 
     @staticmethod
     def format_last_updated_date_and_time(d):
-        return {'update_date': dateformat.format(d, settings.DATE_FORMAT), 'update_time': dateformat.format(d, 'g:i A')}
+        return {'update_date': dateformat.format(d, settings.DATE_FORMAT),
+                'update_time': dateformat.format(d, settings.TIME_FORMAT)}
 
 
 class CourseTemplateWithNavView(CourseNavBarMixin, CourseTemplateView):

--- a/analytics_dashboard/formats/en/formats.py
+++ b/analytics_dashboard/formats/en/formats.py
@@ -1,1 +1,2 @@
 DATE_FORMAT = 'F d, Y'
+TIME_FORMAT = 'g:i A'

--- a/analytics_dashboard/settings/base.py
+++ b/analytics_dashboard/settings/base.py
@@ -321,8 +321,12 @@ LMS_COURSE_SHORTCUT_BASE_URL = None
 # used to construct the shortcut link to view/edit a course in Studio
 CMS_COURSE_SHORTCUT_BASE_URL = None
 
-# Used to determine how dates are displayed in templates
+# Used to determine how dates and time are displayed in templates
+# The strings are intended for use with the django.utils.dateformat
+# module, which uses the PHP's date() style. Format details are
+# described at http://www.php.net/date.
 DATE_FORMAT = 'F d, Y'
+TIME_FORMAT = 'g:i A'
 
 ########## AUTHENTICATION
 AUTH_USER_MODEL = 'core.User'


### PR DESCRIPTION
Provide a setting option called `TIME_FORMAT` to provide such functionality.

This format string uses the PHP date() style, which is described at http://www.php.net/date
