### PR TITLE
Moves individual learner engagement to a top-level section

### DIFF
--- a/docs/en_us/dashboard/source/Reference.rst
+++ b/docs/en_us/dashboard/source/Reference.rst
@@ -564,15 +564,15 @@ in a different spreadsheet application or a text editor.
 
 .. _Learner Computations:
 
-*************************
-Per Learner Computations
-*************************
+*******************************
+Individual Learner Computations
+*******************************
 
 .. note:: This feature is not yet supported. EdX is currently testing the
- per learner activity feature.
+ individual learner activity feature.
 
 For information about the report and charts that are available in Insights
-for individual learner activities, see :ref:`Learners`.
+for individual learner activities, see :ref:`Learner Activity`.
 
 * The computations for these metrics are updated daily and use the enrollment
   status and activities of each learner as of 23:59 UTC on the previous day.

--- a/docs/en_us/dashboard/source/engagement/index.rst
+++ b/docs/en_us/dashboard/source/engagement/index.rst
@@ -1,24 +1,18 @@
 .. _Engagement Index:
 
 ################################
-Learner Engagement and Activity
+Learner Engagement
 ################################
 
-To learn about what learners are doing in your course, from the edX Insights
-menu select **Engagement**. Select **Content** to investigate how many
-learners are interacting with course content overall, and what they are doing.
-For data specifically about the videos in your course, select **Video**.
-
-.. You can also access information about what individual learners are doing in
-.. your course, and how frequently: select **Learners** at the top of any Insights
-.. page. A report of the key activity metrics for all enrolled learners appears,
-.. including problems tried and videos played. You can then review a chart of
-.. individual learner activity over time by clicking that learner's username.
+To gain an overall understanding of what learners are doing in your course,
+from the edX Insights menu select **Engagement**. Select **Content** to
+investigate how many learners are interacting with course content overall, and
+what they are doing. For data specifically about the videos in your course,
+select **Video**.
 
 .. toctree::
    :maxdepth: 1
 
    Engagement_Content
    Engagement_Video
-   learners
 

--- a/docs/en_us/dashboard/source/learners/Learner_Activity.rst
+++ b/docs/en_us/dashboard/source/learners/Learner_Activity.rst
@@ -1,11 +1,11 @@
-.. _Learners:
+.. _Learner Activity:
 
 ################
 Learner Activity
 ################
 
 .. note:: This feature is not yet supported. EdX is currently testing the
- per learner activity feature.
+ individual learner activity feature.
 
 Which learners, specifically, are engaging with my course? Who is struggling,
 and who is doing well? Investigating and comparing the activities of individual

--- a/docs/en_us/dashboard/source/learners/index.rst
+++ b/docs/en_us/dashboard/source/learners/index.rst
@@ -1,0 +1,20 @@
+.. _Learner Index:
+
+################################################
+Individual Learners
+################################################
+
+.. note:: This feature is not yet supported. EdX is currently testing the
+ individual learner activity feature.
+
+You can access information about what individual learners are doing in your
+course, and how frequently: from the edX Insights menu select **Learners**. A
+report of the key activity metrics for all enrolled learners appears, including
+problems tried and videos played. You can then review a chart of individual
+learner activity over time by selecting a learner by username.
+
+.. toctree::
+   :maxdepth: 1
+
+   Learner_Activity
+


### PR DESCRIPTION
- [x] @thallada 
- [x] @dsjen 
- [x] @stroilova 
- [x] @mulby 

HTML builds without warning or error.
