### PR TITLE
Update case on dependency to fix build errors.

### DIFF
--- a/analytics_dashboard/static/js/config.js
+++ b/analytics_dashboard/static/js/config.js
@@ -16,7 +16,7 @@ require.config({
         views: 'js/views',
         utils: 'js/utils',
         load: 'js/load',
-        dataTables: 'bower_components/datatables/media/js/jquery.dataTables',
+        datatables: 'bower_components/datatables/media/js/jquery.dataTables',
         dataTablesBootstrap: 'vendor/dataTables/dataTables.bootstrap',
         naturalSort: 'bower_components/natural-sort/naturalSort',
         d3: 'bower_components/d3/d3',
@@ -53,7 +53,7 @@ require.config({
             }
         },
         dataTablesBootstrap: {
-            deps: ['jquery', 'dataTables']
+            deps: ['jquery', 'datatables']
         },
         naturalSort: {
             exports: 'naturalSort'


### PR DESCRIPTION
I'm not entirely sure what has changed, but it has resulted in the naming of dependencies to be more restrictive.  I've changed `dataTables` to `datatables` to fix the build errors we've run into recently.

@dan-f @lamagnifica 
