### PR TITLE
Deep linking for the Learner Roster page

### DIFF
--- a/analytics_dashboard/static/apps/learners/app/controller.js
+++ b/analytics_dashboard/static/apps/learners/app/controller.js
@@ -70,7 +70,7 @@ define(function (require) {
                         successView: rosterView
                     });
                     this.options.rootView.showChildView('main', loadingView);
-                    
+
                     var fetch = this.options.learnerCollection.fetch({reset: true});
                     if (fetch) {
                         fetch.complete(function (response) {
@@ -169,7 +169,7 @@ define(function (require) {
             this.options.trackingModel.trigger('segment:page');
 
         },
-        
+
         showInvalidParametersPage: function () {
             this.options.rootView.showChildView('main', new AlertView({
                 alertType: 'error',

--- a/analytics_dashboard/static/apps/learners/app/controller.js
+++ b/analytics_dashboard/static/apps/learners/app/controller.js
@@ -175,7 +175,7 @@ define(function (require) {
                 alertType: 'error',
                 title: gettext('Invalid Parameters'),
                 body: gettext('Sorry, we couldn\'t find learners for that query.'),
-                suggestions: [gettext('Try returning to the home page.')]
+                link: {url: '#', text: gettext('Return to the Learners page.')}
             }));
 
             // track the "page" view

--- a/analytics_dashboard/static/apps/learners/app/controller.js
+++ b/analytics_dashboard/static/apps/learners/app/controller.js
@@ -174,8 +174,8 @@ define(function (require) {
             this.options.rootView.showChildView('main', new AlertView({
                 alertType: 'error',
                 title: gettext('Invalid Parameters'),
-                body: gettext('Sorry, we could not find data for that query. ' +
-                              'Please return to the home page.')
+                body: gettext('Sorry, we couldn\'t find learners for that query.'),
+                suggestions: [gettext('Try returning to the home page.')]
             }));
 
             // track the "page" view
@@ -206,15 +206,17 @@ define(function (require) {
                     order = val === 'desc' ? 1 : -1;
                     order_name = val === 'desc' ?  'descending' : 'ascending';
                 } else {
-                    if (val !== collection.getFilterFieldValue(key)) {
-                        fetchNeeded = true;
+                    if (key in collection.filterableFields || key === 'text_search') {
+                        if (val !== collection.getFilterFieldValue(key)) {
+                            fetchNeeded = true;
+                        }
+                        collection.setFilterField(key, val);
                     }
-                    collection.setFilterField(key, val);
                 }
             });
 
             // Set the sort state if sortKey or order from the queryString are different from the current state
-            if (sortKey) {
+            if (sortKey && sortKey in collection.sortableFields) {
                 if (sortKey !== collection.state.sortKey || order !== collection.state.order) {
                     fetchNeeded = true;
                     collection.setSorting(sortKey, order);

--- a/analytics_dashboard/static/apps/learners/app/controller.js
+++ b/analytics_dashboard/static/apps/learners/app/controller.js
@@ -87,7 +87,7 @@ define(function (require) {
                 // These JS errors occur when trying to parse invalid URL parameters
                 if (e instanceof RangeError || e instanceof TypeError) {
                     this.options.rootView.showAlert('error', gettext('Invalid Parameters'),
-                        gettext("Sorry, we couldn't find any learners who matched that query."),
+                        gettext('Sorry, we couldn\'t find any learners who matched that query.'),
                         {url: '#', text: gettext('Return to the Learners page.')});
                 } else {
                     throw e;

--- a/analytics_dashboard/static/apps/learners/app/controller.js
+++ b/analytics_dashboard/static/apps/learners/app/controller.js
@@ -174,7 +174,7 @@ define(function (require) {
             this.options.rootView.showChildView('main', new AlertView({
                 alertType: 'error',
                 title: gettext('Invalid Parameters'),
-                body: gettext('Sorry, we couldn\'t find learners for that query.'),
+                body: gettext('Sorry, we couldn\'t find any learners who matched that query.'),
                 link: {url: '#', text: gettext('Return to the Learners page.')}
             }));
 

--- a/analytics_dashboard/static/apps/learners/app/router.js
+++ b/analytics_dashboard/static/apps/learners/app/router.js
@@ -14,9 +14,13 @@ define(function (require) {
             '*notFound': 'showNotFoundPage'
         },
 
-        onRoute: function (routeName) {
-            if (routeName.indexOf('show') === 0) {
+        // This method is run before the route methods are run.
+        execute: function (callback, args, name) {
+            if (name.indexOf('show') === 0) {
                 this.options.controller.triggerMethod('showPage');
+            }
+            if (callback) {
+                callback.apply(this, args);
             }
         },
 

--- a/analytics_dashboard/static/apps/learners/app/router.js
+++ b/analytics_dashboard/static/apps/learners/app/router.js
@@ -35,8 +35,7 @@ define(function (require) {
         // sorts, or page numbers) into a url and then navigates the router to that url.
         updateUrl: function () {
             this.navigate(this.learnerCollection.getQueryString(), {replace: true});
-        },
-
+        }
     });
 
     return LearnersRouter;

--- a/analytics_dashboard/static/apps/learners/app/router.js
+++ b/analytics_dashboard/static/apps/learners/app/router.js
@@ -9,7 +9,6 @@ define(function (require) {
         // Routes intended to show a page in the app should map to method names
         // beginning with "show", e.g. 'showLearnerRosterPage'.
         appRoutes: {
-            // TODO: handle 'queryString' arguments in https://openedx.atlassian.net/browse/AN-6668
             '(/)(?*queryString)': 'showLearnerRosterPage',
             ':username(/)(?*queryString)': 'showLearnerDetailPage',
             '*notFound': 'showNotFoundPage'
@@ -19,7 +18,21 @@ define(function (require) {
             if (routeName.indexOf('show') === 0) {
                 this.options.controller.triggerMethod('showPage');
             }
-        }
+        },
+
+        initialize: function (options) {
+            this.options = options || {};
+            this.learnerCollection = options.controller.options.learnerCollection;
+            this.listenTo(this.learnerCollection, 'sync', this.updateUrl);
+            Marionette.AppRouter.prototype.initialize.call(this, options);
+        },
+
+        // Called on LearnerCollection update. Converts the state of the collection (including any filters, searchers,
+        // sorts, or page numbers) into a url and then navigates the router to that url.
+        updateUrl: function () {
+            this.navigate(this.learnerCollection.getQueryString());
+        },
+
     });
 
     return LearnersRouter;

--- a/analytics_dashboard/static/apps/learners/app/router.js
+++ b/analytics_dashboard/static/apps/learners/app/router.js
@@ -30,7 +30,7 @@ define(function (require) {
         // Called on LearnerCollection update. Converts the state of the collection (including any filters, searchers,
         // sorts, or page numbers) into a url and then navigates the router to that url.
         updateUrl: function () {
-            this.navigate(this.learnerCollection.getQueryString());
+            this.navigate(this.learnerCollection.getQueryString(), {replace: true});
         },
 
     });

--- a/analytics_dashboard/static/apps/learners/app/spec/controller-spec.js
+++ b/analytics_dashboard/static/apps/learners/app/spec/controller-spec.js
@@ -69,7 +69,7 @@ define(function (require) {
                 last_updated: new Date(2016, 1, 28),
                 course_id: courseId
             };
-            this.collection = new LearnerCollection([this.user], {parse: true});
+            this.collection = new LearnerCollection([this.user], {parse: true, url:'http://example.com'});
             this.controller = new LearnersController({
                 rootView: this.rootView,
                 learnerCollection: this.collection,
@@ -90,6 +90,25 @@ define(function (require) {
         it('should show the learner roster page', function () {
             this.controller.showLearnerRosterPage();
             expectRosterPage(this.controller);
+        });
+
+        it('should show the filtered learner roster page', function (done) {
+            this.controller.showLearnerRosterPage('text_search=foo');
+            this.controller.options.learnerCollection.once('sync', function () {
+                expectRosterPage(this.controller);
+                expect(this.controller.options.rootView.$('.learners-active-filters').html()).toContainText('foo');
+                done();
+            }, this, done);
+            expect(this.controller.options.rootView.$('.learners-main-region').html()).toContainText('Loading...');
+            server.requests[server.requests.length - 1].respond(200, {}, '{}');
+        });
+
+        it('should show invalid parameters alert with invalid URL parameters', function () {
+            this.controller.showLearnerRosterPage('text_search=foo=');
+            expect(this.controller.options.rootView.$('.learners-alert-region').html()).toContainText(
+                'Invalid Parameters'
+            );
+            expect(this.controller.options.rootView.$('.learners-main-region').html()).toBe('');
         });
 
         describe('navigating to the Learner Detail page', function () {

--- a/analytics_dashboard/static/apps/learners/app/spec/controller-spec.js
+++ b/analytics_dashboard/static/apps/learners/app/spec/controller-spec.js
@@ -139,6 +139,16 @@ define(function (require) {
 
                 server.requests[server.requests.length - 1].respond(500, {}, '');
             });
+
+            it('should have query string in return to learners navigation link', function () {
+                this.collection.state.currentPage = 2;
+                this.collection.setSearchString('foobar');
+                this.controller.showLearnerDetailPage('learner');
+                server.requests[0].respond(200, {}, JSON.stringify(this.user));
+                server.requests[server.requests.length - 1].respond(200, {}, JSON.stringify({}));
+                expect(this.controller.options.rootView.$('.learners-navigation-region a').attr('href'))
+                    .toEqual('#?text_search=foobar&page=2');
+                });
         });
 
         // The 'showPage' event gets fired by the router on the

--- a/analytics_dashboard/static/apps/learners/app/spec/controller-spec.js
+++ b/analytics_dashboard/static/apps/learners/app/spec/controller-spec.js
@@ -94,6 +94,7 @@ define(function (require) {
 
         it('should show the filtered learner roster page', function (done) {
             this.controller.showLearnerRosterPage('text_search=foo');
+            expect(this.controller.options.learnerCollection.getSearchString()).toEqual('foo');
             this.controller.options.learnerCollection.once('sync', function () {
                 expectRosterPage(this.controller);
                 expect(this.controller.options.rootView.$('.learners-active-filters').html()).toContainText('foo');

--- a/analytics_dashboard/static/apps/learners/app/spec/controller-spec.js
+++ b/analytics_dashboard/static/apps/learners/app/spec/controller-spec.js
@@ -149,7 +149,7 @@ define(function (require) {
                 server.requests[server.requests.length - 1].respond(200, {}, JSON.stringify({}));
                 expect(this.controller.options.rootView.$('.learners-navigation-region a').attr('href'))
                     .toEqual('#?text_search=foobar&page=2');
-                });
+            });
         });
 
         // The 'showPage' event gets fired by the router on the

--- a/analytics_dashboard/static/apps/learners/app/spec/router-spec.js
+++ b/analytics_dashboard/static/apps/learners/app/spec/router-spec.js
@@ -2,10 +2,10 @@ define(function (require) {
     'use strict';
 
     var Backbone = require('backbone'),
-        PageModel = require('learners/common/models/page'),
-        LearnersRouter = require('learners/app/router'),
+        LearnerCollection = require('learners/common/collections/learners'),
         LearnersController = require('learners/app/controller'),
-        LearnerCollection = require('learners/common/collections/learners');
+        LearnersRouter = require('learners/app/router'),
+        PageModel = require('learners/common/models/page');
 
     describe('LearnersRouter', function () {
         beforeEach(function () {
@@ -102,6 +102,5 @@ define(function (require) {
             });
             this.server.requests[0].respond(200, {}, JSON.stringify([this.user]));
         });
-
     });
 });

--- a/analytics_dashboard/static/apps/learners/app/spec/router-spec.js
+++ b/analytics_dashboard/static/apps/learners/app/spec/router-spec.js
@@ -4,21 +4,27 @@ define(function (require) {
     var Backbone = require('backbone'),
         Marionette = require('marionette'),
 
-        LearnersRouter = require('learners/app/router');
+        PageModel = require('learners/common/models/page'),
+        LearnersRouter = require('learners/app/router'),
+        LearnersController = require('learners/app/controller'),
+        LearnerCollection = require('learners/common/collections/learners');
 
     describe('LearnersRouter', function () {
         beforeEach(function () {
             Backbone.history.start({silent: true});
-            this.controller = new (Marionette.Object.extend({
-                showLearnerRosterPage: function () {},
-                showLearnerDetailPage: function () {},
-                showNotFoundPage: function () {},
-                onShowPage: function () {}
-            }))();
-            spyOn(this.controller, 'showLearnerRosterPage');
-            spyOn(this.controller, 'showLearnerDetailPage');
-            spyOn(this.controller, 'showNotFoundPage');
-            spyOn(this.controller, 'onShowPage');
+            this.server = sinon.fakeServer.create();
+            this.user = {
+                last_updated: new Date(2016, 1, 28)
+            };
+            this.collection = new LearnerCollection([this.user], {url: 'http://example.com'});
+            this.controller = new LearnersController({
+                learnerCollection: this.collection,
+                pageModel: new PageModel()
+            });
+            spyOn(this.controller, 'showLearnerRosterPage').and.stub();
+            spyOn(this.controller, 'showLearnerDetailPage').and.stub();
+            spyOn(this.controller, 'showNotFoundPage').and.stub();
+            spyOn(this.controller, 'onShowPage').and.stub();
             this.router = new LearnersRouter({
                 controller: this.controller
             });
@@ -28,6 +34,7 @@ define(function (require) {
             // Clear previous route
             this.router.navigate('');
             Backbone.history.stop();
+            this.server.restore();
         });
 
         it('triggers a showPage event for pages beginning with "show"', function () {
@@ -86,5 +93,17 @@ define(function (require) {
                 expect(this.controller.showNotFoundPage).toHaveBeenCalledWith('this/does/not/match', null);
             });
         });
+
+        it('URL fragment is updated on LearnerCollection sync', function (done) {
+            this.collection.state.currentPage = 2;
+            this.collection.setFilterField('text_search', 'foo');
+            this.collection.fetch({reset: true});
+            this.collection.once('sync', function () {
+                expect(Backbone.history.getFragment()).toBe('?text_search=foo&page=2');
+                done();
+            });
+            this.server.requests[0].respond(200, {}, JSON.stringify([this.user]));
+        });
+
     });
 });

--- a/analytics_dashboard/static/apps/learners/app/spec/router-spec.js
+++ b/analytics_dashboard/static/apps/learners/app/spec/router-spec.js
@@ -2,8 +2,6 @@ define(function (require) {
     'use strict';
 
     var Backbone = require('backbone'),
-        Marionette = require('marionette'),
-
         PageModel = require('learners/common/models/page'),
         LearnersRouter = require('learners/app/router'),
         LearnersController = require('learners/app/controller'),

--- a/analytics_dashboard/static/apps/learners/app/views/root.js
+++ b/analytics_dashboard/static/apps/learners/app/views/root.js
@@ -63,12 +63,15 @@ define(function (require) {
          * types are defined in the AlertView module.
          * @param {string} title - the title of the alert.
          * @param {string} description - the description of the alert.
+         * @param {object} link - the link for the alert. Has key "url"
+         * (the href) and key "text" (the display text for the link).
          */
-        showAlert: function (type, title, description) {
+        showAlert: function (type, title, description, link) {
             this.showChildView('alert', new AlertView({
                 alertType: type,
                 title: title,
-                body: description
+                body: description,
+                link: link
             }));
         },
 

--- a/analytics_dashboard/static/apps/learners/common/collections/learners.js
+++ b/analytics_dashboard/static/apps/learners/common/collections/learners.js
@@ -5,6 +5,7 @@ define(function (require) {
 
         LearnerModel = require('learners/common/models/learner'),
         LearnerUtils = require('learners/common/utils'),
+        Utils = require('utils/utils'),
 
         LearnerCollection;
 
@@ -54,24 +55,89 @@ define(function (require) {
             return this.hasNextPage();
         },
 
+        /**
+         * The following two methods encode and decode the state of the collection to a query string. This query string
+         * is different than queryParams, which we send to the API server during a fetch. Here, the string encodes the
+         * current user view on the collection including page number, filters applied, search query, and sorting. The
+         * string is then appended on to the fragment identifier portion of the URL.
+         *
+         * e.g. http://.../learners/#?text_search=foo&sortKey=username&order=desc&page=1
+         */
+
         // Encodes the state of the collection into a query string that can be appended onto the URL.
         getQueryString: function () {
             var params = this.getActiveFilterFields(true),
-                fragment = '?';
-            params.page = this.state.currentPage;
-            if (this.state.sortKey !== null) {
-                params.sortKey = this.state.sortKey;
-                params.order = this.state.order === 1 ? 'desc' : 'asc';
-            }
+                fragment = '?',
+                ordered_params = [];
+
+            // Because the active filter fields object is not ordered, these are the only params of ordered_params that
+            // don't have a defined order besides being before sortKey, order, and page.
             _.mapObject(params, function (val, key) {
+                ordered_params.push({key: key, val: val});
+            });
+
+            if (this.state.sortKey !== null) {
+                ordered_params.push({key: 'sortKey', val: this.state.sortKey});
+                ordered_params.push({key: 'order', val: this.state.order === 1 ? 'desc' : 'asc'});
+            }
+            ordered_params.push({key: 'page', val: this.state.currentPage});
+
+            _.each(ordered_params, function (param) {
                 if (fragment.length !== 1) {
                     fragment = fragment.concat('&');
                 }
                 // Note: this assumes that filter keys will never have URI special characters. We should encode the key
                 // too if that assumption is wrong.
-                fragment = fragment.concat(key, '=', encodeURIComponent(val));
+                fragment = fragment.concat(param.key, '=', encodeURIComponent(param.val));
             });
             return fragment === '?' ? '' : fragment;
+        },
+
+        /**
+         * Decodes a query string into arguments and sets the state of the collection to what the arguments describe.
+         * The query string argument should have already had the prefix '?' stripped (the AppRouter does this).
+         *
+         * Returns a boolean stating whether the new state differs from the old state (so the caller knows that the
+         * collection is stale and needs to do a fetch).
+         */
+        setStateFromQueryString: function (queryString) {
+            var params = Utils.parseQueryString(queryString),
+                order = -1,
+                order_name = 'ascending',
+                fetchNeeded = false,
+                page, sortKey;
+
+            _.mapObject(params, function (val, key) {
+                if (key === 'page') {
+                    page = parseInt(val, 10);
+                    if (page !== this.state.currentPage) {
+                        fetchNeeded = true;
+                    }
+                    this.state.currentPage = page;
+                } else if (key === 'sortKey') {
+                    sortKey = val;
+                } else if (key === 'order') {
+                    order = val === 'desc' ? 1 : -1;
+                    order_name = val === 'desc' ?  'descending' : 'ascending';
+                } else {
+                    if (key in this.filterableFields || key === 'text_search') {
+                        if (val !== this.getFilterFieldValue(key)) {
+                            fetchNeeded = true;
+                        }
+                        this.setFilterField(key, val);
+                    }
+                }
+            }, this);
+
+            // Set the sort state if sortKey or order from the queryString are different from the current state
+            if (sortKey && sortKey in this.sortableFields) {
+                if (sortKey !== this.state.sortKey || order !== this.state.order) {
+                    fetchNeeded = true;
+                    this.setSorting(sortKey, order);
+                }
+            }
+
+            return fetchNeeded;
         }
     });
 

--- a/analytics_dashboard/static/apps/learners/common/collections/learners.js
+++ b/analytics_dashboard/static/apps/learners/common/collections/learners.js
@@ -52,6 +52,26 @@ define(function (require) {
 
         hasNext: function () {
             return this.hasNextPage();
+        },
+
+        // Encodes the state of the collection into a query string that can be appended onto the URL.
+        getQueryString: function () {
+            var params = this.getActiveFilterFields(true),
+                fragment = '?';
+            params.page = this.state.currentPage;
+            if (this.state.sortKey !== null) {
+                params.sortKey = this.state.sortKey;
+                params.order = this.state.order === 1 ? 'desc' : 'asc';
+            }
+            _.mapObject(params, function (val, key) {
+                if (fragment.length !== 1) {
+                    fragment = fragment.concat('&');
+                }
+                // Note: this assumes that filter keys will never have URI special characters. We should encode the key
+                // too if that assumption is wrong.
+                fragment = fragment.concat(key, '=', encodeURIComponent(val));
+            });
+            return fragment === '?' ? '' : fragment;
         }
     });
 

--- a/analytics_dashboard/static/apps/learners/common/collections/spec/learners-spec.js
+++ b/analytics_dashboard/static/apps/learners/common/collections/spec/learners-spec.js
@@ -211,8 +211,8 @@ define(function (require) {
                 learners.setFilterField('enrollment_mode', 'audit');
                 learners.setFilterField('cohort', 'group1');
                 // order of filter fields in query string is not defined
-                var qstring = learners.getQueryString();
-                var pageAfterFilters = (qstring === '?enrollment_mode=audit&cohort=group1&page=1' ||
+                var qstring = learners.getQueryString(),
+                    pageAfterFilters = (qstring === '?enrollment_mode=audit&cohort=group1&page=1' ||
                                         qstring === '?cohort=group1&enrollment_mode=audit&page=1');
                 expect(pageAfterFilters).toBe(true);
             });

--- a/analytics_dashboard/static/apps/learners/common/collections/spec/learners-spec.js
+++ b/analytics_dashboard/static/apps/learners/common/collections/spec/learners-spec.js
@@ -189,5 +189,77 @@ define(function (require) {
                 expect(learners.hasNext()).toBe(false);
             });
         });
+
+        describe('Encoding State to a Query String', function () {
+            it('encodes an empty state', function () {
+                expect(learners.getQueryString()).toBe('?page=1');
+            });
+            it('encodes the page number', function () {
+                learners.state.currentPage = 2;
+                expect(learners.getQueryString()).toBe('?page=2');
+            });
+            it('encodes the sort state', function () {
+                learners.state.sortKey = 'username';
+                learners.state.order = 1;
+                expect(learners.getQueryString()).toBe('?sortKey=username&order=desc&page=1');
+            });
+            it('encodes the text search', function () {
+                learners.setFilterField('text_search', 'foo');
+                expect(learners.getQueryString()).toBe('?text_search=foo&page=1');
+            });
+            it('encodes the filters', function () {
+                learners.setFilterField('enrollment_mode', 'audit');
+                learners.setFilterField('cohort', 'group1');
+                // order of filter fields in query string is not defined
+                var qstring = learners.getQueryString();
+                var pageAfterFilters = (qstring === '?enrollment_mode=audit&cohort=group1&page=1' ||
+                                        qstring === '?cohort=group1&enrollment_mode=audit&page=1');
+                expect(pageAfterFilters).toBe(true);
+            });
+        });
+
+        describe('Decoding Query String to a State', function () {
+            var state = {};
+            beforeEach(function () {
+                state = {
+                    firstPage: 1,
+                    lastPage: null,
+                    currentPage: 1,
+                    pageSize: 25,
+                    totalPages: null,
+                    totalRecords: null,
+                    sortKey: null,
+                    order: -1
+                };
+            });
+            it('decodes an empty query string', function () {
+                learners.setStateFromQueryString('');
+                expect(learners.state).toEqual(state);
+                expect(learners.getActiveFilterFields()).toEqual({});
+            });
+            it('decodes the page number', function () {
+                state.currentPage = 2;
+                learners.setStateFromQueryString('page=2');
+                expect(learners.state).toEqual(state);
+                expect(learners.getActiveFilterFields()).toEqual({});
+            });
+            it('decodes the sort', function () {
+                state.sortKey = 'username';
+                state.order = 1;
+                learners.setStateFromQueryString('sortKey=username&order=desc');
+                expect(learners.state).toEqual(state);
+                expect(learners.getActiveFilterFields()).toEqual({});
+            });
+            it('decodes the text search', function () {
+                learners.setStateFromQueryString('text_search=foo');
+                expect(learners.state).toEqual(state);
+                expect(learners.getSearchString()).toEqual('foo');
+            });
+            it('decodes the filters', function () {
+                learners.setStateFromQueryString('enrollment_mode=audit&cohort=group1');
+                expect(learners.state).toEqual(state);
+                expect(learners.getActiveFilterFields()).toEqual({enrollment_mode: 'audit', cohort: 'group1'});
+            });
+        });
     });
 });

--- a/analytics_dashboard/static/apps/learners/common/templates/alert.underscore
+++ b/analytics_dashboard/static/apps/learners/common/templates/alert.underscore
@@ -9,7 +9,7 @@
                     <%- title %>
                 </div>
                 <% if (body) { %>
-                    <div class="body">
+                    <div class="alert-body">
                         <%- body %>
                     </div>
                 <% } %>

--- a/analytics_dashboard/static/apps/learners/common/templates/alert.underscore
+++ b/analytics_dashboard/static/apps/learners/common/templates/alert.underscore
@@ -9,16 +9,23 @@
                     <%- title %>
                 </div>
                 <% if (body) { %>
-                    <div>
+                    <div class="body">
                         <%- body %>
                     </div>
                 <% } %>
                 <% if (suggestions.length) { %>
-                    <ul class="suggestions">
-                        <% suggestions.map(function (suggestion) { %>
-                            <li><%- suggestion %></li>
-                        <% }); %>
-                    </ul>
+                    <div>
+                        <ul class="suggestions">
+                            <% suggestions.map(function (suggestion) { %>
+                                <li><%- suggestion %></li>
+                            <% }); %>
+                        </ul>
+                    </div>
+                <% } %>
+                <% if (link) { %>
+                    <div class="link">
+                        <a href="<%- link.url %>"><%- link.text %></a>
+                    </div>
                 <% } %>
             </div>
         </div>

--- a/analytics_dashboard/static/apps/learners/common/views/alert-view.js
+++ b/analytics_dashboard/static/apps/learners/common/views/alert-view.js
@@ -31,7 +31,8 @@ define(function (require) {
             alertType: 'info',  // default alert type
             title: undefined,   // string title of alert
             body: undefined,    // string body of alert
-            suggestions: []     // list of strings to display after the body
+            suggestions: [],    // list of strings to display after the body
+            link: undefined,    // string to display and url of link on alert
         },
 
         /**

--- a/analytics_dashboard/static/apps/learners/common/views/spec/alert-view-spec.js
+++ b/analytics_dashboard/static/apps/learners/common/views/spec/alert-view-spec.js
@@ -41,5 +41,24 @@ define(function (require) {
             expect(fixture).toContainElement('li');
         });
 
+        it('renders an alert with a link', function () {
+            var fixture = setFixtures('<div class="info-alert"></div>');
+
+            new AlertView({
+                el: '.info-alert',
+                alertType: 'info',
+                title: 'edX Info Alert',
+                body: 'More description about an information alert.',
+                suggestions: ['Display alerts.', 'Alerts are helpful messages!'],
+                link: {url: 'http://example.com', text: 'A helpful link.'}
+            }).render();
+
+            expect(fixture).toContainElement('i.fa-bullhorn');
+            expect(fixture).toContainElement('.alert-info-container');
+            expect(fixture).toContainElement('li');
+            expect(fixture).toContainElement('.link');
+            expect(fixture).toContainElement('a');
+        });
+
     });
 });

--- a/analytics_dashboard/static/apps/learners/detail/templates/return-to-learners.underscore
+++ b/analytics_dashboard/static/apps/learners/detail/templates/return-to-learners.underscore
@@ -1,4 +1,4 @@
-<a href="">
+<a href="#<%- queryString %>">
     <i class="fa fa-arrow-left" aria-hidden="true"></i>
     <%- returnText %>
 </a>

--- a/analytics_dashboard/static/apps/learners/detail/views/learner-return.js
+++ b/analytics_dashboard/static/apps/learners/detail/views/learner-return.js
@@ -9,7 +9,8 @@ define(function (require) {
 
         templateHelpers: function() {
             return {
-                returnText : gettext('Return to Learners')
+                returnText : gettext('Return to Learners'),
+                queryString: this.options.queryString
             };
         },
     });

--- a/analytics_dashboard/static/apps/learners/roster/templates/roster-loading.underscore
+++ b/analytics_dashboard/static/apps/learners/roster/templates/roster-loading.underscore
@@ -1,0 +1,3 @@
+<div class="loading">
+    <p class="text-center"><i class="fa fa-spinner fa-spin fa-lg" aria-hidden="true"></i> <%- loadingText %></p>
+</div>

--- a/analytics_dashboard/static/apps/learners/roster/views/base-header-cell.js
+++ b/analytics_dashboard/static/apps/learners/roster/views/base-header-cell.js
@@ -37,6 +37,11 @@ define(function (require) {
         },
 
         render: function (column, direction) {
+            if (this.collection.state.sortKey && this.collection.state.sortKey === this.column.attributes.name) {
+                direction = this.collection.state.order ? 'ascending' : 'descending';
+                this.column.attributes.direction = direction;
+                column = this.column;
+            }
             Backgrid.HeaderCell.prototype.render.apply(this, arguments);
             this.$el.html(this.template({
                 label: this.column.get('label')

--- a/analytics_dashboard/static/js/test/specs/utils-spec.js
+++ b/analytics_dashboard/static/js/test/specs/utils-spec.js
@@ -86,4 +86,18 @@ define(['utils/utils'], function (Utils) {
         });
     });
 
+    describe('parseQueryString', function () {
+        it('should parse query string', function () {
+            expect(Utils.parseQueryString('foo=bar&baz=quux')).toEqual({foo: 'bar', baz: 'quux'});
+            expect(Utils.parseQueryString('foo=bar&')).toEqual({foo: 'bar'});
+            expect(Utils.parseQueryString('foo=bar&baz')).toEqual({foo: 'bar', baz: ''});
+            expect(Utils.parseQueryString('foo=bar&baz=')).toEqual({foo: 'bar', baz: ''});
+            expect(Utils.parseQueryString('')).toEqual({});
+            expect(Utils.parseQueryString(null)).toEqual({});
+            expect(function () { Utils.parseQueryString('foo=bar='); }).toThrow(
+                new Error('Each "&"-separated substring must either be a key or a key-value pair')
+            );
+        });
+    });
+
 });

--- a/analytics_dashboard/static/js/utils/utils.js
+++ b/analytics_dashboard/static/js/utils/utils.js
@@ -103,6 +103,41 @@ define(['moment', 'underscore', 'utils/globalization'], function (moment, _, Glo
                 }
                 return time;
             }).join(':');
+        },
+
+        /**
+         * Converts the querystring portion of the URL into an object
+         * mapping keys to argument values.
+         *
+         * Examples:
+         * - 'foo=bar&baz=quux' -> {foo: 'bar', baz: 'quux'}
+         * - 'foo=bar&' -> {foo: 'bar'}
+         * - 'foo=bar&baz' -> {foo: 'bar', baz: ''}
+         * - 'foo=bar&baz=' -> {foo: 'bar', baz: ''}
+         * - '' -> {}
+         * - null -> {}
+         *
+         * @param queryString {string}
+         * @returns {object}
+         */
+        parseQueryString: function (queryString) {
+            if (queryString) {
+                return _(decodeURI(queryString).split('&')).map(function (namedVal) {
+                    var keyValPair = namedVal.split('='), obj = {};
+                    if (keyValPair.length === 1 && keyValPair[0]) {  // No value
+                        obj[keyValPair[0]] = '';
+                    } else if (keyValPair.length === 2){
+                        obj[keyValPair[0]] = keyValPair[1];
+                    } else if (keyValPair.length > 2) {  // Have something like foo=bar=...
+                        throw new Error('Each "&"-separated substring must either be a key or a key-value pair');
+                    }
+                    return obj;
+                }).reduce(function (memo, keyValPair) {
+                    return _.extend(memo, keyValPair);
+                });
+            } else {
+                return {}
+            }
         }
     };
 

--- a/analytics_dashboard/static/js/utils/utils.js
+++ b/analytics_dashboard/static/js/utils/utils.js
@@ -129,7 +129,7 @@ define(['moment', 'underscore', 'utils/globalization'], function (moment, _, Glo
                     } else if (keyValPair.length === 2){
                         obj[keyValPair[0]] = keyValPair[1];
                     } else if (keyValPair.length > 2) {  // Have something like foo=bar=...
-                        throw new Error('Each "&"-separated substring must either be a key or a key-value pair');
+                        throw new TypeError('Each "&"-separated substring must either be a key or a key-value pair');
                     }
                     return obj;
                 }).reduce(function (memo, keyValPair) {

--- a/analytics_dashboard/static/js/utils/utils.js
+++ b/analytics_dashboard/static/js/utils/utils.js
@@ -123,15 +123,15 @@ define(['moment', 'underscore', 'utils/globalization'], function (moment, _, Glo
         parseQueryString: function (queryString) {
             if (queryString) {
                 return _(decodeURI(queryString).split('&')).map(function (namedVal) {
-                    var keyValPair = namedVal.split('='), obj = {};
+                    var keyValPair = namedVal.split('='), params = {};
                     if (keyValPair.length === 1 && keyValPair[0]) {  // No value
-                        obj[keyValPair[0]] = '';
+                        params[keyValPair[0]] = '';
                     } else if (keyValPair.length === 2){
-                        obj[keyValPair[0]] = keyValPair[1];
+                        params[keyValPair[0]] = keyValPair[1];
                     } else if (keyValPair.length > 2) {  // Have something like foo=bar=...
                         throw new TypeError('Each "&"-separated substring must either be a key or a key-value pair');
                     }
-                    return obj;
+                    return params;
                 }).reduce(function (memo, keyValPair) {
                     return _.extend(memo, keyValPair);
                 });

--- a/analytics_dashboard/static/js/utils/utils.js
+++ b/analytics_dashboard/static/js/utils/utils.js
@@ -136,7 +136,7 @@ define(['moment', 'underscore', 'utils/globalization'], function (moment, _, Glo
                     return _.extend(memo, keyValPair);
                 });
             } else {
-                return {}
+                return {};
             }
         }
     };

--- a/analytics_dashboard/static/sass/_mixins.scss
+++ b/analytics_dashboard/static/sass/_mixins.scss
@@ -55,7 +55,7 @@
     padding-bottom: $padding-small-horizontal;
   }
 
-  .body, .link {
+  .alert-body, .link {
     padding-bottom: $padding-small-horizontal;
   }
 

--- a/analytics_dashboard/static/sass/_mixins.scss
+++ b/analytics_dashboard/static/sass/_mixins.scss
@@ -38,7 +38,7 @@
 
 @mixin alert-container($alert-color) {
   padding: $padding-large-horizontal $padding-large-vertical;
-  padding-bottom: $padding-large-horizontal * 2;
+  padding-bottom: ($padding-large-horizontal * 2) - $padding-small-horizontal;
   margin-bottom: $padding-large-horizontal * 2;
   background-color: $alert-background-color;
   border-top: 4px solid $alert-color;
@@ -52,6 +52,10 @@
   .short-message {
     font-size: $font-size-large;
     font-weight: 700;
+    padding-bottom: $padding-small-horizontal;
+  }
+
+  .body, .link {
     padding-bottom: $padding-small-horizontal;
   }
 


### PR DESCRIPTION
This change creates a two-way binding between the LearnerCollection state and the URL fragment identifier. As users paginate, apply filters, make searches, and sort on the learner roster the URL will update to include a query string that encodes their view on the roster. They can then copy the link out of their address bar to share. Loading the learner roster link with the query string in the fragment will load the roster table to the same state that it was copied at.

The learner detail page also deep links back to the previous roster table state in the "Return to Learners" link. The browser back button preserves the query string in the fragment identifier as well.

This will allow us to make more refined question links on the course home page that link to a filtered view of the roster page.

Completes [Jira story AN-6671](https://openedx.atlassian.net/browse/AN-6671) (marked internal only).

@ajpal @dsjen @lamagnifica @mulby 
