### PR TITLE
Add loading progress bar for XHRs

### DIFF
--- a/analytics_dashboard/courses/templates/courses/learners.html
+++ b/analytics_dashboard/courses/templates/courses/learners.html
@@ -13,6 +13,7 @@ View of individual learners within a course.
 {% block stylesheets %}
     {{ block.super }}
     <link rel="stylesheet" href="/static/bower_components/backgrid-paginator/backgrid-paginator.min.css" type="text/css">
+    <link rel="stylesheet" href="/static/bower_components/nprogress/nprogress.css" type="text/css">
 {% endblock stylesheets %}
 
 {% block uncompressed_javascript %}

--- a/analytics_dashboard/static/apps/learners/app/app.js
+++ b/analytics_dashboard/static/apps/learners/app/app.js
@@ -4,6 +4,7 @@ define(function (require) {
     var $ = require('jquery'),
         Backbone = require('backbone'),
         Marionette = require('marionette'),
+        NProgress = require('nprogress'),
 
         CourseMetadataModel = require('learners/common/models/course-metadata'),
         LearnerCollection = require('learners/common/collections/learners'),
@@ -87,6 +88,11 @@ define(function (require) {
             }
 
             Backbone.history.start();
+
+            // Loading progress bar via nprogress
+            NProgress.configure({ showSpinner: false });
+            $(document).ajaxStart(function () { NProgress.start(); });
+            $(document).ajaxStop(function () { NProgress.done(); });
         }
     });
 

--- a/analytics_dashboard/static/apps/learners/app/controller.js
+++ b/analytics_dashboard/static/apps/learners/app/controller.js
@@ -11,6 +11,7 @@ define(function (require) {
 
     var Backbone = require('backbone'),
         Marionette = require('marionette'),
+        NProgress = require('nprogress'),
 
         EngagementTimelineModel = require('learners/common/models/engagement-timeline'),
         LearnerDetailView = require('learners/detail/views/learner-detail'),
@@ -23,6 +24,18 @@ define(function (require) {
             this.options = options || {};
             this.listenTo(this.options.learnerCollection, 'sync', this.onLearnerCollectionUpdated);
             this.onLearnerCollectionUpdated(this.options.learnerCollection);
+        },
+
+        /**
+         * Event handler for the 'showPage' event.  Called by the
+         * router whenever a route method beginning with "show" has
+         * been triggered.
+         */
+        onShowPage: function () {
+            // Show a loading bar
+            NProgress.done(true);
+            // Clear any existing alert
+            this.options.rootView.triggerMethod('clearError');
         },
 
         onLearnerCollectionUpdated: function (collection) {

--- a/analytics_dashboard/static/apps/learners/app/router.js
+++ b/analytics_dashboard/static/apps/learners/app/router.js
@@ -6,11 +6,19 @@ define(function (require) {
         LearnersRouter;
 
     LearnersRouter = Marionette.AppRouter.extend({
+        // Routes intended to show a page in the app should map to method names
+        // beginning with "show", e.g. 'showLearnerRosterPage'.
         appRoutes: {
             // TODO: handle 'queryString' arguments in https://openedx.atlassian.net/browse/AN-6668
             '(/)(?*queryString)': 'showLearnerRosterPage',
             ':username(/)(?*queryString)': 'showLearnerDetailPage',
             '*notFound': 'showNotFoundPage'
+        },
+
+        onRoute: function (routeName) {
+            if (routeName.indexOf('show') === 0) {
+                this.options.controller.triggerMethod('showPage');
+            }
         }
     });
 

--- a/analytics_dashboard/static/apps/learners/app/spec/controller-spec.js
+++ b/analytics_dashboard/static/apps/learners/app/spec/controller-spec.js
@@ -1,7 +1,9 @@
 define(function (require) {
     'use strict';
 
-    var CourseMetadataModel = require('learners/common/models/course-metadata'),
+    var $ = require('jquery'),
+
+        CourseMetadataModel = require('learners/common/models/course-metadata'),
         LearnerCollection = require('learners/common/collections/learners'),
         LearnersController = require('learners/app/controller'),
         LearnersRootView = require('learners/app/views/root'),
@@ -105,26 +107,33 @@ define(function (require) {
             });
         });
 
-        it('should hide errors when navigating between pages', function () {
-            var rootView = this.rootView;
-            this.controller.showLearnerRosterPage();
-            expectRosterPage(rootView);
-            expect(rootView.$('[role="alert"]')).not.toExist();
+        // The 'showPage' event gets fired by the router on the
+        // controller any time a route is hit which should change the
+        // current page.
+        describe('showPage event', function () {
+            it('renders the loading bar', function () {
+                jasmine.clock().install();
 
-            this.controller.showLearnerDetailPage('example-username');
-            server.requests[server.requests.length - 1].respond(404, {});
-            expectDetailPage(this.rootView, 'example-username');
-            expect(rootView.$('[role="alert"]')).toExist();
+                expect($('#nprogress')).not.toExist();
+                this.controller.triggerMethod('showPage');
+                expect($('#nprogress')).toExist();
 
-            this.controller.showLearnerRosterPage();
-            expectRosterPage(rootView);
-            expect(rootView.$('[role="alert"]')).not.toExist();
+                jasmine.clock().uninstall();
+            });
+
+            it('hides errors', function () {
+                this.controller.showLearnerDetailPage('example-username');
+                server.requests[server.requests.length - 1].respond(404, {});
+                expectDetailPage(this.rootView, 'example-username');
+                expect(this.rootView.$('[role="alert"]')).toExist();
+                this.controller.triggerMethod('showPage');
+                expect(this.rootView.$('[role="alert"]')).not.toExist();
+            });
         });
 
         it('should show the not found page', function () {
             this.controller.showNotFoundPage();
             expect(this.rootView.$el.html()).toContainText('Sorry, we couldn\'t find the page you\'re looking for.');
         });
-
     });
 });

--- a/analytics_dashboard/static/apps/learners/app/spec/router-spec.js
+++ b/analytics_dashboard/static/apps/learners/app/spec/router-spec.js
@@ -2,20 +2,23 @@ define(function (require) {
     'use strict';
 
     var Backbone = require('backbone'),
+        Marionette = require('marionette'),
 
         LearnersRouter = require('learners/app/router');
 
     describe('LearnersRouter', function () {
         beforeEach(function () {
             Backbone.history.start({silent: true});
-            this.controller = {
+            this.controller = new (Marionette.Object.extend({
                 showLearnerRosterPage: function () {},
                 showLearnerDetailPage: function () {},
-                showNotFoundPage: function () {}
-            };
+                showNotFoundPage: function () {},
+                onShowPage: function () {}
+            }))();
             spyOn(this.controller, 'showLearnerRosterPage');
             spyOn(this.controller, 'showLearnerDetailPage');
             spyOn(this.controller, 'showNotFoundPage');
+            spyOn(this.controller, 'onShowPage');
             this.router = new LearnersRouter({
                 controller: this.controller
             });
@@ -25,6 +28,13 @@ define(function (require) {
             // Clear previous route
             this.router.navigate('');
             Backbone.history.stop();
+        });
+
+        it('triggers a showPage event for pages beginning with "show"', function () {
+            this.router.navigate('foo', {trigger: true});
+            expect(this.controller.onShowPage).toHaveBeenCalled();
+            this.router.navigate('/', {trigger: true});
+            expect(this.controller.onShowPage).toHaveBeenCalled();
         });
 
         describe('showLearnerRosterPage', function () {

--- a/analytics_dashboard/static/apps/learners/app/views/root.js
+++ b/analytics_dashboard/static/apps/learners/app/views/root.js
@@ -31,10 +31,6 @@ define(function (require) {
 
         initialize: function (options) {
             this.options = options || {};
-
-            // clear error message whenever the main section changes (e.g. detail
-            // or roster pages shown)
-            this.getRegion('main').on('before:show', this.onClearError.bind(this));
         },
 
         onRender: function () {

--- a/analytics_dashboard/static/js/config.js
+++ b/analytics_dashboard/static/js/config.js
@@ -46,7 +46,8 @@ require.config({
         SecondLevelDomains: 'bower_components/uri.js/src/SecondLevelDomains',
         learners: 'apps/learners',
         'axe-core': 'bower_components/axe-core/axe.min',
-        sinon: 'bower_components/sinon/lib/sinon'
+        sinon: 'bower_components/sinon/lib/sinon',
+        nprogress: 'bower_components/nprogress/nprogress'
     },
     wrapShim: true,
     shim: {

--- a/bower.json
+++ b/bower.json
@@ -35,7 +35,8 @@
     "backgrid-paginator": "^0.3.5",
     "backgrid-filter": "^0.3.5",
     "text": "^2.0.14",
-    "axe-core": "^1.1.1"
+    "axe-core": "^1.1.1",
+    "nprogress": "^0.2.0"
   },
   "resolutions": {
     "backbone": "~1.2.3",

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -27,7 +27,6 @@ module.exports = function (config) {
             {pattern: 'analytics_dashboard/static/apps/**/*.underscore', included: false},
             'analytics_dashboard/static/js/config.js',
             'analytics_dashboard/static/js/test/spec-runner.js',
-            './node_modules/phantomjs-polyfill/bind-polyfill.js',
         ],
 
         exclude: [

--- a/package.json
+++ b/package.json
@@ -24,11 +24,10 @@
     "karma-jasmine": "^0.3.6",
     "karma-jasmine-jquery": "^0.1.1",
     "karma-jasmine-html-reporter": "^0.2.0",
-    "karma-phantomjs-launcher": "^0.1.4",
+    "karma-phantomjs-launcher": "^1.0.0",
     "karma-requirejs": "^0.2.2",
     "karma-sinon": "^1.0.3",
-    "phantomjs": "^1.9.11",
-    "phantomjs-polyfill": "^0.0.1",
+    "phantomjs-prebuilt": "^2.1.7",
     "sinon": "1.17.3"
   }
 }


### PR DESCRIPTION
Adds a "progress bar" youtube/github style to the top of the page when "loading" pages within the SPA. In particular the progress bar tracks XHRs and page transitions.

@dsjen please review

[AN-7128](https://openedx.atlassian.net/browse/AN-7128)
