### PR TITLE
Revert "Pulling edX packages from PyPI"

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,8 +10,6 @@ django-model-utils==1.5.0 	# BSD
 djangorestframework==3.3.1  # BSD
 django-soapbox==1.1         # BSD
 django-waffle==0.10			# BSD
-edx-ccx-keys==0.2.0
-edx-opaque-keys==0.3.1
 edx-rest-api-client>=1.5.0, <1.6.0  # Apache
 
 # other versions cause a segment fault when running compression
@@ -20,7 +18,7 @@ libsass==0.5.1              # MIT
 logutils==0.3.3				# BSD
 
 # versions above 0.2.3 introduce a breaking change
-python-social-auth==0.2.14
+python-social-auth==0.2.3
 edx-auth-backends==0.1.2    # AGPL
 
 # TODO Use the PyPi package once it is updated.
@@ -29,3 +27,6 @@ git+https://github.com/pinax/django-announcements.git@f85e690705e038a62407abe54a
 git+https://github.com/edx/django-lang-pref-middleware.git@0.1.0#egg=django-lang-pref-middleware
 git+https://github.com/edx/edx-analytics-data-api-client.git@0.6.1#egg=edx-analytics-data-api-client==0.6.1  # edX
 git+https://github.com/edx/i18n-tools.git@0d7847f9dfa2281640527b4dc51f5854f950f9b7#egg=i18n_tools
+git+https://github.com/edx/opaque-keys.git@d45d0bd8d64c69531be69178b9505b5d38806ce0#egg=opaque-keys
+# custom opaque-key implementations for ccx
+git+https://github.com/jazkarta/ccx-keys.git@e6b03704b1bb97c1d2f31301ecb4e3a687c536ea#egg=ccx-keys


### PR DESCRIPTION
This reverts commit beab527fa77ec98e711608c92539002ebe1fdc2d, which
introduced a regression.

@clintonb @dsjen FYI. I'm going to merge once tests pass.
