### PR TITLE
Clear error when switching pages in learner analytics app.

### DIFF
--- a/analytics_dashboard/static/apps/learners/app/views/root.js
+++ b/analytics_dashboard/static/apps/learners/app/views/root.js
@@ -30,6 +30,10 @@ define(function (require) {
 
         initialize: function (options) {
             this.options = options || {};
+
+            // clear error message whenever the main section changes (e.g. detail
+            // or roster pages shown)
+            this.getRegion('main').on('before:show', this.onClearError.bind(this));
         },
 
         onRender: function () {


### PR DESCRIPTION
This clears out the error message when navigating between roster and details views.  It's just one line of app code and many lines of test code. :)

@dan-f, please review.
