### PR TITLE
Disabling the learner lens still enables navigating to it.

### DIFF
--- a/analytics_dashboard/courses/tests/test_views/test_learners.py
+++ b/analytics_dashboard/courses/tests/test_views/test_learners.py
@@ -79,6 +79,10 @@ class LearnersViewTests(ViewTestMixin, SwitchMixin, TestCase):
         })
         self.assertNotContains(response, self.TABLE_ERROR_TEXT)
 
+    def test_success_if_hidden(self):
+        self.toggle_switch('enable_learner_analytics', False)
+        self.test_success()
+
     @data(Timeout, ConnectionError, ValueError)
     def test_data_api_error(self, RequestExceptionClass):
         learners_payload = {'should_not': 'return this value'}

--- a/analytics_dashboard/courses/views/__init__.py
+++ b/analytics_dashboard/courses/views/__init__.py
@@ -368,8 +368,10 @@ class CourseNavBarMixin(object):
         # Get the active primary item and remove it from the list
         primary_nav_item = None
         if self.active_primary_nav_item:
-            primary_nav_item = [i for i in primary_nav_items if i['name'] == self.active_primary_nav_item][0]
-            primary_nav_items.remove(primary_nav_item)
+            navs = [i for i in primary_nav_items if i['name'] == self.active_primary_nav_item]
+            if navs:
+                primary_nav_item = navs[0]
+                primary_nav_items.remove(primary_nav_item)
 
         context.update({
             'primary_nav_item': primary_nav_item,


### PR DESCRIPTION
This enables navigating to the learners lens if the functionality is switched off--useful for our beta release. :)

Please review @thallada @ajpal @mulby 
