### PR TITLE
Update Learners lens copy

### DIFF
--- a/analytics_dashboard/courses/views/__init__.py
+++ b/analytics_dashboard/courses/views/__init__.py
@@ -530,7 +530,7 @@ class CourseHome(CourseTemplateWithNavView):
                 'heading': _('What are individual learners doing?'),
                 'items': [
                     {
-                        'title': _('Who is enrolled?'),
+                        'title': _("Who is engaged? Who isn't?"),
                         'view': 'courses:learners:learners',
                         'breadcrumbs': [_('All Learners')]
                     },


### PR DESCRIPTION
Update the learner lens copy on the course home page.

<img width="368" alt="screen shot 2016-04-22 at 9 14 37 am" src="https://cloud.githubusercontent.com/assets/2146312/14742575/faf887a2-086a-11e6-8db4-54b04236346d.png">

@dsjen please review
@lamagnifica and @shnayder FYI - this is the copy that you asked for :)

[AN-7011](https://openedx.atlassian.net/browse/AN-7011)
