### PR TITLE
Clarify name/username header in roster view

### DIFF
--- a/analytics_dashboard/static/apps/learners/common/collections/learners.js
+++ b/analytics_dashboard/static/apps/learners/common/collections/learners.js
@@ -17,7 +17,7 @@ define(function (require) {
             this.url = options.url;
             this.courseId = options.courseId;
 
-            this.registerSortableField('username', gettext('Name'));
+            this.registerSortableField('username', gettext('Name (Username)'));
             this.registerSortableField('problems_attempted', gettext('Problems Tried'));
             this.registerSortableField('problems_completed', gettext('Problems Correct'));
             this.registerSortableField('videos_viewed', gettext('Videos'));

--- a/analytics_dashboard/static/apps/learners/roster/views/base-header-cell.js
+++ b/analytics_dashboard/static/apps/learners/roster/views/base-header-cell.js
@@ -9,17 +9,33 @@ define(function (require) {
 
         baseHeaderCellTemplate = require('text!learners/roster/templates/base-header-cell.underscore'),
 
-        BaseHeaderCell;
+        BaseHeaderCell,
+        tooltips;
+
+    tooltips = {
+        username: gettext('The name and username of this learner. Click to sort by username.'),
+        problems_attempted: gettext('Number of unique problems this learner attempted.'),
+        problems_completed: gettext('Number of unique problems the learner answered correctly.'),
+        videos_viewed: gettext('Number of unique videos this learner played.'),
+        problem_attempts_per_completed: gettext('Average number of attempts per correct problem. Learners with a relatively high value compared to their peers may be struggling.'),   // jshint ignore:line
+        discussion_contributions: gettext('Number of contributions by this learner, including posts, responses, and comments.')   // jshint ignore:line
+    };
 
     BaseHeaderCell = Backgrid.HeaderCell.extend({
         attributes: {
             scope: 'col'
         },
+
         template: _.template(baseHeaderCellTemplate),
+
         initialize: function () {
             Backgrid.HeaderCell.prototype.initialize.apply(this, arguments);
             this.collection.on('backgrid:sort', this.onSort, this);
+            // Set up the tooltip
+            this.$el.attr('title', tooltips[this.column.get('name')]);
+            this.$el.tooltip({ container: '.learners-table' });
         },
+
         render: function (column, direction) {
             Backgrid.HeaderCell.prototype.render.apply(this, arguments);
             this.$el.html(this.template({
@@ -28,9 +44,11 @@ define(function (require) {
             this.renderSortState(column, direction);
             return this;
         },
+
         onSort: function (column, direction) {
             this.renderSortState(column, direction);
         },
+
         renderSortState: function (column, direction) {
             var sortIcon = this.$('i'),
                 sortDirectionMap;

--- a/analytics_dashboard/static/apps/learners/roster/views/spec/roster-spec.js
+++ b/analytics_dashboard/static/apps/learners/roster/views/spec/roster-spec.js
@@ -228,8 +228,8 @@ define(function (require) {
         describe('table headers', function() {
 
             it('has tooltips', function () {
-                // username doesn't have tooltips
-                var headersWithTips = [
+                var headerClasses = [
+                    'username',
                     'videos_viewed',
                     'problems_completed',
                     'problems_attempted',
@@ -242,7 +242,7 @@ define(function (require) {
                     collectionOptions: {parse: true}
                 });
 
-                _(headersWithTips).each(function (headerClass) {
+                _(headerClasses).each(function (headerClass) {
                     var $heading = $('th.' + headerClass).focusin(),
                         $tooltip;
 

--- a/analytics_dashboard/static/apps/learners/roster/views/table.js
+++ b/analytics_dashboard/static/apps/learners/roster/views/table.js
@@ -15,7 +15,7 @@ define(function (require) {
         learnerTableTemplate = require('text!learners/roster/templates/table.underscore'),
 
         createEngagementCell,
-        createEngagementHeaderCell,
+        EngagementHeaderCell,
         LearnerTableView;
 
     /**
@@ -62,29 +62,9 @@ define(function (require) {
      * Cell class for engagement headers, which need to be right
      * aligned.
      */
-    createEngagementHeaderCell = function (key) {
-        var tooltips = {
-            problems_attempted: gettext('Number of unique problems this learner attempted.'),
-            problems_completed: gettext('Number of unique problems the learner answered correctly.'),
-            videos_viewed: gettext('Number of unique videos this learner played.'),
-            problem_attempts_per_completed: gettext('Average number of attempts per correct problem. Learners with a relatively high value compared to their peers may be struggling.'),   // jshint ignore:line
-            discussion_contributions: gettext('Number of contributions by this learner, including posts, responses, and comments.')   // jshint ignore:line
-        };
-
-        return BaseHeaderCell.extend({
-            className: 'learner-engagement-cell',
-
-            attributes: _.extend({}, BaseHeaderCell.prototype.attributes, {
-                title: tooltips[key]
-            }),
-
-            initialize: function () {
-                BaseHeaderCell.prototype.initialize.apply(this, arguments);
-                this.$el.tooltip({ container: '.learners-table' });
-            }
-
-        });
-    };
+    EngagementHeaderCell = BaseHeaderCell.extend({
+        className: 'learner-engagement-cell',
+    });
 
     LearnerTableView = Marionette.LayoutView.extend({
         template: _.template(learnerTableTemplate),
@@ -117,7 +97,7 @@ define(function (require) {
                             significantDigits: key === 'problem_attempts_per_completed' ? 1 : 0
                         }, options);
                         column.cell = createEngagementCell(key, options);
-                        column.headerCell = createEngagementHeaderCell(key);
+                        column.headerCell = EngagementHeaderCell;
                     }
 
                     return column;


### PR DESCRIPTION
Clarifies the Name and Username header in the learner roster table.

![screen shot 2016-04-22 at 9 07 37 am](https://cloud.githubusercontent.com/assets/2146312/14742351/b0ec39c0-0869-11e6-9bcd-986749a6e14f.png)

@dsjen please review
@lamagnifica how does this copy work for you? What should I change it to?

[AN-6974](https://openedx.atlassian.net/browse/AN-6974)
