### PR TITLE
Learner Detail page & Learner Engagement Timeline

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -143,6 +143,9 @@
 
         // Django translation
         "gettext",
-        "ngettext"
+        "ngettext",
+
+        // Sinon library
+        "sinon"
     ]
 }

--- a/analytics_dashboard/courses/templates/courses/learners.html
+++ b/analytics_dashboard/courses/templates/courses/learners.html
@@ -23,7 +23,8 @@ View of individual learners within a course.
                  learnerListJson: {{ learner_list_json | escape_json }},
                  learnerListUrl: '{{ learner_list_url }}',
                  courseLearnerMetadataJson: {{ course_learner_metadata_json | escape_json }},
-                 courseLearnerMetadataUrl: '{{ course_learner_metadata_url }}'
+                 courseLearnerMetadataUrl: '{{ course_learner_metadata_url }}',
+                 learnerEngagementTimelineUrl: '{{ learner_engagement_timeline_url }}'
              });
              app.start();
          });

--- a/analytics_dashboard/courses/views/learners.py
+++ b/analytics_dashboard/courses/views/learners.py
@@ -28,6 +28,13 @@ class LearnersView(CourseTemplateWithNavView):
                 'learner_analytics_api:v0:CourseMetadata',
                 args=(self.course_id,)
             ),
+            'learner_engagement_timeline_url': reverse(
+                'learner_analytics_api:v0:EngagementTimeline',
+                # Unfortunately, we need to pass a username to the `reverse`
+                # function.  This will get dynamically interpolated with the
+                # actual users' usernames on the client side.
+                kwargs={'username': 'temporary_username'}
+            ),
         })
         # Try to prefetch API responses.  If anything fails, the front-end will
         # retry the requests and gracefully fail.

--- a/analytics_dashboard/static/apps/learners/js/app.js
+++ b/analytics_dashboard/static/apps/learners/js/app.js
@@ -27,7 +27,7 @@ define([
          *
          * @param options specifies the following values:
          * - courseId (string) required - the course id for this
-         *   learner app
+         *   learner app.
          * - containerSelector (string) required - the CSS selector
          *   for the HTML element that this app should attach to
          * - learnerListUrl (string) required - the URL for the
@@ -43,6 +43,8 @@ define([
          *   representing an initial server response from the Learner
          *   Course Metadata endpoint used for data on cohorts,
          *   segments, enrollment modes, and engagement ranges.
+         * - learnerEngagementTimelineUrl (String) required - the URL for the
+         *   Learner Engagement Timeline API endpoint.
          */
         initialize: function (options) {
             this.options = options || {};
@@ -69,9 +71,11 @@ define([
 
             router = new LearnersRouter({
                 controller: new LearnersController({
+                    courseId: this.options.courseId,
                     learnerCollection: learnerCollection,
                     courseMetadata: courseMetadata,
-                    rootView: rootView
+                    rootView: rootView,
+                    learnerEngagementTimelineUrl: this.options.learnerEngagementTimelineUrl
                 })
             });
 

--- a/analytics_dashboard/static/apps/learners/js/controller.js
+++ b/analytics_dashboard/static/apps/learners/js/controller.js
@@ -9,8 +9,16 @@
 define([
     'backbone',
     'marionette',
+    'learners/js/models/engagement-timeline',
+    'learners/js/views/learner-detail',
     'learners/js/views/roster-view'
-], function (Backbone, Marionette, LearnerRosterView) {
+], function (
+    Backbone,
+    Marionette,
+    EngagementTimelineModel,
+    LearnerDetailView,
+    LearnerRosterView
+) {
     'use strict';
 
     var LearnersController = Marionette.Object.extend({
@@ -25,13 +33,21 @@ define([
             }));
         },
 
+        /**
+         * Render the learner detail page assuming the learner model fetch
+         * succeeds.
+         *
+         * @returns a jqXHR representing the learner engagement model fetch.
+         */
         showLearnerDetailPage: function (username) {
-            // TODO: we'll eventually have to fetch the learner either
-            // from the cached collection, or from the server.  See
-            // https://openedx.atlassian.net/browse/AN-6191
-            this.options.rootView.showChildView('main', new (Backbone.View.extend({
-                render: function () {this.$el.text(username); return this;}
-            }))());
+            var engagementTimelineModel = new EngagementTimelineModel({}, {
+                url: this.options.learnerEngagementTimelineUrl.replace('temporary_username', username),
+                courseId: this.options.courseId
+            });
+            this.options.rootView.showChildView('main', new LearnerDetailView({
+                engagementTimelineModel: engagementTimelineModel
+            }));
+            return engagementTimelineModel.fetch();
         },
 
         showNotFoundPage: function () {

--- a/analytics_dashboard/static/apps/learners/js/models/course-metadata.js
+++ b/analytics_dashboard/static/apps/learners/js/models/course-metadata.js
@@ -20,6 +20,7 @@ define([
         },
 
         initialize: function (attributes, options) {
+            Backbone.Model.prototype.initialize.call(this, attributes, options);
             this.options = options || {};
         },
 

--- a/analytics_dashboard/static/apps/learners/js/models/engagement-timeline.js
+++ b/analytics_dashboard/static/apps/learners/js/models/engagement-timeline.js
@@ -41,7 +41,6 @@ define([
         hasData: function() {
             return this.get('days').length > 0;
         }
-
     });
 
     return EngagementTimelineModel;

--- a/analytics_dashboard/static/apps/learners/js/models/engagement-timeline.js
+++ b/analytics_dashboard/static/apps/learners/js/models/engagement-timeline.js
@@ -1,0 +1,43 @@
+define([
+    'backbone',
+    'learners/js/utils'
+], function (
+    Backbone,
+    LearnerUtils
+) {
+    'use strict';
+
+    var EngagementTimelineModel = Backbone.Model.extend({
+        /* Days is an array of objects, with each object containing the
+         * following keys:
+         *      - date (string) ISO 8601 date
+         *      - discussions_contributed (int) number of discussions
+         *        contributed to on the specified date.
+         *      - problems_attempted (int) number of problems
+         *        attempted on the specified date.
+         *      - problems_completed (int) number of problems
+         *        completed on the specified date.
+         *      - videos_viewed (int) number of videos
+         *        viewed on the specified date.
+         */
+        defaults: {
+            days: []
+        },
+
+        initialize: function (attributes, options) {
+            Backbone.Model.prototype.initialize.call(this, attributes, options);
+            this.options = options || {};
+        },
+
+        url: function () {
+            return this.options.url + '?course_id=' + encodeURIComponent(this.options.courseId);
+        },
+
+        fetch: function () {
+            return Backbone.Model.prototype.fetch.apply(this, arguments)
+                .fail(LearnerUtils.handleAjaxFailure.bind(this));
+        }
+    });
+
+    return EngagementTimelineModel;
+});

--- a/analytics_dashboard/static/apps/learners/js/models/engagement-timeline.js
+++ b/analytics_dashboard/static/apps/learners/js/models/engagement-timeline.js
@@ -36,7 +36,12 @@ define([
         fetch: function () {
             return Backbone.Model.prototype.fetch.apply(this, arguments)
                 .fail(LearnerUtils.handleAjaxFailure.bind(this));
+        },
+
+        hasData: function() {
+            return this.get('days').length > 0;
         }
+
     });
 
     return EngagementTimelineModel;

--- a/analytics_dashboard/static/apps/learners/js/models/learner-model.js
+++ b/analytics_dashboard/static/apps/learners/js/models/learner-model.js
@@ -1,4 +1,7 @@
-define(['backbone'], function (Backbone) {
+define([
+    'backbone',
+    'learners/js/utils'
+], function (Backbone, LearnerUtils) {
     'use strict';
 
     var LearnerModel = Backbone.Model.extend({
@@ -19,7 +22,12 @@ define(['backbone'], function (Backbone) {
         idAttribute: 'username',
 
         url: function () {
-            return Backbone.Model.prototype.url.call(this) + '?course_id=' + this.get('course_id');
+            return Backbone.Model.prototype.url.call(this) + '?course_id=' + encodeURIComponent(this.get('course_id'));
+        },
+
+        fetch: function (options) {
+            return Backbone.Model.prototype.fetch.call(this, options)
+                .fail(LearnerUtils.handleAjaxFailure.bind(this));
         },
 
         /**

--- a/analytics_dashboard/static/apps/learners/js/spec/controller-spec.js
+++ b/analytics_dashboard/static/apps/learners/js/spec/controller-spec.js
@@ -3,19 +3,22 @@ define([
     'learners/js/collections/learner-collection',
     'learners/js/controller',
     'learners/js/models/course-metadata',
-    'marionette'
-], function ($, LearnerCollection, LearnersController, CourseMetadataModel, Marionette) {
+    'learners/js/views/root-view'
+], function ($, LearnerCollection, LearnersController, CourseMetadataModel, LearnersRootView) {
     'use strict';
 
     describe('LearnersController', function () {
+        var courseId,
+            server;
+
+        courseId = 'test/course/id';
+
         beforeEach(function () {
             var collection;
+            server = sinon.fakeServer.create();
             setFixtures('<div class="root-view"><div class="main"></div></div>');
-            this.rootView = new (Marionette.LayoutView.extend({
-                regions: {
-                    main: '.main'
-                }
-            }))({el: '.root-view'});
+            this.rootView = new LearnersRootView({el: '.root-view'});
+            this.rootView.render();
             // The learner roster view looks at the first learner in
             // the collection in order to render a last updated
             // message.
@@ -31,14 +34,20 @@ define([
                     segments: ['highly_engaged'],
                     engagements: {},
                     last_updated: new Date(),
-                    course_id: 'test/course/id'
+                    course_id: courseId
                 }
             ]);
             this.controller = new LearnersController({
                 rootView: this.rootView,
                 learnerCollection: collection,
-                courseMetadata: new CourseMetadataModel()
+                courseMetadata: new CourseMetadataModel(),
+                learnerEngagementTimelineUrl: '/test-endpoint/',
+                courseId: courseId
             });
+        });
+
+        afterEach(function () {
+            server.restore();
         });
 
         it('should show the learner roster page', function () {
@@ -46,12 +55,33 @@ define([
             expect(this.rootView.$('.learner-roster')).toBeInDOM();
         });
 
-        it('should show the learner detail page', function () {
-            // The current learner detail page is a stub.  The actual
-            // page will be implemented in
-            // https://openedx.atlassian.net/browse/AN-6191
-            this.controller.showLearnerDetailPage('example-username');
-            expect(this.rootView.$el.html()).toContainText('example-username');
+        describe('navigating to the Learner Detail page', function () {
+            it('should show the learner detail page', function () {
+                var engagementTimelineResponse;
+                this.controller.showLearnerDetailPage('example-username');
+                // Showing the learner detail page triggers a request for the
+                // learner engagement timeline data.
+                engagementTimelineResponse = JSON.stringify({days: [{
+                    date: '2016-01-01',
+                    discussions_contributed: 1,
+                    problems_attempted: 1,
+                    problems_completed: 1,
+                    videos_viewed: 1
+                }]});
+                server.requests[server.requests.length - 1].respond(200, {}, engagementTimelineResponse);
+                expect(this.rootView.$('.learner-detail-container')).toExist();
+            });
+
+            it('should handle AJAX errors', function (done) {
+                var rootView = this.rootView;
+                this.controller.showLearnerDetailPage('example-username')
+                    .always(function () {
+                        expect(rootView.$('.learner-detail-container')).toExist();
+                        expect(rootView.$('[role="alert"]')).toExist();
+                        done();
+                    });
+                server.requests[server.requests.length - 1].respond(500, {}, '');
+            });
         });
 
         it('should show the not found page', function () {

--- a/analytics_dashboard/static/apps/learners/js/spec/course-metadata-spec.js
+++ b/analytics_dashboard/static/apps/learners/js/spec/course-metadata-spec.js
@@ -1,4 +1,4 @@
-require(['learners/js/models/course-metadata'], function (CourseMetadataModel) {
+define(['learners/js/models/course-metadata'], function (CourseMetadataModel) {
     'use strict';
 
     describe('CourseMetadataModel', function () {
@@ -6,7 +6,7 @@ require(['learners/js/models/course-metadata'], function (CourseMetadataModel) {
 
         beforeEach(function () {
             jasmine.clock().install();
-            server = sinon.fakeServer.create(); // jshint ignore:line
+            server = sinon.fakeServer.create();
         });
 
         afterEach(function () {

--- a/analytics_dashboard/static/apps/learners/js/spec/engagement-timeline-model-spec.js
+++ b/analytics_dashboard/static/apps/learners/js/spec/engagement-timeline-model-spec.js
@@ -1,0 +1,39 @@
+define([
+    'learners/js/models/engagement-timeline'
+], function (EngagementTimelineModel) {
+    'use strict';
+
+    describe('EngagementTimelineModel', function () {
+        var server;
+
+        beforeEach(function () {
+            server = sinon.fakeServer.create();
+        });
+
+        afterEach(function () {
+            server.restore();
+        });
+
+        it('sets its URL from the options parameter', function () {
+            var model = new EngagementTimelineModel({}, {
+                courseId: 'test/course/id',
+                url: '/test-endpoint/'
+            });
+            expect(model.url()).toBe('/test-endpoint/?course_id=test%2Fcourse%2Fid');
+        });
+
+        it('handles AJAX failures', function (done) {
+            var model = new EngagementTimelineModel({}, {
+                    courseId: 'test/course/id',
+                    url: '/test-endpoint/'
+                }),
+                responseJson = {error_message: 'Sorry, something went wrong'};
+            spyOn(model, 'trigger');
+            model.fetch().always(function () {
+                expect(model.trigger).toHaveBeenCalledWith('serverError', 500, responseJson);
+                done();
+            });
+            server.requests[server.requests.length - 1].respond(500, {}, JSON.stringify(responseJson));
+        });
+    });
+});

--- a/analytics_dashboard/static/apps/learners/js/spec/engagement-timeline-spec.js
+++ b/analytics_dashboard/static/apps/learners/js/spec/engagement-timeline-spec.js
@@ -1,0 +1,105 @@
+define([
+    'jquery',
+    'learners/js/models/engagement-timeline',
+    'learners/js/views/engagement-timeline',
+    'moment',
+    'underscore'
+], function (
+    $,
+    EngagementTimelineModel,
+    EngagementTimelineView,
+    moment,
+    _
+) {
+    'use strict';
+
+    describe('EngagementTimelineView', function () {
+        var expectLegendRendered,
+            expectTimelineRendered,
+            expectXAxisRendered,
+            fixtureClass,
+            getTimelineModel;
+
+        expectLegendRendered = function (view) {
+            var labels,
+                legendItems;
+            labels = ['Discussion Contributions', 'Problems Completed', 'Videos Viewed'];
+            legendItems = view.$('.nv-legend-text');
+            expect(labels.length).toEqual(legendItems.length);
+            _.each(labels, function (label, index) {
+                expect(legendItems[index]).toHaveText(label);
+            });
+        };
+
+        expectXAxisRendered = function (view) {
+            var dates,
+                xLabels;
+            dates = _.map(view.model.get('days'), function (day) {
+                return moment(Date.parse(day.date)).format('M/D');
+            });
+            // Note that NVD3 unfortunately doesn't semantically order the
+            // x-axis labels in the DOM, so we can't verify each label in order.
+            xLabels = _.chain(view.$('.nv-x.nv-axis text'))
+                .filter(function (el) {
+                    return $(el).text() !== '';
+                })
+                .map(function (el) {
+                    return $(el).text();
+                })
+                .value();
+            expect(dates.sort()).toEqual(xLabels.sort());
+        };
+
+        expectTimelineRendered = function (view) {
+            // We can't verify the rendering of the actual svg paths, since they
+            // don't semantically encode which data they represent; instead NVD3
+            // encodes pixel/location values of the points along the paths.
+            // We also can't verify the rendering of Y axis, since it represents
+            // the range of engagement values, and does so by taking the minimum
+            // and maximum values, and interpolating values between them.
+            expectLegendRendered(view);
+            expectXAxisRendered(view);
+        };
+
+        fixtureClass = '.engagement-timeline-fixture';
+
+        getTimelineModel = function () {
+            return new EngagementTimelineModel({
+                days: [{
+                    date: '2016-01-01',
+                    discussions_contributed: 1,
+                    problems_attempted: 1,
+                    problems_completed: 1,
+                    videos_viewed: 1
+                }, {
+                    date: '2016-01-02',
+                    discussions_contributed: 2,
+                    problems_attempted: 2,
+                    problems_completed: 2,
+                    videos_viewed: 2
+                }, {
+                    fdate: '2016-01-03',
+                    discussions_contributed: 3,
+                    problems_attempted: 3,
+                    problems_completed: 3,
+                    videos_viewed: 3
+                }]
+            });
+        };
+
+        beforeEach(function () {
+            setFixtures('<div class="' + fixtureClass.slice(1) + '"></div>');
+        });
+
+        it('can render an engagement timeline', function () {
+            var model, view;
+            model = getTimelineModel();
+            view = new EngagementTimelineView({
+                model: model,
+                el: fixtureClass
+            });
+            view.render().onAttach();
+            expectTimelineRendered(view);
+        });
+    });
+});

--- a/analytics_dashboard/static/apps/learners/js/spec/engagement-timeline-spec.js
+++ b/analytics_dashboard/static/apps/learners/js/spec/engagement-timeline-spec.js
@@ -92,7 +92,8 @@ define([
         });
 
         it('can render an engagement timeline', function () {
-            var model, view;
+            var model,
+                view;
             model = getTimelineModel();
             view = new EngagementTimelineView({
                 model: model,

--- a/analytics_dashboard/static/apps/learners/js/spec/learner-collection-spec.js
+++ b/analytics_dashboard/static/apps/learners/js/spec/learner-collection-spec.js
@@ -18,7 +18,7 @@ define(['learners/js/collections/learner-collection', 'URI'], function (LearnerC
         };
 
         beforeEach(function () {
-            server = sinon.fakeServer.create(); // jshint ignore:line
+            server = sinon.fakeServer.create();
             learners = new LearnerCollection(null, {url: '/endpoint/', courseId: courseId});
         });
 

--- a/analytics_dashboard/static/apps/learners/js/spec/learner-detail-spec.js
+++ b/analytics_dashboard/static/apps/learners/js/spec/learner-detail-spec.js
@@ -1,0 +1,36 @@
+define([
+    'learners/js/models/engagement-timeline',
+    'learners/js/views/learner-detail'
+], function (
+    EngagementTimelineModel,
+    LearnerDetailView
+) {
+    'use strict';
+
+    describe('LearnerDetailView', function () {
+        var fixtureClass = '.learner-detail-fixture';
+
+        beforeEach(function () {
+            setFixtures('<div class="' + fixtureClass.slice(1) + '"></div>');
+        });
+
+        it('renders a learner engagement timeline', function () {
+            var engagementTimelineModel, detailView;
+            engagementTimelineModel = new EngagementTimelineModel({
+                days: [{
+                    date: '2016-01-01',
+                    discussions_contributed: 1,
+                    problems_attempted: 1,
+                    problems_completed: 1,
+                    videos_viewed: 1
+                }]
+            });
+            detailView = new LearnerDetailView({
+                engagementTimelineModel: engagementTimelineModel,
+                el: fixtureClass
+            });
+            detailView.render().onBeforeShow();
+            expect(detailView.$('.learner-engagement-timeline')).toExist();
+        });
+    });
+});

--- a/analytics_dashboard/static/apps/learners/js/spec/learner-detail-spec.js
+++ b/analytics_dashboard/static/apps/learners/js/spec/learner-detail-spec.js
@@ -14,8 +14,26 @@ define([
             setFixtures('<div class="' + fixtureClass.slice(1) + '"></div>');
         });
 
+        it('renders a loading view first', function () {
+            var engagementTimelineModel = new EngagementTimelineModel(),
+                detailView = new LearnerDetailView({
+                    engagementTimelineModel: engagementTimelineModel,
+                    el: fixtureClass
+                });
+
+            detailView.render().onBeforeShow();
+            expect(detailView.$('.loading-container')).toExist();
+            expect(detailView.$('.learner-engagement-timeline')).not.toExist();
+
+            engagementTimelineModel.trigger('sync');
+            expect(detailView.$('.loading-container')).not.toExist();
+            expect(detailView.$('.learner-engagement-timeline')).toExist();
+        });
+
         it('renders a learner engagement timeline', function () {
-            var engagementTimelineModel, detailView;
+            var engagementTimelineModel,
+                detailView;
+
             engagementTimelineModel = new EngagementTimelineModel({
                 days: [{
                     date: '2016-01-01',
@@ -30,6 +48,7 @@ define([
                 el: fixtureClass
             });
             detailView.render().onBeforeShow();
+            expect(detailView.$('.loading-container')).not.toExist();
             expect(detailView.$('.learner-engagement-timeline')).toExist();
         });
     });

--- a/analytics_dashboard/static/apps/learners/js/spec/learner-model-spec.js
+++ b/analytics_dashboard/static/apps/learners/js/spec/learner-model-spec.js
@@ -33,11 +33,11 @@ define(['backbone', 'learners/js/models/learner-model'], function (Backbone, Lea
         it('should treat the username as its id', function () {
             var learner = new LearnerModel({username: 'daniel', course_id: 'edX/DemoX/Demo_Course'});
             new (Backbone.Collection.extend({url: '/endpoint/'}))([learner]);
-            expect(learner.url()).toEqual('/endpoint/daniel?course_id=edX/DemoX/Demo_Course');
+            expect(learner.url()).toEqual('/endpoint/daniel?course_id=edX%2FDemoX%2FDemo_Course');
             learner = new (LearnerModel.extend({
                 urlRoot: '/other-endpoint/'
             }))({username: 'daniel', course_id: 'edX/DemoX/Demo_Course'});
-            expect(learner.url()).toEqual('/other-endpoint/daniel?course_id=edX/DemoX/Demo_Course');
+            expect(learner.url()).toEqual('/other-endpoint/daniel?course_id=edX%2FDemoX%2FDemo_Course');
         });
     });
 });

--- a/analytics_dashboard/static/apps/learners/js/spec/loading-view-spec.js
+++ b/analytics_dashboard/static/apps/learners/js/spec/loading-view-spec.js
@@ -1,0 +1,31 @@
+define([
+    'backbone',
+    'learners/js/views/loading-view',
+    'underscore'
+], function (Backbone, LoadingView, _) {
+    'use strict';
+
+    describe('LoadingView', function () {
+
+        var fixtureClass = '.loading-fixture';
+
+        beforeEach(function () {
+            setFixtures('<div class="' + fixtureClass.slice(1) + '"></div>');
+        });
+
+        it('shows and hides loading template', function () {
+            var loadingView = new LoadingView({
+                model: new Backbone.Model(),
+                el: fixtureClass,
+                template: _.template('<div class="loading"><%= loadingText %></div>'),
+                successView: new Backbone.View()
+            });
+
+            loadingView.render().onBeforeShow();
+            expect(loadingView.$('.loading')).toContainText('Loading...');
+            loadingView.model.trigger('sync');
+            expect(loadingView.$('.loading')).not.toContainText('Loading...');
+        });
+
+    });
+});

--- a/analytics_dashboard/static/apps/learners/js/spec/roster-view-spec.js
+++ b/analytics_dashboard/static/apps/learners/js/spec/roster-view-spec.js
@@ -90,7 +90,7 @@ define([
 
         beforeEach(function () {
             setFixtures('<div class="' + fixtureClass + '"></div>');
-            server = sinon.fakeServer.create();  // jshint ignore:line
+            server = sinon.fakeServer.create();
         });
 
         afterEach(function () {

--- a/analytics_dashboard/static/apps/learners/js/spec/utils-spec.js
+++ b/analytics_dashboard/static/apps/learners/js/spec/utils-spec.js
@@ -1,4 +1,4 @@
-require([
+define([
     'jquery',
     'learners/js/utils'
 ], function ($, LearnerUtils) {
@@ -10,7 +10,7 @@ require([
 
             beforeEach(function () {
                 jasmine.clock().install();
-                server = sinon.fakeServer.create();  // jshint ignore:line
+                server = sinon.fakeServer.create();
             });
 
             afterEach(function () {

--- a/analytics_dashboard/static/apps/learners/js/utils.js
+++ b/analytics_dashboard/static/apps/learners/js/utils.js
@@ -84,6 +84,7 @@ define([], function () {
                 if (status === 504) {
                     return [
                         'appError',
+                        // Translators: "504" is a number representing a server error, so please leave it as "504".
                         gettext('504: Server error: processing your request took too long to complete. Reload the page to try again.') // jshint ignore:line
                     ];
                 } else {

--- a/analytics_dashboard/static/apps/learners/js/views/engagement-timeline.js
+++ b/analytics_dashboard/static/apps/learners/js/views/engagement-timeline.js
@@ -1,9 +1,9 @@
 define([
     'marionette',
     'text!learners/templates/engagement-timeline.underscore',
-    'views/trends-view',
-    'underscore'
-], function (Marionette, engagementTimelineTemplate, TrendsView, _) {
+    'underscore',
+    'views/trends-view'
+], function (Marionette, engagementTimelineTemplate, _, TrendsView) {
     'use strict';
 
     var LearnerEngagementTimelineView = Marionette.LayoutView.extend({

--- a/analytics_dashboard/static/apps/learners/js/views/engagement-timeline.js
+++ b/analytics_dashboard/static/apps/learners/js/views/engagement-timeline.js
@@ -21,7 +21,7 @@ define([
                 model: this.model,
                 modelAttribute: 'days',
                 isDataAvailable: function () {
-                    return this.model.get('days').length > 0;
+                    return this.model.hasData();
                 },
                 trends: [{
                     key: 'discussion_contributions',

--- a/analytics_dashboard/static/apps/learners/js/views/engagement-timeline.js
+++ b/analytics_dashboard/static/apps/learners/js/views/engagement-timeline.js
@@ -1,0 +1,52 @@
+define([
+    'marionette',
+    'text!learners/templates/engagement-timeline.underscore',
+    'views/trends-view',
+    'underscore'
+], function (Marionette, engagementTimelineTemplate, TrendsView, _) {
+    'use strict';
+
+    var LearnerEngagementTimelineView = Marionette.LayoutView.extend({
+        template: _.template(engagementTimelineTemplate),
+        regions: {
+            main: '.learner-engagement-timeline.analytics-chart'
+        },
+        onAttach: function () {
+            // Normally we'd declare this logic in the
+            // `Marionette.View.onBeforeView` method, but the TrendsView
+            // requires that the chart's container element is in the DOM.
+            new TrendsView({
+                showLegend: true,
+                el: this.regions.main,
+                model: this.model,
+                modelAttribute: 'days',
+                isDataAvailable: function () {
+                    return this.model.get('days').length > 0;
+                },
+                trends: [{
+                    key: 'discussion_contributions',
+                    title: gettext('Discussion Contributions'),
+                    type: 'number'
+                }, {
+                    key: 'problems_completed',
+                    title: gettext('Problems Completed'),
+                    type: 'number'
+                }, {
+                    key: 'videos_viewed',
+                    title: gettext('Videos Viewed'),
+                    type: 'number'
+                }],
+                x: {
+                    title: gettext('Date'),
+                    key: 'date'
+                },
+                y: {
+                    title: gettext('Value'), // TODO: doc review of y-axis display name
+                    key: 'value'
+                }
+            });
+        }
+    });
+
+    return LearnerEngagementTimelineView;
+});

--- a/analytics_dashboard/static/apps/learners/js/views/learner-detail.js
+++ b/analytics_dashboard/static/apps/learners/js/views/learner-detail.js
@@ -1,13 +1,17 @@
 define([
     'learners/js/utils',
     'learners/js/views/engagement-timeline',
+    'learners/js/views/loading-view',
     'marionette',
+    'text!learners/templates/chart-loading.underscore',
     'text!learners/templates/learner-detail.underscore',
     'underscore'
 ], function (
     LearnerUtils,
     LearnerEngagementTimelineView,
+    LoadingView,
     Marionette,
+    chartLoadingTemplate,
     learnerDetailTemplate,
     _
 ) {
@@ -17,7 +21,7 @@ define([
         className: 'learner-detail-container',
         template: _.template(learnerDetailTemplate),
         regions: {
-            engagementTimeline: '.learner-engagement-timeline-container.analytics-chart-container'
+            engagementTimeline: '.learner-engagement-timeline-container'
         },
         initialize: function (options) {
             Marionette.LayoutView.prototype.initialize.call(this, options);
@@ -29,10 +33,26 @@ define([
                 sync: LearnerUtils.EventTransformers.syncToClearError
             }, this);
         },
+        onAppError: function () {
+            this.removeRegion('engagementTimeline');
+        },
         onBeforeShow: function () {
-            this.showChildView('engagementTimeline', new LearnerEngagementTimelineView({
-                model: this.options.engagementTimelineModel
-            }));
+            var timelineModel = this.options.engagementTimelineModel,
+                timelineView = new LearnerEngagementTimelineView({
+                    model: timelineModel
+                }),
+                mainView = timelineView;
+
+            if (!timelineModel.hasData()) {
+                // instead of showing the timeline direction, show a loading view
+                mainView = new LoadingView({
+                    model: timelineModel,
+                    template: _.template(chartLoadingTemplate),
+                    successView: timelineView
+                });
+            }
+
+            this.showChildView('engagementTimeline', mainView);
         }
     });
 

--- a/analytics_dashboard/static/apps/learners/js/views/learner-detail.js
+++ b/analytics_dashboard/static/apps/learners/js/views/learner-detail.js
@@ -1,0 +1,40 @@
+define([
+    'learners/js/utils',
+    'learners/js/views/engagement-timeline',
+    'marionette',
+    'text!learners/templates/learner-detail.underscore',
+    'underscore'
+], function (
+    LearnerUtils,
+    LearnerEngagementTimelineView,
+    Marionette,
+    learnerDetailTemplate,
+    _
+) {
+    'use strict';
+
+    var LearnerDetailView = Marionette.LayoutView.extend({
+        className: 'learner-detail-container',
+        template: _.template(learnerDetailTemplate),
+        regions: {
+            engagementTimeline: '.learner-engagement-timeline-container.analytics-chart-container'
+        },
+        initialize: function (options) {
+            Marionette.LayoutView.prototype.initialize.call(this, options);
+            this.options = options || {};
+
+            LearnerUtils.mapEvents(this.options.engagementTimelineModel, {
+                serverError: LearnerUtils.EventTransformers.serverErrorToAppError,
+                networkError: LearnerUtils.EventTransformers.networkErrorToAppError,
+                sync: LearnerUtils.EventTransformers.syncToClearError
+            }, this);
+        },
+        onBeforeShow: function () {
+            this.showChildView('engagementTimeline', new LearnerEngagementTimelineView({
+                model: this.options.engagementTimelineModel
+            }));
+        }
+    });
+
+    return LearnerDetailView;
+});

--- a/analytics_dashboard/static/apps/learners/js/views/loading-view.js
+++ b/analytics_dashboard/static/apps/learners/js/views/loading-view.js
@@ -1,0 +1,34 @@
+define([
+    'marionette'
+], function (Marionette) {
+    'use strict';
+
+    /**
+     * Displays loading spinner.  Upon a successful load, the view will be
+     * replaced with the "success" view.
+     *
+     * This view expects a template with a "loading" class and "loadingText"
+     * template variable.
+     */
+    var LoadingView = Marionette.LayoutView.extend({
+
+        templateHelpers: function () {
+            return {
+                // Translators: This message indicates content is loading in the page.
+                loadingText: gettext('Loading...')
+            };
+        },
+
+        regions: {
+            loadingRegion: '.loading'
+        },
+
+        onBeforeShow: function () {
+            this.listenTo(this.model, 'sync', function () {
+                this.showChildView('loadingRegion', this.options.successView);
+            });
+        }
+    });
+
+    return LoadingView;
+});

--- a/analytics_dashboard/static/apps/learners/js/views/roster-view.js
+++ b/analytics_dashboard/static/apps/learners/js/views/roster-view.js
@@ -12,6 +12,7 @@ define([
     'bootstrap',
     'bootstrap_accessibility',  // adds the aria-describedby to tooltips
     'jquery',
+    'learners/js/utils',
     'learners/js/views/alert-view',
     'marionette',
     'text!learners/templates/cohort-filter.underscore',
@@ -31,6 +32,7 @@ define([
     _Bootstrap,
     _BootstrapAccessibility,
     $,
+    LearnerUtils,
     AlertView,
     Marionette,
     cohortFilterTemplate,
@@ -488,33 +490,17 @@ define([
         },
 
         initialize: function (options) {
+            var eventTransformers;
+
             this.options = options || {};
-            this.listenTo(this.options.collection, 'serverError', this.handleServerError);
-            this.listenTo(this.options.collection, 'networkError', this.handleNetworkError);
-            this.listenTo(this.options.collection, 'sync', this.handleSync);
-            this.listenTo(this.options.courseMetadata, 'serverError', this.handleServerError);
-            this.listenTo(this.options.courseMetadata, 'networkError', this.handleNetworkError);
-            this.listenTo(this.options.courseMetadata, 'sync', this.handleSync);
-        },
 
-        handleServerError: function (status) {
-            if (status === 504) {
-                this.triggerMethod('appError', gettext('504: Server error: processing your request took too long to complete. Reload the page to try again.')); // jshint ignore:line
-            } else {
-                this.triggerMethod(
-                    'appError', gettext('Server error: your request could not be processed. Reload the page to try again.') // jshint ignore:line
-                );
-            }
-        },
-
-        handleNetworkError: function () {
-            this.triggerMethod(
-                'appError', gettext('Network error: your request could not be processed. Reload the page to try again.')
-            );
-        },
-
-        handleSync: function () {
-            this.triggerMethod('clearError');
+            eventTransformers = {
+                serverError: LearnerUtils.EventTransformers.serverErrorToAppError,
+                networkError: LearnerUtils.EventTransformers.networkErrorToAppError,
+                sync: LearnerUtils.EventTransformers.syncToClearError
+            };
+            LearnerUtils.mapEvents(this.options.collection, eventTransformers, this);
+            LearnerUtils.mapEvents(this.options.courseMetadata, eventTransformers, this);
         },
 
         onBeforeShow: function () {

--- a/analytics_dashboard/static/apps/learners/templates/chart-loading.underscore
+++ b/analytics_dashboard/static/apps/learners/templates/chart-loading.underscore
@@ -1,0 +1,9 @@
+<div class="loading">
+    <div class="analytics-chart-container">
+       <div class="analytics-chart">
+           <div class="loading-container">
+                <p class="text-center"><i class="fa fa-spinner fa-spin fa-lg" aria-hidden="true"></i> <%- loadingText %></p>
+            </div>
+        </div>
+    </div>
+</div>

--- a/analytics_dashboard/static/apps/learners/templates/engagement-timeline.underscore
+++ b/analytics_dashboard/static/apps/learners/templates/engagement-timeline.underscore
@@ -1,1 +1,3 @@
-<div class="learner-engagement-timeline analytics-chart"></div>
+<div class="analytics-chart-container">
+    <div class="learner-engagement-timeline analytics-chart"></div>
+</div>

--- a/analytics_dashboard/static/apps/learners/templates/engagement-timeline.underscore
+++ b/analytics_dashboard/static/apps/learners/templates/engagement-timeline.underscore
@@ -1,0 +1,1 @@
+<div class="learner-engagement-timeline analytics-chart"></div>

--- a/analytics_dashboard/static/apps/learners/templates/learner-detail.underscore
+++ b/analytics_dashboard/static/apps/learners/templates/learner-detail.underscore
@@ -1,0 +1,1 @@
+<div class="learner-engagement-timeline-container analytics-chart-container"></div>

--- a/analytics_dashboard/static/apps/learners/templates/learner-detail.underscore
+++ b/analytics_dashboard/static/apps/learners/templates/learner-detail.underscore
@@ -1,1 +1,1 @@
-<div class="learner-engagement-timeline-container analytics-chart-container"></div>
+<div class="learner-engagement-timeline-container"></div>

--- a/analytics_dashboard/static/js/test/specs/announcement-view-spec.js
+++ b/analytics_dashboard/static/js/test/specs/announcement-view-spec.js
@@ -37,7 +37,7 @@ define(['views/announcement-view', 'jquery', 'underscore'], function (Announceme
             var server;
 
             beforeEach(function () {
-                server = sinon.fakeServer.create(); // jshint ignore:line
+                server = sinon.fakeServer.create();
                 view.dismiss();
             });
 

--- a/analytics_dashboard/static/js/views/attribute-listener-view.js
+++ b/analytics_dashboard/static/js/views/attribute-listener-view.js
@@ -8,17 +8,38 @@ define(['backbone'],
          * view.
          */
         var AttributeListenerView = Backbone.View.extend({
+            /**
+             * Initializes an AttributeListenerView.
+             *
+             * @param options an options object containing the following keys:
+             *   - modelAttribute (String) the attribute on the model which the
+             *     view should react to
+             *   - isDataAvailable (Function) an optional function which, if
+             *     provided, specifies how to determine if the model has data.
+             *     It is bound to the context of this view.  If not provided,
+             *     this view simply checks for the presence of
+             *     'model.modelAttribute' on the model.
+             */
             initialize: function (options) {
                 var self = this;
+                this.options = options || {};
                 self.modelAttribute = options.modelAttribute;
                 self.listenTo(self.model, 'change:' + self.modelAttribute, self.render);
             },
 
             renderIfDataAvailable: function () {
                 var self = this;
-                if (self.model.has(self.modelAttribute)) {
+                if (self.isDataAvailable()) {
                     self.render();
                 }
+            },
+
+            isDataAvailable: function () {
+                var isDataAvailableFunc = this.options.isDataAvailable;
+                if (typeof isDataAvailableFunc === 'function') {
+                    return isDataAvailableFunc.call(this);
+                }
+                return this.model.has(this.modelAttribute);
             },
 
             /**

--- a/analytics_dashboard/static/js/views/attribute-listener-view.js
+++ b/analytics_dashboard/static/js/views/attribute-listener-view.js
@@ -1,58 +1,62 @@
-define(['backbone'],
-    function (Backbone) {
-        'use strict';
+define([
+    'backbone',
+    'underscore'
+], function (
+    Backbone,
+    _
+) {
+    'use strict';
+
+    /**
+     * This base view listens for a change in a model attribute and calls
+     * render() when the attribute changes.  By default, it clears out the
+     * view.
+     */
+    var AttributeListenerView = Backbone.View.extend({
+        /**
+         * Initializes an AttributeListenerView.
+         *
+         * It's recommended that the view's model implements a 'hasData'
+         * function, which specifies when the model has data to show.  If
+         * 'model.hasData()' is not implemented, this view simply checks for
+         * the presence of 'model.modelAttribute' on the model.
+         *
+         * @param options an options object containing the following keys:
+         *   - modelAttribute (String) the attribute on the model which the
+         *     view should react to
+         */
+        initialize: function (options) {
+            var self = this;
+            this.options = options || {};
+            self.modelAttribute = options.modelAttribute;
+            self.listenTo(self.model, 'change:' + self.modelAttribute, self.render);
+        },
+
+        renderIfDataAvailable: function () {
+            var self = this;
+            if (self.isDataAvailable()) {
+                self.render();
+            }
+        },
+
+        isDataAvailable: function () {
+            var isDataAvailableFunc = this.model.hasData;
+            if (_.isFunction(isDataAvailableFunc)) {
+                return isDataAvailableFunc.call(this.model);
+            }
+            return this.model.has(this.modelAttribute);
+        },
 
         /**
-         * This base view listens for a change in a model attribute and calls
-         * render() when the attribute changes.  By default, it clears out the
-         * view.
+         * Clears out the view.
          */
-        var AttributeListenerView = Backbone.View.extend({
-            /**
-             * Initializes an AttributeListenerView.
-             *
-             * @param options an options object containing the following keys:
-             *   - modelAttribute (String) the attribute on the model which the
-             *     view should react to
-             *   - isDataAvailable (Function) an optional function which, if
-             *     provided, specifies how to determine if the model has data.
-             *     It is bound to the context of this view.  If not provided,
-             *     this view simply checks for the presence of
-             *     'model.modelAttribute' on the model.
-             */
-            initialize: function (options) {
-                var self = this;
-                this.options = options || {};
-                self.modelAttribute = options.modelAttribute;
-                self.listenTo(self.model, 'change:' + self.modelAttribute, self.render);
-            },
+        render: function () {
+            var self = this;
+            self.$el.empty();
+            return self;
+        }
 
-            renderIfDataAvailable: function () {
-                var self = this;
-                if (self.isDataAvailable()) {
-                    self.render();
-                }
-            },
+    });
 
-            isDataAvailable: function () {
-                var isDataAvailableFunc = this.options.isDataAvailable;
-                if (typeof isDataAvailableFunc === 'function') {
-                    return isDataAvailableFunc.call(this);
-                }
-                return this.model.has(this.modelAttribute);
-            },
-
-            /**
-             * Clears out the view.
-             */
-            render: function () {
-                var self = this;
-                self.$el.empty();
-                return self;
-            }
-
-        });
-
-        return AttributeListenerView;
-    }
-);
+    return AttributeListenerView;
+});

--- a/analytics_dashboard/static/js/views/chart-view.js
+++ b/analytics_dashboard/static/js/views/chart-view.js
@@ -17,6 +17,28 @@ define(['d3', 'jquery', 'nvd3', 'underscore', 'utils/utils', 'views/attribute-li
                 }
             ),
 
+            /**
+             * Initializes a ChartView.
+             *
+             * @param options (Object) an object specifying view parameters.
+             * This options hash must include:
+             *  - trends (Array of Objects) defines timeline trends:
+             *      [{
+             *          key: str,   // key for data lookup
+             *          title: str, // display name (should be translated)
+             *          type: str   // data type
+             *      }, ...]
+             *  - x (Object) defines how to find x axis data:
+             *      {
+             *          title: str, // display name (translated) for the X axis
+             *          key: str    // key for the data lookup
+             *      }
+             *  - y (Object) defines how to find y axis data:
+             *      {
+             *          title: str // display name (translated) for the X axis
+             *          key: str   // key for the data lookup
+             *      }
+             */
             initialize: function (options) {
                 AttributeListenerView.prototype.initialize.call(this, options);
                 var self = this;

--- a/analytics_dashboard/static/js/views/chart-view.js
+++ b/analytics_dashboard/static/js/views/chart-view.js
@@ -30,6 +30,21 @@ define(['d3', 'jquery', 'nvd3', 'underscore', 'utils/utils', 'views/attribute-li
              * Returns an array of maps of the trend data passed to nvd3 for
              * rendering.  The map consists of the trend data as 'values' and
              * the trend title as 'key'.
+             *
+             * Part of the contract is that
+             * 'this.model.get(this.options.modelAttribute)' has a particular
+             * structure: it is an array of objects, where each object
+             * represents a tick in the chart.  Each object contains key/value
+             * pairs for each trend as well as a key/value pair which maps the x
+             * axis name to the value for that particular tick.  For example:
+             *   this.options.modelAttribute -> [
+             *       {
+             *           day: '2000-01-01', // the x-axis in this example
+             *           someTrend: 4,      // a trend value
+             *           anotherTrend: 22   // another trend value
+             *       },
+             *       ...
+             *   ]
              */
             assembleTrendData: function () {
                 var self = this,

--- a/analytics_dashboard/static/js/views/trends-view.js
+++ b/analytics_dashboard/static/js/views/trends-view.js
@@ -2,7 +2,42 @@ define(['moment', 'nvd3', 'underscore', 'views/chart-view'],
     function (moment, nvd3, _, ChartView) {
         'use strict';
 
+        /**
+         * TrendsView renders several threads of timeline data over a period of
+         * time on the x axis.
+         */
         var TrendsView = ChartView.extend({
+
+            /**
+             * Initializes a TrendsView.
+             *
+             * @param options (Object) an object specifying view parameters.
+             * In addition to parameters passed to 'ChartView', this options
+             * hash must include:
+             *  - trends (Array of Objects) defines timeline trends:
+             *      [{
+             *          key: str,   // key for data lookup
+             *          title: str, // display name (should be translated)
+             *          type: str   // data type
+             *      }, ...]
+             *  - x (Object) defines how to find x axis data:
+             *      {
+             *          title: str, // display name (translated) for the X axis
+             *          key: str    // key for the data lookup
+             *      }
+             *  - y (Object) defines how to find y axis data:
+             *      {
+             *          title: str // display name (translated) for the X axis
+             *          key: str   // key for the data lookup
+             *      }
+             */
+            initialize: function (options) {
+                ChartView.prototype.initialize.call(this, options);
+            },
+
+            defaults: _.extend({}, ChartView.prototype.defaults, {
+                showLegend: false
+            }),
 
             getChart: function () {
                 return nvd3.models.lineChart();
@@ -12,7 +47,7 @@ define(['moment', 'nvd3', 'underscore', 'views/chart-view'],
                 ChartView.prototype.initChart.call(this, chart);
                 var self = this;
 
-                chart.showLegend(false)
+                chart.showLegend(this.options.showLegend)
                     .useInteractiveGuideline(true);
 
                 if (_(self.options).has('interactiveTooltipHeaderTemplate')) {

--- a/analytics_dashboard/static/js/views/trends-view.js
+++ b/analytics_dashboard/static/js/views/trends-view.js
@@ -8,33 +8,6 @@ define(['moment', 'nvd3', 'underscore', 'views/chart-view'],
          */
         var TrendsView = ChartView.extend({
 
-            /**
-             * Initializes a TrendsView.
-             *
-             * @param options (Object) an object specifying view parameters.
-             * In addition to parameters passed to 'ChartView', this options
-             * hash must include:
-             *  - trends (Array of Objects) defines timeline trends:
-             *      [{
-             *          key: str,   // key for data lookup
-             *          title: str, // display name (should be translated)
-             *          type: str   // data type
-             *      }, ...]
-             *  - x (Object) defines how to find x axis data:
-             *      {
-             *          title: str, // display name (translated) for the X axis
-             *          key: str    // key for the data lookup
-             *      }
-             *  - y (Object) defines how to find y axis data:
-             *      {
-             *          title: str // display name (translated) for the X axis
-             *          key: str   // key for the data lookup
-             *      }
-             */
-            initialize: function (options) {
-                ChartView.prototype.initialize.call(this, options);
-            },
-
             defaults: _.extend({}, ChartView.prototype.defaults, {
                 showLegend: false
             }),


### PR DESCRIPTION
This PR implements the Learner Detail page, which currently only consists of the Learner Engagement Timeline.
- Clicking on a user in the table now takes you to their detail page
- The detail page renders a timeline trends chart of their engagement

@dsjen please review
