### PR TITLE
Persist search string, cohort filters when navigating back/forard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,6 @@ validate_python: test.requirements test_python quality
 validate_js: requirements.js
 	$(NODE_BIN)/gulp test
 	$(NODE_BIN)/gulp lint
-	$(NODE_BIN)/gulp jscs
 
 validate: validate_python validate_js
 

--- a/analytics_dashboard/static/apps/learners/js/spec/roster-view-spec.js
+++ b/analytics_dashboard/static/apps/learners/js/spec/roster-view-spec.js
@@ -57,7 +57,7 @@ define([
             );
             rosterView = new LearnerRosterView({
                 collection: collection,
-                courseMetadata: new CourseMetadataModel(options.courseMetadata),
+                courseMetadata: options.courseMetadataModel || new CourseMetadataModel(options.courseMetadata),
                 el: '.' + fixtureClass
             }).render();
             rosterView.onBeforeShow();
@@ -505,6 +505,23 @@ define([
                     getLastRequest().respond(200, {}, JSON.stringify(getResponseBody(1, 1)));
                     expect($('option[value="' + cohort + '"]')).toBeSelected();
                 };
+
+                it('renders the current cohort filter', function () {
+                    var courseMetadataModel,
+                        collection,
+                        rosterView;
+                    courseMetadataModel = new CourseMetadataModel({cohorts: {
+                        'Cohort A': 1,
+                        'Cohort B': 2
+                    }});
+                    collection = new LearnerCollection();
+                    collection.setFilterField('cohort', 'Cohort A');
+                    rosterView = getRosterView({
+                        courseMetadataModel: courseMetadataModel,
+                        collection: collection
+                    });
+                    expect(rosterView.$('.learners-cohort-filter option[value="Cohort A"]')).toBeSelected();
+                });
 
                 it('does not render when the course contains no cohorts', function () {
                     var rosterView = getRosterView({courseMetadata: {cohorts: {}}});

--- a/analytics_dashboard/static/apps/learners/js/spec/roster-view-spec.js
+++ b/analytics_dashboard/static/apps/learners/js/spec/roster-view-spec.js
@@ -48,12 +48,15 @@ define([
         };
 
         getRosterView = function (options) {
+            var collection,
+                rosterView;
             options = options || {};
-            var rosterView = new LearnerRosterView({
-                collection: new LearnerCollection(
-                    options.collectionResponse,
-                    _.extend({url: 'test-url'}, options.collectionOptions)
-                ),
+            collection = options.collection || new LearnerCollection(
+                options.collectionResponse,
+                _.extend({url: 'test-url'}, options.collectionOptions)
+            );
+            rosterView = new LearnerRosterView({
+                collection: collection,
                 courseMetadata: new CourseMetadataModel(options.courseMetadata),
                 el: '.' + fixtureClass
             }).render();
@@ -427,6 +430,17 @@ define([
                     text_search: searchString
                 }));
             };
+
+            it('renders the current search string', function () {
+                var collection,
+                    rosterView,
+                    searchString;
+                searchString = 'search string';
+                collection = new LearnerCollection();
+                collection.setSearchString(searchString);
+                rosterView = getRosterView({collection: collection});
+                expect(rosterView.$('#search-learners')).toHaveValue(searchString);
+            });
 
             it('can search for arbitrary strings', function () {
                 var searchString = 'search string';

--- a/analytics_dashboard/static/apps/learners/js/views/roster-view.js
+++ b/analytics_dashboard/static/apps/learners/js/views/roster-view.js
@@ -262,6 +262,10 @@ define([
             return _.extend(Backgrid.Extension.ServerSideFilter.prototype.events, {'click .search': 'search'});
         },
         template: _.template(learnerSearchTemplate, null, {variable: null}),
+        initialize: function (options) {
+            this.value = options.collection.searchString;
+            Backgrid.Extension.ServerSideFilter.prototype.initialize.call(this, options);
+        },
         render: function () {
             this.$el.empty().append(this.template({
                 name: this.name,

--- a/analytics_dashboard/static/apps/learners/templates/cohort-filter.underscore
+++ b/analytics_dashboard/static/apps/learners/templates/cohort-filter.underscore
@@ -4,9 +4,10 @@
     <%- selectDisplayName %>
 </label>
 <select id="cohort-filter" class="form-control">
-    <option selected value=""><%- allCohortsSelectedMessage %></option>
-    <% _.each(cohorts, function (cohortData, cohortName) { %>
-        <option value="<%- cohortName %>"><%- cohortData.displayName %></option>
+    <% _.each(cohorts, function (cohort) { %>
+        <option value="<%- cohort.cohortName %>" <% if (cohort.selected) { %> selected <% } %>>
+            <%- cohort.displayName %>
+        </option>
     <% }); %>
 </select>
 <% } %>

--- a/analytics_dashboard/static/apps/learners/templates/search.underscore
+++ b/analytics_dashboard/static/apps/learners/templates/search.underscore
@@ -4,7 +4,9 @@
         <input id="search-learners"
             class="form-control"
             type="search"
-            <% if (placeholder) { %> placeholder="<%- placeholder %>" <% } %> name="<%- name %>"
+            <% if (placeholder) { %> placeholder="<%- placeholder %>" <% } %>
+            name="<%- name %>"
+            <% if (value) { %> value="<%- value %>" <% } %>
         />
         <a href="#" type="button" class="clear btn" data-backgrid-action="clear">
             <i class="fa fa-times" aria-hidden="true"></i>

--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
     "font-awesome": "~4.2.0",
     "natural-sort": "overset/javascript-natural-sort#dbf4ca259b327a488bd1d7897fd46d80c414a7e0",
     "cldr-data": "26.0.3",
-    "edx-ui-toolkit": "~0.5.0",
+    "edx-ui-toolkit": "~0.10.0",
     "marionette": "~2.4.4",
     "uri.js": "1.17",
     "backgrid": "^0.3.5",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -44,11 +44,7 @@
         return gulp.src(paths.lint)
             .pipe(jshint())
             .pipe(jshint.reporter('default'))
-            .pipe(jshint.reporter('fail'));
-    });
-
-    gulp.task('jscs', function () {
-        return gulp.src(paths.lint)
+            .pipe(jshint.reporter('fail'))
             .pipe(jscs());
     });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -59,7 +59,7 @@
         runKarma(paths.karmaConf, cb, {
             singleRun: false,
             autoWatch: true,
-            browsers: ['Firefox'],
+            browsers: ['Chrome'],
             reporters: ['kjhtml']
         });
     });

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -55,7 +55,7 @@ module.exports = function (config) {
             'karma-phantomjs-launcher',
             'karma-coverage',
             'karma-sinon',
-            'karma-firefox-launcher'
+            'karma-chrome-launcher'
         ],
 
         // test results reporter to use

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "jscs": "^1.10.0",
     "karma": "^0.12.16",
     "karma-coverage": "^0.2.6",
-    "karma-firefox-launcher": "^0.1.7",
+    "karma-chrome-launcher": "^0.2.3",
     "karma-jasmine": "^0.3.6",
     "karma-jasmine-jquery": "^0.1.1",
     "karma-jasmine-html-reporter": "^0.2.0",


### PR DESCRIPTION
Make sure that when the user executes a search or filters by cohort, clicks on a learner, and then goes back, they still see the active search in the search widget.

[AN-7055](https://openedx.atlassian.net/browse/AN-7055)

@dsjen FYI
