### PR TITLE
Fix edge cases for metric ranges

### DIFF
--- a/analytics_dashboard/static/apps/learners/common/models/course-metadata.js
+++ b/analytics_dashboard/static/apps/learners/common/models/course-metadata.js
@@ -94,6 +94,8 @@ define(function (require) {
                             return null;
                         }
                         return [
+                            // A null element is interpreted as infinity
+                            // Note: Something like [null, 0] is invalid. The API should not return that.
                             _.isNull(range[0]) ? Infinity : range[0],
                             _.isNull(range[1]) ? Infinity : range[1]
                         ];
@@ -134,6 +136,8 @@ define(function (require) {
          *     in-range.
          *   - When the range is infinite in the positive dimension, infinity is
          *     considered in-range.
+         *   - When the range has the same value on both sides, that value is
+         *     considered in-range, but only that value.
          *
          * @param value Value in question.
          * @param range Array of min and max.  May be null.

--- a/analytics_dashboard/static/apps/learners/common/models/course-metadata.js
+++ b/analytics_dashboard/static/apps/learners/common/models/course-metadata.js
@@ -94,7 +94,7 @@ define(function (require) {
                             return null;
                         }
                         return [
-                            _.isNull(range[0]) ? -Infinity : range[0],
+                            _.isNull(range[0]) ? Infinity : range[0],
                             _.isNull(range[1]) ? Infinity : range[1]
                         ];
                     });
@@ -141,6 +141,7 @@ define(function (require) {
         inMetricRange: function(value, range) {
             return _.isNull(range) ? false :
                 (value === Infinity && range[1] === Infinity) ? true :
+                (value === range[0] && range[0] === range[1]) ? true :
                 value >= range[0] && value < range[1];
         }
     });

--- a/analytics_dashboard/static/apps/learners/common/models/course-metadata.js
+++ b/analytics_dashboard/static/apps/learners/common/models/course-metadata.js
@@ -143,10 +143,13 @@ define(function (require) {
          * @param range Array of min and max.  May be null.
          */
         inMetricRange: function(value, range) {
-            return _.isNull(range) ? false :
-                (value === Infinity && range[1] === Infinity) ? true :
-                (value === range[0] && range[0] === range[1]) ? true :
-                value >= range[0] && value < range[1];
+            if (_.isNull(range)) {
+                return false;
+            } else if ((value === Infinity && range[1] === Infinity) ||
+                       (value === range[0] && range[0] === range[1])) {
+                return true;
+            }
+            return value >= range[0] && value < range[1];
         }
     });
 

--- a/analytics_dashboard/static/apps/learners/common/models/spec/course-metadata-spec.js
+++ b/analytics_dashboard/static/apps/learners/common/models/spec/course-metadata-spec.js
@@ -67,15 +67,22 @@ define(function (require) {
             var courseMetadata = new CourseMetadataModel({
                 engagement_ranges: {
                     problems_attempted: {
-                        below_average: [null, 0],
-                        average: [0, null],
+                        below_average: [0, 10],
+                        average: [10, null],
                         above_average: null
+                    },
+                    problem_attempts_per_completed: {
+                        below_average: [0, 10],
+                        average: [10, null],
+                        above_average: [null, null]
                     }
                 }
             }, {parse: true});
-            expect(courseMetadata.get('engagement_ranges').problems_attempted.below_average).toEqual([-Infinity, 0]);
-            expect(courseMetadata.get('engagement_ranges').problems_attempted.average).toEqual([0, Infinity]);
+            expect(courseMetadata.get('engagement_ranges').problems_attempted.below_average).toEqual([0, 10]);
+            expect(courseMetadata.get('engagement_ranges').problems_attempted.average).toEqual([10, Infinity]);
             expect(courseMetadata.get('engagement_ranges').problems_attempted.above_average).toEqual(null);
+            expect(courseMetadata.get('engagement_ranges').problem_attempts_per_completed.above_average)
+                .toEqual([Infinity, Infinity]);
         });
 
         it('does not parse engagement date range', function () {
@@ -111,6 +118,12 @@ define(function (require) {
             it('inf is included in ranges with an infinite upper bound', function () {
                 var courseMetadata = new CourseMetadataModel();
                 expect(courseMetadata.inMetricRange(Infinity, [0, Infinity])).toBe(true);
+            });
+
+            it('value is included in ranges where value is specified on both sides', function () {
+                var courseMetadata = new CourseMetadataModel();
+                expect(courseMetadata.inMetricRange(0, [0, 0])).toBe(true);
+                expect(courseMetadata.inMetricRange(Infinity, [Infinity, Infinity])).toBe(true);
             });
         });
 


### PR DESCRIPTION
This resolves [AN-7462](https://openedx.atlassian.net/browse/AN-7462) (internal).
1. A null on the left side of the range given from the API is now interpreted as Infinity.
   - e.g.: [null, null] -> [Infinity, Infinity]
   - it used to be considered negative Infinity (-Infinity), but we decided that metric ranges will not contain negative values.
2. `inMetricRange()` now considers X in range of a range [X, X].
   - e.g.: Infinity is in [Infinity, Infinity]

@ajpal @dsjen 
