### PR TITLE
Use master branch of data api.

### DIFF
--- a/scripts/install_analytics_data_api.sh
+++ b/scripts/install_analytics_data_api.sh
@@ -2,7 +2,6 @@
 
 git clone https://github.com/edx/edx-analytics-data-api.git
 cd edx-analytics-data-api
-git checkout learner-analytics
 pip install -q -r requirements/base.txt
 make test.install_elasticsearch
 cd -


### PR DESCRIPTION
Now that the API's learner analytics branch is merged back into master, we don't need to switch to the branch.

@dan-f, please review.
