### PR TITLE
Updated disclosure/collapsible css.

### DIFF
--- a/analytics_dashboard/courses/templates/courses/_video_preview.html
+++ b/analytics_dashboard/courses/templates/courses/_video_preview.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 
-<div class="module-preview-collapsible container-fluid" data-collapse-text="{{ collapse_text }}" data-expand-text="{{ expand_text }}">
+<div class="module-preview-disclosure container-fluid" data-collapse-text="{{ collapse_text }}" data-expand-text="{{ expand_text }}">
     <div class="row">
         <div class="col-xs-12">
             <span class="pull-right">
@@ -11,11 +11,11 @@
             </span>
             <div>
                 {# The aria-expanded attribute will be updated via edx-ui-toolkit CollapsibleView. #}
-                <button aria-expanded="false" aria-controls="collapsible-preview" class="collapsible-toggle-text center-block btn btn-default">{{ collapse_text }}</button>
+                <button aria-expanded="false" aria-controls="disclosure-preview" class="disclosure-toggle center-block btn btn-default">{{ collapse_text }}</button>
             </div>
         </div>
 
-        <div id="collapsible-preview" class="col-xs-12 collapsible-content">
+        <div id="disclosure-preview" class="col-xs-12 disclosure-target">
             <div id="module-loading">
                 {% include "loading.html" %}
             </div>

--- a/analytics_dashboard/static/js/config.js
+++ b/analytics_dashboard/static/js/config.js
@@ -37,7 +37,7 @@ require.config({
         'cldr-data': 'bower_components/cldr-data',
         globalize: 'bower_components/globalize/dist/globalize',
         globalization: 'js/utils/globalization',
-        collapsible: 'bower_components/edx-ui-toolkit/src/js/disclosure/disclosure-view',
+        disclosure: 'bower_components/edx-ui-toolkit/src/js/disclosure/disclosure-view',
         marionette: 'bower_components/marionette/lib/core/backbone.marionette.min',
         uitk: 'bower_components/edx-ui-toolkit/src',
         // URI and its dependencies

--- a/analytics_dashboard/static/js/engagement-video-timeline-main.js
+++ b/analytics_dashboard/static/js/engagement-video-timeline-main.js
@@ -5,8 +5,8 @@
 require(['vendor/domReady!', 'load/init-page'], function(doc, page) {
     'use strict';
 
-    require(['collapsible', 'underscore', 'views/data-table-view', 'views/iframe-view', 'views/stacked-timeline-view'],
-        function (CollapsibleView, _, DataTableView, IFrameView, StackedTimelineView) {
+    require(['disclosure', 'underscore', 'views/data-table-view', 'views/iframe-view', 'views/stacked-timeline-view'],
+        function (DisclosureView, _, DataTableView, IFrameView, StackedTimelineView) {
 
             var courseModel = page.models.courseModel,
                 timelineSettings = [
@@ -31,8 +31,8 @@ require(['vendor/domReady!', 'load/init-page'], function(doc, page) {
 
             tableColumns = tableColumns.concat(timelineSettings);
 
-            new CollapsibleView({
-                el: '.module-preview-collapsible'
+            new DisclosureView({
+                el: '.module-preview-disclosure'
             });
 
             // loading the iframe blocks content, so load it after the rest of the page loads

--- a/analytics_dashboard/static/sass/_developer.scss
+++ b/analytics_dashboard/static/sass/_developer.scss
@@ -615,7 +615,7 @@ table.dataTable thead th.sorting_desc:after {
   border-top: none;
 }
 
-.module-preview-collapsible {
+.module-preview-disclosure {
   // the video preview height can be variable, so use media queries to mimic height changes
   .video-preview {
     width: 100%;
@@ -631,12 +631,12 @@ table.dataTable thead th.sorting_desc:after {
     }
   }
 
-  .collapsible-toggle-text {
+  .disclosure-toggle {
     // moving the text down just a tad so that it's in line with the next/previous buttons
     padding-top: 8px;
   }
 
-  .collapsible-content {
+  .disclosure-target {
     // initially collapsed
     display: none;
   }


### PR DESCRIPTION
This fixes video preview not working by updated css naming of "collapsible" to "disclosure" in both the sass and in the video timeline css.

@dan-f please review.
