### PR TITLE
Set last updated date on learner detail page

### DIFF
--- a/analytics_dashboard/static/apps/learners/app/controller.js
+++ b/analytics_dashboard/static/apps/learners/app/controller.js
@@ -82,8 +82,7 @@ define(function (require) {
                 detailView;
 
             this.options.pageModel.set({
-                title: gettext('Learner Details'),
-                lastUpdated: undefined
+                title: gettext('Learner Details')
             });
 
             detailView = new LearnerDetailView({
@@ -94,6 +93,9 @@ define(function (require) {
 
             // fetch data is the model is empty
             if (!learnerModel.hasData()) {
+                learnerModel.on('change:last_updated', function () {
+                    this.options.pageModel.set('lastUpdated', learnerModel.get('last_updated'));
+                }, this);
                 learnerModel.urlRoot = this.options.learnerListUrl;
                 learnerModel.set({
                     course_id: this.options.courseId,

--- a/analytics_dashboard/static/apps/learners/app/spec/controller-spec.js
+++ b/analytics_dashboard/static/apps/learners/app/spec/controller-spec.js
@@ -20,12 +20,15 @@ define(function (require) {
 
         // convenience method for asserting that we are on the learner detail page
         expectDetailPage = function (controller) {
+            var date = new Date(2016, 1, 28);
             expect(controller.options.rootView.$('.learners-navigation-region').html())
                 .toContainText('Return to Learners');
             expect(controller.options.rootView.$('.learner-detail-container')).toExist();
             expect(controller.options.rootView.$('.learner-summary-container')).toExist();
             expect(controller.options.rootView.$('.learners-header-region').html())
                 .toContainText('Learner Details');
+            expect(controller.options.rootView.$('.learners-header-region').html())
+                .toContainText(date.toLocaleDateString('en-us', {year: 'numeric', month: 'long', day: 'numeric'}));
             expect(controller.options.trackingModel.get('page')).toBe('learner_details');
             expect(controller.options.trackingModel.trigger).toHaveBeenCalledWith('segment:page');
         };
@@ -41,8 +44,7 @@ define(function (require) {
         };
 
         beforeEach(function () {
-            var collection,
-                pageModel = new PageModel();
+            var pageModel = new PageModel();
 
             server = sinon.fakeServer.create();
             setFixtures('<div class="root-view"><div class="main"></div></div>');
@@ -54,24 +56,23 @@ define(function (require) {
             // The learner roster view looks at the first learner in
             // the collection in order to render a last updated
             // message.
-            collection = new LearnerCollection([
-                {
-                    name: 'learner',
-                    username: 'learner',
-                    email: 'learner@example.com',
-                    account_url: 'example.com/learner',
-                    enrollment_mode: 'audit',
-                    enrollment_date: new Date(),
-                    cohort: null,
-                    segments: ['highly_engaged'],
-                    engagements: {},
-                    last_updated: new Date(2016, 1, 28),
-                    course_id: courseId
-                }
-            ], {parse: true});
+            this.user = {
+                name: 'learner',
+                username: 'learner',
+                email: 'learner@example.com',
+                account_url: 'example.com/learner',
+                enrollment_mode: 'audit',
+                enrollment_date: new Date(),
+                cohort: null,
+                segments: ['highly_engaged'],
+                engagements: {},
+                last_updated: new Date(2016, 1, 28),
+                course_id: courseId
+            };
+            this.collection = new LearnerCollection([this.user], {parse: true});
             this.controller = new LearnersController({
                 rootView: this.rootView,
-                learnerCollection: collection,
+                learnerCollection: this.collection,
                 courseMetadata: new CourseMetadataModel(),
                 pageModel: pageModel,
                 learnerEngagementTimelineUrl: '/test-engagement-endpoint/',
@@ -94,7 +95,7 @@ define(function (require) {
         describe('navigating to the Learner Detail page', function () {
             it('should show the learner detail page', function () {
                 var engagementTimelineResponse;
-                this.controller.showLearnerDetailPage('example-username');
+                this.controller.showLearnerDetailPage('learner');
                 // Showing the learner detail page triggers a request for the
                 // learner engagement timeline data.
                 engagementTimelineResponse = JSON.stringify({days: [{
@@ -104,6 +105,7 @@ define(function (require) {
                     problems_completed: 1,
                     videos_viewed: 1
                 }]});
+                server.requests[0].respond(200, {}, JSON.stringify(this.user));
                 server.requests[server.requests.length - 1].respond(200, {}, engagementTimelineResponse);
                 expectDetailPage(this.controller);
             });
@@ -133,7 +135,8 @@ define(function (require) {
             });
 
             it('hides app-wide errors', function () {
-                this.controller.showLearnerDetailPage('example-username');
+                this.controller.showLearnerDetailPage('learner');
+                server.requests[0].respond(200, {}, JSON.stringify(this.user));
                 server.requests[server.requests.length - 1].respond(500, {});
                 expectDetailPage(this.controller);
                 expect(this.rootView.$('[role="alert"]')).toExist();


### PR DESCRIPTION
The learner's detail page didn't have the last updated date set correctly (it just said "unknown"). There are two ways that a user could get to the page:
1. When the user loads the roster page first, the last updated date is loaded into every learner in the LearnerCollection, _but_ when they click a specific learner, the code in controller.js would overwrite the last updated date in the PageModel with undefined and never reset it.
2. When the user went directly to a learner detail page, a new LearnerModel would have to be created, but the PageModel was never updated with the last updated date after the learner was loaded.

The solution here is to not overwrite the PageModel's last updated date with undefined, and to set it to whatever the LearnerModel's last updated date is whenever it changes.

Also, edited the tests to check for this issue.

@ajpal @dsjen 
