### PR TITLE
Fix warnings due to jshint 2.9.1-rc1 release

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -25,7 +25,7 @@
     "quotmark"        : "single",  // Enforces the consistency of quotation marks used throughout your code. It accepts three values: true, "single", and "double".
     "undef"           : true,      // Prohibits the use of explicitly undeclared variables.
     "unused"          : true,      // Warns when you define and never use your variables.
-    "strict"          : true,      // Requires all functions to run in ECMAScript 5's strict mode.
+    "strict"          : "func",    // Requires all functions to run in ECMAScript 5's strict mode.
     "trailing"        : true,      // Makes it an error to leave a trailing whitespace in your code.
     "maxlen"          : 120,       // Lets you set the maximum length of a line.
     //"maxparams"     : 4,         // Lets you set the max number of formal parameters allowed per function.
@@ -44,7 +44,6 @@
     "expr"          : false,       // Suppresses warnings about the use of expressions where normally you would expect to see assignments or function calls.
     "funcscope"     : false,       // Suppresses warnings about declaring variables inside of control structures while accessing them later from the outside.
     "gcl"           : false,       // Makes JSHint compatible with Google Closure Compiler.
-    "globalstrict"  : false,       // Suppresses warnings about the use of global strict mode.
     "iterator"      : false,       // Suppresses warnings about the __iterator__ property.
     "lastsemic"     : false,       // Suppresses warnings about missing semicolons, but only when the semicolon is omitted for the last statement in a one-line block.
     "laxbreak"      : false,       // Suppresses most of the warnings about possibly unsafe line breaks in your code.

--- a/analytics_dashboard/static/js/test/spec-runner.js
+++ b/analytics_dashboard/static/js/test/spec-runner.js
@@ -2,63 +2,65 @@
  * This is where your tests go.  It should happen automatically when you
  * add files to the karma configuration.
  */
-'use strict';
+(function () {
+    'use strict';
 
-var isBrowser = window.__karma__ === undefined,
-    specs = [],
-    config = {};
+    var isBrowser = window.__karma__ === undefined,
+        specs = [],
+        config = {};
 
-// Two execution paths: browser or gulp
-if (isBrowser) {
-    // The browser cannot read directories, so all files must be enumerated below.
-    specs = [
-        config.baseUrl + 'js/spec/specs/attribute-view-spec.js',
-        config.baseUrl + 'js/spec/specs/course-model-spec.js',
-        config.baseUrl + 'js/spec/specs/data-table-spec.js',
-        config.baseUrl + 'js/spec/specs/tracking-model-spec.js',
-        config.baseUrl + 'js/spec/specs/trends-view-spec.js',
-        config.baseUrl + 'js/spec/specs/world-map-view-spec.js',
-        config.baseUrl + 'js/spec/specs/tracking-view-spec.js',
-        config.baseUrl + 'js/spec/specs/utils-spec.js',
-        config.baseUrl + 'js/spec/specs/globalization-spec.js',
-        config.baseUrl + 'js/spec/specs/announcement-view-spec.js'
-    ];
-} else {
-    // the Insights application loads gettext identity library via django, thus
-    // components reference gettext globally so a shim is added here to reflect
-    // the text so tests can be run if modules reference gettext
-    if (!window.gettext) {
-        window.gettext = function(text) {
-            return text;
-        };
-    }
-
-    // you can automatically get the test files using karma's configs
-    for (var file in window.__karma__.files) {
-        if (/spec\.js$/.test(file)) {
-            specs.push(file);
+    // Two execution paths: browser or gulp
+    if (isBrowser) {
+        // The browser cannot read directories, so all files must be enumerated below.
+        specs = [
+            config.baseUrl + 'js/spec/specs/attribute-view-spec.js',
+            config.baseUrl + 'js/spec/specs/course-model-spec.js',
+            config.baseUrl + 'js/spec/specs/data-table-spec.js',
+            config.baseUrl + 'js/spec/specs/tracking-model-spec.js',
+            config.baseUrl + 'js/spec/specs/trends-view-spec.js',
+            config.baseUrl + 'js/spec/specs/world-map-view-spec.js',
+            config.baseUrl + 'js/spec/specs/tracking-view-spec.js',
+            config.baseUrl + 'js/spec/specs/utils-spec.js',
+            config.baseUrl + 'js/spec/specs/globalization-spec.js',
+            config.baseUrl + 'js/spec/specs/announcement-view-spec.js'
+        ];
+    } else {
+        // the Insights application loads gettext identity library via django, thus
+        // components reference gettext globally so a shim is added here to reflect
+        // the text so tests can be run if modules reference gettext
+        if (!window.gettext) {
+            window.gettext = function(text) {
+                return text;
+            };
         }
+
+        // you can automatically get the test files using karma's configs
+        for (var file in window.__karma__.files) {
+            if (/spec\.js$/.test(file)) {
+                specs.push(file);
+            }
+        }
+        // This is where karma puts the files
+        config.baseUrl = '/base/analytics_dashboard/static/';
+
+        // Karma lets you list the test files here
+        config.deps = specs;
+        config.callback = window.__karma__.start;
     }
-    // This is where karma puts the files
-    config.baseUrl = '/base/analytics_dashboard/static/';
 
-    // Karma lets you list the test files here
-    config.deps = specs;
-    config.callback = window.__karma__.start;
-}
+    requirejs.config(config);
 
-requirejs.config(config);
-
-// the browser needs to kick off jasmine.  The gulp task does it through
-// node
-if (isBrowser) {
-    //jasmine 2.0 needs boot.js to run, which loads on a window load, so this is
-    // a hack
-    // http://stackoverflow.com/questions/19240302/does-jasmine-2-0-really-not-work-with-require-js
-    require(['boot'], function () {
-        require(specs,
-            function () {
-                window.onload();
-            });
-    });
-}
+    // the browser needs to kick off jasmine.  The gulp task does it through
+    // node
+    if (isBrowser) {
+        //jasmine 2.0 needs boot.js to run, which loads on a window load, so this is
+        // a hack
+        // http://stackoverflow.com/questions/19240302/does-jasmine-2-0-really-not-work-with-require-js
+        require(['boot'], function () {
+            require(specs,
+                function () {
+                    window.onload();
+                });
+        });
+    }
+})();


### PR DESCRIPTION
Explanation:

jshint released a release candidate with breaking changes to how strict/globalstrict is handled. See https://github.com/jshint/jshint/releases/tag/2.9.1-rc1. gulp-jshint included this RC version of jshint, which it probably shouldn't have. I'm going to dive a little more into that bug tomorrow.

@dsjen please review.
