### PR TITLE
Updated elasticsearch port to match api test server.

### DIFF
--- a/scripts/run_analytics_data_api.sh
+++ b/scripts/run_analytics_data_api.sh
@@ -12,7 +12,7 @@ make test.run_elasticsearch
 # it during testing.
 sleep 10
 # Create the ElasticSearch indicies and mappings.
-export ELASTICSEARCH_LEARNERS_HOST='http://localhost:9200'
+export ELASTICSEARCH_LEARNERS_HOST='http://localhost:9223'
 export ELASTICSEARCH_LEARNERS_INDEX='learner'
 export ELASTICSEARCH_LEARNERS_UPDATE_INDEX='index_update'
 export DJANGO_SETTINGS_MODULE="analyticsdataserver.settings.local"


### PR DESCRIPTION
This updates the elasticsearch port to match the one specified in https://github.com/edx/edx-analytics-data-api/pull/124.

Please review, @ajpal @thallada.
