### PR TITLE
Fix active filter when searching empty string

### DIFF
--- a/analytics_dashboard/static/apps/learners/roster/views/search.js
+++ b/analytics_dashboard/static/apps/learners/roster/views/search.js
@@ -54,14 +54,22 @@ define(function (require) {
 
         search: function (event) {
             event.preventDefault();
-            this.collection.setSearchString(this.searchBox().val().trim());
-            this.collection.refresh();
-            this.resetFocus();
+            var searchString = this.searchBox().val().trim();
+            if (searchString === '') {
+                this.collection.unsetSearchString();
+            } else {
+                this.collection.setSearchString(searchString);
+            }
+            this.execute();
         },
 
         clear: function (event) {
             event.preventDefault();
             this.collection.unsetSearchString();
+            this.execute();
+        },
+
+        execute: function () {
             this.collection.refresh();
             this.resetFocus();
         },

--- a/analytics_dashboard/static/apps/learners/roster/views/spec/roster-spec.js
+++ b/analytics_dashboard/static/apps/learners/roster/views/spec/roster-spec.js
@@ -494,7 +494,8 @@ define(function (require) {
             });
 
             it('can clear the search by searching the empty string', function () {
-                var rosterView, searchString;
+                var rosterView,
+                    searchString;
                 searchString = 'search string';
                 rosterView = getRosterView();
                 executeSearch(searchString);

--- a/analytics_dashboard/static/apps/learners/roster/views/spec/roster-spec.js
+++ b/analytics_dashboard/static/apps/learners/roster/views/spec/roster-spec.js
@@ -494,13 +494,16 @@ define(function (require) {
             });
 
             it('can clear the search by searching the empty string', function () {
-                var searchString = 'search string';
-                getRosterView();
+                var rosterView, searchString;
+                searchString = 'search string';
+                rosterView = getRosterView();
                 executeSearch(searchString);
                 expectSearchedFor(searchString);
                 getLastRequest().respond(200, {}, JSON.stringify(getResponseBody(1, 1)));
                 executeSearch('');
+                expect(rosterView.options.collection.getSearchString()).toBeNull();
                 expect(getLastRequestParams().text_search).toBeUndefined();
+                getLastRequest().respond(200, {}, JSON.stringify(getResponseBody(1, 1)));
             });
 
             it('handles server errors', function () {

--- a/build.js
+++ b/build.js
@@ -69,7 +69,7 @@
             exclude: ['js/common']
         },
         {
-            name: 'learners/app/app',
+            name: 'apps/learners/app/app',
             exclude: ['js/common']
         }
     ]


### PR DESCRIPTION
@dsjen when searching for nothing (e.g. clicking the search icon or hitting return/enter when there's nothing in the search box), an active filter displaying `""` used to appear. This fixes that.

[AN-7228](https://openedx.atlassian.net/browse/AN-7228)
