### PR TITLE
Added loading view for engagement timeline.

### DIFF
--- a/analytics_dashboard/static/apps/learners/js/models/engagement-timeline.js
+++ b/analytics_dashboard/static/apps/learners/js/models/engagement-timeline.js
@@ -36,7 +36,12 @@ define([
         fetch: function () {
             return Backbone.Model.prototype.fetch.apply(this, arguments)
                 .fail(LearnerUtils.handleAjaxFailure.bind(this));
+        },
+
+        hasData: function() {
+            return this.get('days').length > 0;
         }
+
     });
 
     return EngagementTimelineModel;

--- a/analytics_dashboard/static/apps/learners/js/spec/engagement-timeline-spec.js
+++ b/analytics_dashboard/static/apps/learners/js/spec/engagement-timeline-spec.js
@@ -92,7 +92,8 @@ define([
         });
 
         it('can render an engagement timeline', function () {
-            var model, view;
+            var model,
+                view;
             model = getTimelineModel();
             view = new EngagementTimelineView({
                 model: model,

--- a/analytics_dashboard/static/apps/learners/js/spec/learner-detail-spec.js
+++ b/analytics_dashboard/static/apps/learners/js/spec/learner-detail-spec.js
@@ -14,8 +14,26 @@ define([
             setFixtures('<div class="' + fixtureClass.slice(1) + '"></div>');
         });
 
+        it('renders a loading view first', function () {
+            var engagementTimelineModel = new EngagementTimelineModel(),
+                detailView = new LearnerDetailView({
+                    engagementTimelineModel: engagementTimelineModel,
+                    el: fixtureClass
+                });
+
+            detailView.render().onBeforeShow();
+            expect(detailView.$('.loading-container')).toExist();
+            expect(detailView.$('.learner-engagement-timeline')).not.toExist();
+
+            engagementTimelineModel.trigger('sync');
+            expect(detailView.$('.loading-container')).not.toExist();
+            expect(detailView.$('.learner-engagement-timeline')).toExist();
+        });
+
         it('renders a learner engagement timeline', function () {
-            var engagementTimelineModel, detailView;
+            var engagementTimelineModel,
+                detailView;
+
             engagementTimelineModel = new EngagementTimelineModel({
                 days: [{
                     date: '2016-01-01',
@@ -30,6 +48,7 @@ define([
                 el: fixtureClass
             });
             detailView.render().onBeforeShow();
+            expect(detailView.$('.loading-container')).not.toExist();
             expect(detailView.$('.learner-engagement-timeline')).toExist();
         });
     });

--- a/analytics_dashboard/static/apps/learners/js/spec/loading-view-spec.js
+++ b/analytics_dashboard/static/apps/learners/js/spec/loading-view-spec.js
@@ -1,0 +1,31 @@
+define([
+    'backbone',
+    'learners/js/views/loading-view',
+    'underscore'
+], function (Backbone, LoadingView, _) {
+    'use strict';
+
+    describe('LoadingView', function () {
+
+        var fixtureClass = '.loading-fixture';
+
+        beforeEach(function () {
+            setFixtures('<div class="' + fixtureClass.slice(1) + '"></div>');
+        });
+
+        it('shows and hides loading template', function () {
+            var loadingView = new LoadingView({
+                model: new Backbone.Model(),
+                el: fixtureClass,
+                template: _.template('<div class="loading"><%= loadingText %></div>'),
+                successView: new Backbone.View()
+            });
+
+            loadingView.render().onBeforeShow();
+            expect(loadingView.$('.loading')).toContainText('Loading...');
+            loadingView.model.trigger('sync');
+            expect(loadingView.$('.loading')).not.toContainText('Loading...');
+        });
+
+    });
+});

--- a/analytics_dashboard/static/apps/learners/js/views/engagement-timeline.js
+++ b/analytics_dashboard/static/apps/learners/js/views/engagement-timeline.js
@@ -21,7 +21,7 @@ define([
                 model: this.model,
                 modelAttribute: 'days',
                 isDataAvailable: function () {
-                    return this.model.get('days').length > 0;
+                    return this.model.hasData();
                 },
                 trends: [{
                     key: 'discussion_contributions',

--- a/analytics_dashboard/static/apps/learners/js/views/learner-detail.js
+++ b/analytics_dashboard/static/apps/learners/js/views/learner-detail.js
@@ -1,13 +1,17 @@
 define([
     'learners/js/utils',
     'learners/js/views/engagement-timeline',
+    'learners/js/views/loading-view',
     'marionette',
+    'text!learners/templates/chart-loading.underscore',
     'text!learners/templates/learner-detail.underscore',
     'underscore'
 ], function (
     LearnerUtils,
     LearnerEngagementTimelineView,
+    LoadingView,
     Marionette,
+    chartLoadingTemplate,
     learnerDetailTemplate,
     _
 ) {
@@ -17,7 +21,7 @@ define([
         className: 'learner-detail-container',
         template: _.template(learnerDetailTemplate),
         regions: {
-            engagementTimeline: '.learner-engagement-timeline-container.analytics-chart-container'
+            engagementTimeline: '.learner-engagement-timeline-container'
         },
         initialize: function (options) {
             Marionette.LayoutView.prototype.initialize.call(this, options);
@@ -29,10 +33,26 @@ define([
                 sync: LearnerUtils.EventTransformers.syncToClearError
             }, this);
         },
+        onAppError: function () {
+            this.removeRegion('engagementTimeline');
+        },
         onBeforeShow: function () {
-            this.showChildView('engagementTimeline', new LearnerEngagementTimelineView({
-                model: this.options.engagementTimelineModel
-            }));
+            var timelineModel = this.options.engagementTimelineModel,
+                timelineView = new LearnerEngagementTimelineView({
+                    model: timelineModel
+                }),
+                mainView = timelineView;
+
+            if (!timelineModel.hasData()) {
+                // instead of showing the timeline direction, show a loading view
+                mainView = new LoadingView({
+                    model: timelineModel,
+                    template: _.template(chartLoadingTemplate),
+                    successView: timelineView
+                });
+            }
+
+            this.showChildView('engagementTimeline', mainView);
         }
     });
 

--- a/analytics_dashboard/static/apps/learners/js/views/loading-view.js
+++ b/analytics_dashboard/static/apps/learners/js/views/loading-view.js
@@ -1,0 +1,34 @@
+define([
+    'marionette'
+], function (Marionette) {
+    'use strict';
+
+    /**
+     * Displays loading spinner.  Upon a successful load, the view will be
+     * replaced with the "success" view.
+     *
+     * This view expects a template with a "loading" class and "loadingText"
+     * template variable.
+     */
+    var LoadingView = Marionette.LayoutView.extend({
+
+        templateHelpers: function () {
+            return {
+                // Translators: This message indicates content is loading in the page.
+                loadingText: gettext('Loading...')
+            };
+        },
+
+        regions: {
+            loadingRegion: '.loading'
+        },
+
+        onBeforeShow: function () {
+            this.listenTo(this.model, 'sync', function () {
+                this.showChildView('loadingRegion', this.options.successView);
+            });
+        }
+    });
+
+    return LoadingView;
+});

--- a/analytics_dashboard/static/apps/learners/templates/chart-loading.underscore
+++ b/analytics_dashboard/static/apps/learners/templates/chart-loading.underscore
@@ -1,0 +1,9 @@
+<div class="loading">
+    <div class="analytics-chart-container">
+       <div class="analytics-chart">
+           <div class="loading-container">
+                <p class="text-center"><i class="fa fa-spinner fa-spin fa-lg" aria-hidden="true"></i> <%- loadingText %></p>
+            </div>
+        </div>
+    </div>
+</div>

--- a/analytics_dashboard/static/apps/learners/templates/engagement-timeline.underscore
+++ b/analytics_dashboard/static/apps/learners/templates/engagement-timeline.underscore
@@ -1,1 +1,3 @@
-<div class="learner-engagement-timeline analytics-chart"></div>
+<div class="analytics-chart-container">
+    <div class="learner-engagement-timeline analytics-chart"></div>
+</div>

--- a/analytics_dashboard/static/apps/learners/templates/learner-detail.underscore
+++ b/analytics_dashboard/static/apps/learners/templates/learner-detail.underscore
@@ -1,1 +1,1 @@
-<div class="learner-engagement-timeline-container analytics-chart-container"></div>
+<div class="learner-engagement-timeline-container"></div>


### PR DESCRIPTION
This adds a loading view to the engagement timeline, displaying a spinner initially.  When data is loaded the spinner is replaced by the timeline, or upon error, the loader is removed.  The generic loading view takes a loading template (e.g. chart loading) and replace it with a "success" view upon data load.

@dan-f please review.
