### PR TITLE
Updates supported browsers, streamlines browsers.rst

### DIFF
--- a/docs/en_us/shared/browsers.rst
+++ b/docs/en_us/shared/browsers.rst
@@ -6,124 +6,25 @@
 edX Browser Support
 ####################
 
-The edX Platform runs on the following browsers.
+The edX platform runs on the following browsers.
 
-* `Chrome <https://www.google.com/chrome>`_
-* `Safari <https://www.apple.com/safari>`_
-* `Firefox <https://mozilla.org/firefox>`_
-* `Internet Explorer <https://microsoft.com/ie>`_
+* `Chrome`_
+* `Safari`_
+* `Firefox`_
+* `Microsoft Edge`_ and `Microsoft Internet Explorer`_ 11
 
-.. note:: If you use the Safari browser, be aware that it does not support the 
- search feature for the `edX documentation`_. This is a known limitation.
+The edX platform is routinely tested and verified on the current version and
+the previous version of each of these browsers. We generally encourage the use
+of, and fully support only, the latest version.
 
-The edX Platform is routinely tested and verified on the current
-and previous version of each of these browsers. We generally encourage the
-use of and fully support only the latest version.
-
-This information is updated as new major operating system and browser versions
-are released. All point releases are supported unless noted; occasional
-exceptions are based on specific bug fixes or feature updates.
-
-***********************************
-edX Learning Management System
-***********************************
-
-The following table shows operating system and browser support for the edX
-learning management system (LMS), which learners and course teams use to
-interact with course content.
-
-.. list-table::
-   :widths: 20 10 10 10 10 10
-   :header-rows: 1
-
-   * -
-     - Chrome
-     - Safari
-     - Firefox
-     - IE 9
-     - IE 10
-   * - Windows 8
-     - Yes
-     - N/A
-     - Yes
-     - Yes
-     - Yes
-   * - Mac OSX Mavericks or Yosemite
-     - Yes
-     - Yes
-     - Yes
-     - N/A
-     - N/A
-
-For more information about the LMS, see `Building and Running an edX Course`_. 
-
-***********************************
-edX Studio
-***********************************
-
-The following table shows operating system and browser support for edX Studio,
-which course teams use to build a course.
-
-.. list-table::
-   :widths: 20 10 10 10 10 10
-   :header-rows: 1
-
-   * -
-     - Chrome
-     - Safari
-     - Firefox
-     - IE 9
-     - IE 10
-   * - Windows 8
-     - Yes
-     - N/A
-     - Yes
-     - Provisional
-     - Provisional
-   * - Mac OSX Mavericks or Yosemite
-     - Yes
-     - Yes
-     - Yes
-     - N/A
-     - N/A
-
-For more information about Studio, see `Building and Running an edX Course`_. 
-
-***********************************
-edX Insights
-***********************************
-
-The following table shows operating system and browser support for edX
-Insights, which course teams use to review and download data about their
-courses and learners.
-
-.. list-table::
-   :widths: 20 10 10 10 10 10
-   :header-rows: 1
-
-   * -
-     - Chrome
-     - Safari
-     - Firefox
-     - IE 9
-     - IE 10
-   * - Windows 8
-     - Yes
-     - N/A
-     - Yes
-     - Provisional
-     - Provisional
-   * - Mac OSX Mavericks or Yosemite
-     - Yes
-     - Yes
-     - Yes
-     - N/A
-     - N/A
-
-For more information about edX Insights, see `Using edX Insights`_.
+.. note:: If you use the Safari browser, be aware that it does not support the
+ search feature for the guides on `docs.edx.org`_. This is a known limitation.
 
 
+.. _Chrome: https://www.google.com/chrome
+.. _Safari: https://www.apple.com/safari
+.. _Firefox: https://mozilla.org/firefox
+.. _Microsoft Edge: https://www.microsoft.com/microsoft-edge
+.. _Microsoft Internet Explorer: http://windows.microsoft.com/internet-explorer/download-ie
 
-.. _edX documentation: http://docs.edx.org
-.. _Building and Running an edX Course: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/
-.. _Using edX Insights: http://edx-insights.readthedocs.org/en/latest/
+.. _docs.edx.org: http://docs.edx.org


### PR DESCRIPTION
## [DOC-2587](https://openedx.atlassian.net/browse/DOC-2587)

IE 10 is no longer supported. IE 11 continues to be supported, and Microsoft Edge is undergoing testing now. Per discussion with @benpatterson, providing separate matrices for the browsers and operating systems seemed unnecessarily detailed. so I removed them. 

[ ] Open question about how caret browsing will work in Edge.

There is a companion PR for the edx-documentation repo, https://github.com/edx/edx-documentation/pull/796.
### Date Needed

25 Jan 2016
### Reviewers
- [x] Subject matter expert: @benpatterson 
- [ ] Subject matter expert: @cptvitamin 
- [ ] Doc team review (sanity check): @catong @srpearce @pdesjardins 

FYI: @smagoun @mulby @dan-f 
### Testing
- [ ] Ran make html without warnings or errors
### Post-review
- [x] Add description to release notes task as a comment
- [ ] Squash commits
