### PR TITLE
Update learner-analytics table styles to be more consistent.

### DIFF
--- a/analytics_dashboard/static/sass/_config-variables.scss
+++ b/analytics_dashboard/static/sass/_config-variables.scss
@@ -193,7 +193,7 @@ $brand-info: $color-status;
 $brand-warning: $color-warning;
 $brand-danger: $color-error;
 
-// scaffoling
+// scaffolding
 $body-bg: $edx-gray-l2;
 $text-color: $gray-d2;
 // $link-color: ;

--- a/analytics_dashboard/static/sass/_developer.scss
+++ b/analytics_dashboard/static/sass/_developer.scss
@@ -754,6 +754,23 @@ table.dataTable thead th.sorting_desc:after {
 }
 
 .learner-roster {
+
+  th {
+
+    font-weight: 600;
+
+    a {
+      // update header colors
+      color: $text-color;
+    }
+
+    i {
+      // makes the sort icons gray
+      color: $gray;
+    }
+
+  }
+
   .learner-engagement-cell {
     text-align: right;
   }
@@ -798,7 +815,6 @@ table.dataTable thead th.sorting_desc:after {
   }
 
   .learner-cell-above-average {
-
     color: $above-average-color;
   }
 


### PR DESCRIPTION
- Set font weight on table headers.
- Set font color on table headers to black.
# Before

![before](https://cloud.githubusercontent.com/assets/5265058/14395129/e19d8cbc-fd9d-11e5-997d-791abd1ff939.png)
# After

![after](https://cloud.githubusercontent.com/assets/5265058/14395126/df91549e-fd9d-11e5-84af-1e89f7732b89.png)

@dan-f please review
