### PR TITLE
Removes recruitment section, adds specific email address guidance

### DIFF
--- a/docs/en_us/dashboard/source/learners/Learner_Activity.rst
+++ b/docs/en_us/dashboard/source/learners/Learner_Activity.rst
@@ -152,8 +152,9 @@ instructor dashboard of an edx.org course.
 
 * Selecting a learner email address in Insights opens the default email client
   of the computer that you are currently using. As a result, if you use your
-  personal computer to access Insights, your personal email address could be
-  used to send the message.
+  personal computer to access Insights, your personal email address might be
+  the default for sending the message. Be sure to use only your official
+  institution email address when you communicate with learners by email.
 
 * Insights does not log when messages are sent, or record the email address of
   the sender or the recipient.
@@ -223,16 +224,6 @@ discussions. They can also search by username to find the activity reported for
 individual cohort members. The learner activity charts can show, at a glance,
 whether discussion activity is a regular part of a learner's weekly involvement
 in the course, or if it takes place more sporadically.
-
-==========================
-Recruiting Job Candidates
-==========================
-
-An organization used their MOOC as a recruiting tool. They defined a set of
-criteria for potential job candidates, including metrics that would reflect
-engagement over time, mastery of the material, and interaction with other
-learners. Learners who met or exceeded these criteria were automatically placed
-into consideration for a screening interview.
 
 ==================================
 Identifying Questionable Activity


### PR DESCRIPTION
Per Nell:

Hi Alison, Tena and I have read through this and recommend a couple edits:
-   The section on emailing learners (6.1.1.2.1) should be revised to instruct against using any personal email to communicate with a learner. Course teams and professors should only email from official institution email addresses, and that expectation should be plainly stated.
-   The section on recruiting (6.1.2.3) should be deleted. While the situation may have occurred, it's not a core part of why we're offering this feature, and we don't typically promote the offering of courses as recruiting tools.

We earlier discussed with Gabe and Olga the possibility of removing the active link for individual email addresses from prominent display on the page.  It feels odd, because one-on-one interaction wouldn't (as a practical matter, just couldn't) be the norm.  I think they were going to gauge reaction to the beta, so I'm not sure if or where that issue landed - Gabe, any updates?

Lastly, adding Nina (in case she's not already in the loop) for her input on how we present the use cases for this feature in general, and particularly in the last section (6.1.2.4) re: use of the feature to identify "questionable activity," given Nina's work to address cheating concerns.

Nell

[ ] @stroilova 
[ ] @ninabeth
[ ] @mulby 
[ ] @watsonemily
[ ]  Nell
