### PR TITLE
Implement active filters controls

### DIFF
--- a/analytics_dashboard/courses/templates/courses/learners.html
+++ b/analytics_dashboard/courses/templates/courses/learners.html
@@ -46,7 +46,7 @@ View of individual learners within a course.
             </div>
             {% show_table_error %}
         {% else %}
-            <div class="learners-app-container">
+            <div class="learners-app-container container-fluid">
                 {% include "loading.html" %}
             </div>
         {% endif %}

--- a/analytics_dashboard/static/apps/learners/app/templates/root.underscore
+++ b/analytics_dashboard/static/apps/learners/app/templates/root.underscore
@@ -1,4 +1,4 @@
 <div id="learner-app-focusable" tabindex="-1"></div>
-<div class="learners-header-region"></div>
-<div class="learners-error-region"></div>
-<div class="learners-main-region"></div>
+<div class="learners-header-region row"></div>
+<div class="learners-error-region row"></div>
+<div class="learners-main-region row"></div>

--- a/analytics_dashboard/static/apps/learners/roster/templates/active-filters.underscore
+++ b/analytics_dashboard/static/apps/learners/roster/templates/active-filters.underscore
@@ -1,0 +1,20 @@
+<% if (hasActiveFilters) { %>
+    <span id="active-filters-title"><%- activeFiltersTitle %></span>
+    <ul class="active-filters list-inline" aria-describedby="active-filters-title">
+        <% _.mapObject(activeFilters, function (filterVal, filterKey) { %>
+            <li class="filter filter-<%- filterKey %>">
+                <button class="action-clear-filter btn btn-default" data-filter-key="<%- filterKey %>">
+                    <%- filterVal.displayName %> &nbsp; <i class="fa fa-times" aria-hidden="true"></i>
+                    <span class="sr-only"><%- removeFilterMessage %></span>
+                </button>
+            </li>
+        <% }); %>
+
+        <li>
+            <button class="action-clear-all-filters btn btn-link">
+                <%- clearFiltersMessage %>
+                <span class="sr-only"><%- clearFiltersSrMessage %></span>
+            </button>
+        </li>
+    </ul>
+<% } %>

--- a/analytics_dashboard/static/apps/learners/roster/templates/roster.underscore
+++ b/analytics_dashboard/static/apps/learners/roster/templates/roster.underscore
@@ -1,6 +1,11 @@
 <div class="row">
+    <div class="col-md-12">
+        <div class="learners-active-filters"></div>
+    </div>
+</div>
+<div class="row">
     <div class="col-md-4 col-md-push-8">
-        <div class="learners-table-controls"></div>
+        <section class="learners-table-controls" aria-label="<%- controlsLabel %>"></section>
     </div>
     <div class="col-md-8 col-md-pull-4">
         <div class="learners-results"></div>

--- a/analytics_dashboard/static/apps/learners/roster/views/active-filters.js
+++ b/analytics_dashboard/static/apps/learners/roster/views/active-filters.js
@@ -1,0 +1,81 @@
+define(function (require) {
+    'use strict';
+
+    var $ = require('jquery'),
+        _ = require('underscore'),
+        Marionette = require('marionette'),
+
+        LearnerCollection = require('learners/common/collections/learners'),
+
+        ActiveFiltersView,
+
+        activeFiltersTemplate = require('text!learners/roster/templates/active-filters.underscore');
+
+    ActiveFiltersView = Marionette.ItemView.extend({
+        events: {
+            'click .action-clear-filter': 'clearOneFilter',
+            'click .action-clear-all-filters': 'clearAllFilters'
+        },
+
+        template: _.template(activeFiltersTemplate),
+
+        initialize: function (options) {
+            this.options = options || {};
+            this.listenTo(this.options.collection, 'sync', this.render);
+        },
+
+        templateHelpers: function () {
+            // Note that search is included in 'activeFilters'
+            var activeFilters = this.options.collection.getActiveFilterFields(true),
+                hasActiveFilters = !_.isEmpty(activeFilters);
+
+            activeFilters = _.mapObject(activeFilters, function (filterVal, filterKey) {
+                var filterDisplayName;
+                if (filterKey === LearnerCollection.DefaultSearchKey) {
+                    filterDisplayName = '"' + filterVal + '"';
+                } else if (filterKey === 'cohort') {
+                    // Translators: this is a label describing a selection that the user initiated.
+                    filterDisplayName = _.template(gettext('Cohort: <%= filterVal %>'))({
+                        filterVal: filterVal
+                    });
+                } else if (filterKey === 'enrollment_mode') {
+                    // Translators: this is a label describing a selection that the user initiated.
+                    filterDisplayName = _.template(gettext('Enrollment Track: <%= filterVal %>'))({
+                        filterVal: filterVal
+                    });
+                } else {
+                    filterDisplayName = filterVal;
+                }
+                return {
+                    displayName: filterDisplayName
+                };
+            });
+
+            return {
+                hasActiveFilters: hasActiveFilters,
+                activeFilters: activeFilters,
+                activeFiltersTitle: gettext('Active Filters:'),
+                removeFilterMessage: gettext('Click to remove this filter'),
+                // Translators: "Clear" in this context means "remove all of the filters"
+                clearFiltersMessage: gettext('Clear'),
+                clearFiltersSrMessage: gettext('Click to remove all filters')
+            };
+        },
+
+        clearOneFilter: function (event) {
+            var filterKey;
+            event.preventDefault();
+            filterKey = $(event.currentTarget).data('filter-key');
+            this.options.collection.unsetFilterField(filterKey);
+            this.options.collection.refresh();
+        },
+
+        clearAllFilters: function (event) {
+            event.preventDefault();
+            this.options.collection.unsetAllFilterFields();
+            this.options.collection.refresh();
+        }
+    });
+
+    return ActiveFiltersView;
+});

--- a/analytics_dashboard/static/apps/learners/roster/views/results.js
+++ b/analytics_dashboard/static/apps/learners/roster/views/results.js
@@ -39,7 +39,7 @@ define(function (require) {
             }
         },
         createAlertView: function(collection) {
-            var hasSearch =  !_.isNull(collection.searchString) && collection.searchString !== '',
+            var hasSearch =  collection.hasActiveSearch(),
                 hasActiveFilter = !_.isEmpty(collection.getActiveFilterFields()),
                 suggestions = [],
                 noLearnersMessage,

--- a/analytics_dashboard/static/apps/learners/roster/views/roster.js
+++ b/analytics_dashboard/static/apps/learners/roster/views/roster.js
@@ -11,6 +11,7 @@ define(function (require) {
     var _ = require('underscore'),
         Marionette = require('marionette'),
 
+        ActiveFiltersView = require('learners/roster/views/active-filters'),
         LearnerResultsView = require('learners/roster/views/results'),
         LearnerUtils = require('learners/common/utils'),
         RosterControlsView = require('learners/roster/views/controls'),
@@ -33,6 +34,7 @@ define(function (require) {
         template: _.template(rosterTemplate),
 
         regions: {
+            activeFilters: '.learners-active-filters',
             controls: '.learners-table-controls',
             results: '.learners-results'
         },
@@ -52,6 +54,9 @@ define(function (require) {
         },
 
         onBeforeShow: function () {
+            this.showChildView('activeFilters', new ActiveFiltersView({
+                collection: this.options.collection
+            }));
             this.showChildView('controls', new RosterControlsView({
                 collection: this.options.collection,
                 courseMetadata: this.options.courseMetadata
@@ -60,6 +65,12 @@ define(function (require) {
                 collection: this.options.collection,
                 courseMetadata: this.options.courseMetadata
             }));
+        },
+
+        templateHelpers: function () {
+            return {
+                controlsLabel: gettext('Learner roster controls')
+            };
         }
     });
 

--- a/analytics_dashboard/static/apps/learners/roster/views/search.js
+++ b/analytics_dashboard/static/apps/learners/roster/views/search.js
@@ -24,15 +24,21 @@ define(function (require) {
         className: function () {
             return [Backgrid.Extension.ServerSideFilter.prototype.className, 'learners-search'].join(' ');
         },
+
         events: function () {
             return _.extend(Backgrid.Extension.ServerSideFilter.prototype.events, {'click .search': 'search'});
         },
+
         template: _.template(learnerSearchTemplate, null, {variable: null}),
+
         initialize: function (options) {
-            this.value = options.collection.searchString;
+            this.options = options || {};
+            this.listenTo(options.collection, 'sync', this.render);
             Backgrid.Extension.ServerSideFilter.prototype.initialize.call(this, options);
         },
+
         render: function () {
+            this.value = this.options.collection.getSearchString();
             this.$el.empty().append(this.template({
                 name: this.name,
                 placeholder: this.placeholder,
@@ -45,16 +51,21 @@ define(function (require) {
             this.delegateEvents();
             return this;
         },
-        search: function () {
-            Backgrid.Extension.ServerSideFilter.prototype.search.apply(this, arguments);
+
+        search: function (event) {
+            event.preventDefault();
             this.collection.setSearchString(this.searchBox().val().trim());
+            this.collection.refresh();
             this.resetFocus();
         },
-        clear: function () {
-            Backgrid.Extension.ServerSideFilter.prototype.clear.apply(this, arguments);
+
+        clear: function (event) {
+            event.preventDefault();
             this.collection.unsetSearchString();
+            this.collection.refresh();
             this.resetFocus();
         },
+
         resetFocus: function () {
             $('#learner-app-focusable').focus();
         }

--- a/analytics_dashboard/static/sass/_developer.scss
+++ b/analytics_dashboard/static/sass/_developer.scss
@@ -755,6 +755,12 @@ table.dataTable thead th.sorting_desc:after {
 
 .learner-roster {
 
+  .learners-active-filters {
+    .active-filters {
+      display: inline-block;
+    }
+  }
+
   th {
 
     font-weight: 600;

--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
     "font-awesome": "~4.2.0",
     "natural-sort": "overset/javascript-natural-sort#dbf4ca259b327a488bd1d7897fd46d80c414a7e0",
     "cldr-data": "26.0.3",
-    "edx-ui-toolkit": "~0.10.0",
+    "edx-ui-toolkit": "edx/edx-ui-toolkit#29759050aff2f4f3cb6921432855ad057bd69bb1",
     "marionette": "~2.4.4",
     "uri.js": "1.17",
     "backgrid": "^0.3.5",


### PR DESCRIPTION
Adds an active filters control to display all active filters (including search) and allow the user to clear any given one (or all).

This unearthed a slew of bugs which should be addressed. I'm going to add some more tests where it makes sense. I also have to remove a bunch of old TODOs.

This heavily relies on https://github.com/edx/edx-ui-toolkit/pull/61.

@dsjen check it out!

[AN-6207](https://openedx.atlassian.net/browse/AN-6207)
