### PR TITLE
Display standard table error if learner service unavailable.

### DIFF
--- a/analytics_dashboard/courses/templates/courses/learners.html
+++ b/analytics_dashboard/courses/templates/courses/learners.html
@@ -14,21 +14,27 @@ View of individual learners within a course.
 
 {% block uncompressed_javascript %}
     {{ block.super }}
-    <script>
-     require(['load/init-page', 'learners/js/app'], function (page, LearnersApp) {
-         var app = new LearnersApp({
-             courseId: '{{ course_id }}',
-             containerSelector: '.learners-app-container',
-             learnerListJson: {{ learner_list_json | escape_json }},
-             learnerListUrl: '{{ learner_list_url }}',
-             courseLearnerMetadataJson: {{ course_learner_metadata_json | escape_json }},
-             courseLearnerMetadataUrl: '{{ course_learner_metadata_url }}'
+    {% if not show_error %}
+        <script>
+         require(['load/init-page', 'learners/js/app'], function (page, LearnersApp) {
+             var app = new LearnersApp({
+                 courseId: '{{ course_id }}',
+                 containerSelector: '.learners-app-container',
+                 learnerListJson: {{ learner_list_json | escape_json }},
+                 learnerListUrl: '{{ learner_list_url }}',
+                 courseLearnerMetadataJson: {{ course_learner_metadata_json | escape_json }},
+                 courseLearnerMetadataUrl: '{{ course_learner_metadata_url }}'
+             });
+             app.start();
          });
-         app.start();
-     });
-    </script>
+        </script>
+    {% endif %}
 {% endblock uncompressed_javascript %}
 
 {% block child_content %}
-    <div class="learners-app-container"></div>
+    {% if show_error %}
+        {% show_table_error %}
+    {% else %}
+        <div class="learners-app-container"></div>
+    {% endif %}
 {% endblock %}

--- a/analytics_dashboard/courses/tests/test_views/test_learners.py
+++ b/analytics_dashboard/courses/tests/test_views/test_learners.py
@@ -18,6 +18,7 @@ from courses.tests.test_views import DEMO_COURSE_ID, ViewTestMixin
 @httpretty.activate
 @ddt
 class LearnersViewTests(ViewTestMixin, SwitchMixin, TestCase):
+    TABLE_ERROR_TEXT = 'We are unable to load this table.'
     viewname = 'courses:learners:learners'
 
     @classmethod
@@ -79,7 +80,9 @@ class LearnersViewTests(ViewTestMixin, SwitchMixin, TestCase):
         self._assert_context(response, {
             'learner_list_json': learners_payload,
             'course_learner_metadata_json': course_metadata_payload,
+            'show_error': False
         })
+        self.assertNotContains(response, self.TABLE_ERROR_TEXT)
 
     @data(Timeout, ConnectionError, ValueError)
     def test_data_api_error(self, RequestExceptionClass):
@@ -95,7 +98,9 @@ class LearnersViewTests(ViewTestMixin, SwitchMixin, TestCase):
                 self._assert_context(response, {
                     'learner_list_json': {},
                     'course_learner_metadata_json': {},
+                    'show_error': True,
                 })
+                self.assertContains(response, self.TABLE_ERROR_TEXT, 1)
                 lc.check(
                     ('courses.views.learners', 'ERROR', 'Failed to reach the Learner List endpoint'),
                     ('courses.views.learners', 'ERROR', 'Failed to reach the Course Learner Metadata endpoint')

--- a/analytics_dashboard/courses/views/learners.py
+++ b/analytics_dashboard/courses/views/learners.py
@@ -51,4 +51,7 @@ class LearnersView(CourseTemplateWithNavView):
                 logger.exception(error_message)
                 context[data_name] = {}
 
+        # Only show roster if data is avilable for it; otherwise, an error will be displayed.
+        context['show_error'] = False if context['learner_list_json'] else True
+
         return context


### PR DESCRIPTION
This checks to see if learner data could be fetched initially.  If not, the standard table error message will be displayed:

![screen shot 2016-03-29 at 11 14 25 am](https://cloud.githubusercontent.com/assets/5265058/14113093/76102a1e-f59f-11e5-87b8-2c0c8ed43702.png)

@dan-f, please review.
