### PR TITLE
Add learner summary to details page.

### DIFF
--- a/analytics_dashboard/static/apps/learners/app/app.js
+++ b/analytics_dashboard/static/apps/learners/app/app.js
@@ -74,7 +74,8 @@ define(function (require) {
                     courseMetadata: courseMetadata,
                     pageModel:  pageModel,
                     rootView: rootView,
-                    learnerEngagementTimelineUrl: this.options.learnerEngagementTimelineUrl
+                    learnerEngagementTimelineUrl: this.options.learnerEngagementTimelineUrl,
+                    learnerListUrl: this.options.learnerListUrl,
                 })
             });
 

--- a/analytics_dashboard/static/apps/learners/common/models/learner.js
+++ b/analytics_dashboard/static/apps/learners/common/models/learner.js
@@ -1,7 +1,8 @@
 define(function (require) {
     'use strict';
 
-    var Backbone = require('backbone'),
+    var _ = require('underscore'),
+        Backbone = require('backbone'),
 
         LearnerUtils = require('learners/common/utils'),
 
@@ -42,6 +43,13 @@ define(function (require) {
             parsedResponse.enrollment_date = response.enrollment_date ? new Date(response.enrollment_date) : null;
             parsedResponse.last_updated = response.last_updated ? new Date(response.last_updated) : null;
             return parsedResponse;
+        },
+
+        /**
+         * Returns true if the username has been set.  False otherwise.
+         */
+        hasData: function () {
+            return !_(this.get('username')).isEmpty();
         }
     });
 

--- a/analytics_dashboard/static/apps/learners/common/models/spec/learner-spec.js
+++ b/analytics_dashboard/static/apps/learners/common/models/spec/learner-spec.js
@@ -43,5 +43,14 @@ define(function (require) {
             }))({username: 'daniel', course_id: 'edX/DemoX/Demo_Course'});
             expect(learner.url()).toEqual('/other-endpoint/daniel?course_id=edX%2FDemoX%2FDemo_Course');
         });
+
+        it('should use username to determine if data is available', function () {
+            var learner = new LearnerModel();
+            expect(learner.hasData()).toBe(false);
+
+            learner.set('username', 'spiderman');
+            expect(learner.hasData()).toBe(true);
+        });
+
     });
 });

--- a/analytics_dashboard/static/apps/learners/detail/templates/email.underscore
+++ b/analytics_dashboard/static/apps/learners/detail/templates/email.underscore
@@ -1,0 +1,6 @@
+<% if (!_(email).isEmpty()) { %>
+    <a href="mailto:<%- email %>">
+        <i class="fa fa-envelope-o" aria-hidden="true"></i>
+        <%- email %>
+    </a>
+<% } %>

--- a/analytics_dashboard/static/apps/learners/detail/templates/learner-detail.underscore
+++ b/analytics_dashboard/static/apps/learners/detail/templates/learner-detail.underscore
@@ -1,1 +1,18 @@
+<section class="learner-summary-container">
+    <div class="row">
+        <div class="col-sm-3 col-xs-6 learner-names" />
+        <% _.each(['learner-enrollment', 'learner-cohort', 'learner-accessed'], function(learnerClass) { %>
+            <div class="col-sm-3 col-xs-6 <%- learnerClass %>"></div>
+        <% }); %>
+    </div>
+</section>
+
+<div class="section-heading bordered fake-tab">
+    <h4 class="section-title"><%- engagement %></h4>
+    <span class="section-heading-note small learner-email"></span>
+</div>
+
+<div class="section-heading">
+    <h4 class="section-title"><%- activity %></h4>
+</div>
 <div class="learner-engagement-timeline-container"></div>

--- a/analytics_dashboard/static/apps/learners/detail/templates/learner-names.underscore
+++ b/analytics_dashboard/static/apps/learners/detail/templates/learner-names.underscore
@@ -1,0 +1,2 @@
+<div class="learner-username"><%- username %></div>
+<div class="learner-name"><%- name %></div>

--- a/analytics_dashboard/static/apps/learners/detail/templates/learner-summary-field.underscore
+++ b/analytics_dashboard/static/apps/learners/detail/templates/learner-summary-field.underscore
@@ -1,0 +1,6 @@
+<div class="learner-summary-field">
+    <%- field %>
+</div>
+<div class="learner-summary-value">
+    <%- value %>
+</span>

--- a/analytics_dashboard/static/apps/learners/detail/views/learner-email.js
+++ b/analytics_dashboard/static/apps/learners/detail/views/learner-email.js
@@ -1,0 +1,14 @@
+define(function (require) {
+    'use strict';
+
+    var _ = require('underscore'),
+        Marionette = require('marionette');
+
+    return Marionette.ItemView.extend({
+        template: _.template(require('text!learners/detail/templates/email.underscore')),
+        modelEvents: {
+            'change:email': 'render'
+        }
+    });
+
+});

--- a/analytics_dashboard/static/apps/learners/detail/views/learner-names.js
+++ b/analytics_dashboard/static/apps/learners/detail/views/learner-names.js
@@ -1,0 +1,14 @@
+define(function (require) {
+    'use strict';
+
+    var _ = require('underscore'),
+        Marionette = require('marionette');
+
+    return Marionette.ItemView.extend({
+        template: _.template(require('text!learners/detail/templates/learner-names.underscore')),
+        modelEvents: {
+            change: 'render'
+        }
+    });
+
+});

--- a/analytics_dashboard/static/apps/learners/detail/views/learner-summary-field.js
+++ b/analytics_dashboard/static/apps/learners/detail/views/learner-summary-field.js
@@ -1,0 +1,57 @@
+define(function (require) {
+    'use strict';
+
+    var _ = require('underscore'),
+        Marionette = require('marionette'),
+
+        template = require('text!learners/detail/templates/learner-summary-field.underscore'),
+
+        LearnerSummaryFieldView;
+
+    /**
+     * Displays a field name followed by a value upon model update.
+     */
+    LearnerSummaryFieldView = Marionette.LayoutView.extend({
+
+        template: _.template(template),
+
+        /**
+         * Options:
+         *  - modelAttribute: attribute that the view will listen to change events on
+         *  - fieldDisplayName: Display name of field.
+         *  - valueFormatter (optional): function callback for formatting value.
+         */
+        initialize: function (options) {
+            Marionette.LayoutView.prototype.initialize.call(this, options);
+            this.options = options || {};
+            this.model.on('change:' + this.options.modelAttribute, this.render);
+        },
+
+        /**
+         * Formats 'value' according to the valueFormatter callback if provided.
+         * Otherwise, returns the value or 'n/a'.
+         */
+        formatValue: function (value) {
+            if (_(this.options).has('valueFormatter')) {
+                return this.options.valueFormatter(value);
+            } else {
+                return this.defaultFormatter(value);
+            }
+        },
+
+        defaultFormatter: function (value) {
+            // Translators: 'n/a' means 'not available'
+            return value || gettext('n/a');
+        },
+
+        templateHelpers: function () {
+            return {
+                field: this.options.fieldDisplayName,
+                value: this.formatValue(this.model.get(this.options.modelAttribute))
+            };
+        }
+
+    });
+
+    return LearnerSummaryFieldView;
+});

--- a/analytics_dashboard/static/apps/learners/detail/views/spec/learner-summary-field-spec.js
+++ b/analytics_dashboard/static/apps/learners/detail/views/spec/learner-summary-field-spec.js
@@ -1,0 +1,65 @@
+define(function (require) {
+    'use strict';
+
+    var Backbone = require('backbone'),
+        LearnerSummaryFieldView = require('learners/detail/views/learner-summary-field');
+
+    describe('LearnerSummaryField', function () {
+        var fixture;
+
+        beforeEach(function () {
+            fixture = setFixtures('<div id="summary"></div>');
+        });
+
+        it('displays a field and value', function () {
+            var model = new Backbone.Model({animal: 'Rubber Duck'}),
+                view = new LearnerSummaryFieldView({
+                    model: model,
+                    modelAttribute: 'animal',
+                    fieldDisplayName: 'Animal',
+                    el: fixture
+                });
+
+            view.render();
+
+            expect(fixture).toContainText('Animal');
+            expect(fixture).toContainText('Rubber Duck');
+        });
+
+        it('displays "n/a" initially and updates', function () {
+            var model = new Backbone.Model(),
+                view = new LearnerSummaryFieldView({
+                    model: model,
+                    modelAttribute: 'model-attribute',
+                    fieldDisplayName: 'Field',
+                    el: fixture
+                });
+
+            view.render();
+            expect(fixture).toContainText('Field');
+            expect(fixture).toContainText('n/a');
+
+            model.set('model-attribute', 'My Attribute');
+            expect(fixture).toContainText('Field');
+            expect(fixture).toContainText('My Attribute');
+        });
+
+        it('formats values', function () {
+            var model = new Backbone.Model({animal: 'Rubber Duck'}),
+                view = new LearnerSummaryFieldView({
+                    model: model,
+                    modelAttribute: 'animal',
+                    fieldDisplayName: 'Friend',
+                    el: fixture,
+                    valueFormatter: function (value) {
+                        return value + 'y';
+                    }
+                });
+
+            view.render();
+            expect(fixture).toContainText('Friend');
+            expect(fixture).toContainText('Rubber Ducky');
+        });
+
+    });
+});

--- a/analytics_dashboard/static/sass/_developer.scss
+++ b/analytics_dashboard/static/sass/_developer.scss
@@ -833,3 +833,28 @@ table.dataTable thead th.sorting_desc:after {
 
   }
 }
+
+// styles for the learner details summary
+.learner-summary-container {
+
+  .learner-username {
+    font-size: $font-size-large;
+  }
+
+  .learner-name {
+    font-size: $font-size-large * 1.5;
+  }
+
+  // e.g. "enrollment" or "cohort"
+  .learner-summary-field {
+    color: $gray-l1;
+  }
+
+}
+
+.learner-detail-container {
+  // this heading will be replaced with a tab in the future
+  .bordered.fake-tab {
+    border-bottom-width: 3px;
+  }
+}


### PR DESCRIPTION
This adds basic user profile information to the learner details page.  Values will be filled in when available and "n/a" otherwise.

Code changes:
- displaying 404 alert in the respective section
- learner data is fetched from the collection if available and otherwise through the api
- engagement activity is nested within the "Engagement" (fake) tab
# Data Loaded

![screen shot 2016-05-19 at 3 24 19 pm](https://cloud.githubusercontent.com/assets/5265058/15406766/ca4b9ace-1dd5-11e6-9496-57203b1378b5.png)
# 404s

![screen shot 2016-05-19 at 3 25 12 pm](https://cloud.githubusercontent.com/assets/5265058/15406792/e5203260-1dd5-11e6-907c-28c04d53c769.png)

@dan-f please review.
