### PR TITLE
Updated edx-rest-api-client dependency.

### DIFF
--- a/analytics_dashboard/core/tests/test_utils.py
+++ b/analytics_dashboard/core/tests/test_utils.py
@@ -1,6 +1,6 @@
 import uuid
 
-from ddt import data, ddt, unpack
+from ddt import ddt
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -55,11 +55,6 @@ class CourseStructureApiClientTests(TestCase):
     """
     Tests the CourseStructureApiClient wrapper class.
     """
-    @data((None, None), ('http://example.com/', None), (None, 'arbitrary_access_token'))
-    @unpack
-    def test_required_args(self, url, access_token):
-        with self.assertRaises(ValueError):
-            CourseStructureApiClient(url, access_token)
 
     def test_default_timeout(self):
         client = CourseStructureApiClient('http://example.com/', 'arbitrary_access_token')

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ django-libsass==0.2			# BSD
 django-model-utils==1.5.0 	# BSD
 django-soapbox==1.1         # BSD
 django-waffle==0.10			# BSD
-edx-rest-api-client==1.2.1              # Apache
+edx-rest-api-client>=1.5.0, <1.6.0  # Apache
 
 # other versions cause a segment fault when running compression
 libsass==0.5.1              # MIT


### PR DESCRIPTION
@dan-f -- this is the proposed solution for [AN-6686](https://openedx.atlassian.net/browse/AN-6686).  Please see comments in the ticket.

~~I'm still waiting on confirmation on the exact version of slumber that is installed on the buggy AMI and won't merge this until then.~~  Confirmed!
