### PR TITLE
Keep table sort icons on same line as headers

### DIFF
--- a/analytics_dashboard/static/sass/_developer.scss
+++ b/analytics_dashboard/static/sass/_developer.scss
@@ -767,6 +767,7 @@ table.dataTable thead th.sorting_desc:after {
     i {
       // makes the sort icons gray
       color: $gray;
+      display: inline;
     }
 
   }


### PR DESCRIPTION
@dsjen this makes this:

<img width="75" alt="screen shot 2016-04-15 at 4 40 35 pm" src="https://cloud.githubusercontent.com/assets/2146312/14574309/d87e287c-0328-11e6-8cf0-ae3ef2cbcbe6.png">

become this:

<img width="75" alt="screen shot 2016-04-15 at 4 41 13 pm" src="https://cloud.githubusercontent.com/assets/2146312/14574319/e7b4bb58-0328-11e6-9d58-0e14e6f3897e.png">
