### PR TITLE
Pin requests library.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,6 +20,7 @@ logutils==0.3.3				# BSD
 # TODO Remove this once https://github.com/omab/python-social-auth/pull/908 is released.
 python-social-auth==0.2.14
 
+requests==2.10.0            # Apache 2.0
 
 # TODO Use the PyPi package once it is updated.
 git+https://github.com/pinax/django-announcements.git@f85e690705e038a62407abe54ac195f60760934b#egg=django-announcements # MIT


### PR DESCRIPTION
The requests library was satisfied by v2.2.0, whereas we at least need v2.4.0 to satisfy the [ConnectTimeout](https://github.com/kennethreitz/requests/commit/8f9ce13e433013cd9bd4dbe9cf61c5b5f14b65ed) exception in [views.py#L3](https://github.com/edx/edx-analytics-dashboard/blob/44c32ca4495f510555d2057ea37c9f48d3a0eb21/analytics_dashboard/learner_analytics_api/v0/views.py#L3).

Please review, @thallada @ajpal.
