### PR TITLE
Log when the insights database is unavailable

### DIFF
--- a/analytics_dashboard/core/views.py
+++ b/analytics_dashboard/core/views.py
@@ -36,7 +36,8 @@ def health(_request):
         cursor.fetchone()
         cursor.close()
         database_status = OK
-    except DatabaseError:  # pylint: disable=catching-non-exception
+    except DatabaseError as e:  # pylint: disable=catching-non-exception
+        logger.exception('Database is not reachable: %s', e)
         database_status = UNAVAILABLE
 
     try:


### PR DESCRIPTION
@dsjen @e0d in looking at our recent outages, I noticed that the health check logs when the analytics API is unavailable, but not when the insights database is unavailable. This simply adds that functionality.
