### PR TITLE
Configure eslint resolver for requirejs/bower/amd

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,7 +27,7 @@
                                 "json!cldr-data/supplemental/numberingSystems.json"]
     },
     "rules": {
-        "import/no-unresolved": [2, {"amd": true}],
+        "import/no-unresolved": ["error", {"amd": true}],
         "no-new" : "off",
         "no-param-reassign" : "off",
         "no-undef" : "off",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,8 +6,28 @@
 		"setFixtures": true,  // added globally by jasmine-jquery
 		"sinon": true // used for mocking
 	},
+    "settings": {
+        "import/resolver": {
+            "node": {
+                "extensions": [".js", ".json"],
+                "moduleDirectory": ["node_modules", "analytics_dashboard/static",
+                                    "analytics_dashboard/static/js"]
+            }
+        },
+        "import/core-modules": ["jquery", "underscore", "backbone", "backbone.paginator", "backbone.wreqr",
+                                "backbone.babysitter", "backgrid", "backgrid-filter", "backgrid-paginator", "bootstrap",
+                                "bootstrap_accessibility", "models", "collections", "views", "utils", "load",
+                                "datatables", "dataTablesBootstrap", "naturalSort", "d3", "nvd3", "topojson",
+                                "datamaps", "moment", "text", "json", "cldr", "cldr-data", "globalize", "globalization",
+                                "marionette", "uitk", "URI", "IPv6", "punycode", "SecondLevelDomains", "learners",
+                                "axe-core", "sinon", "nprogress",
+                                "vendor/domReady!", "globalize/number", "boot",
+                                "uitk/disclosure/disclosure-view",
+                                "json!cldr-data/supplemental/likelySubtags.json",
+                                "json!cldr-data/supplemental/numberingSystems.json"]
+    },
 	"rules": {
-		"import/no-unresolved": "off",
+        "import/no-unresolved": [2, {"amd": true}],
 	    "no-new" : "off",
 	    "no-param-reassign" : "off",
 	    "no-undef" : "off",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,11 +1,11 @@
 {
-	"extends": "eslint-config-edx",
-	"globals": {
-		"gettext": true, // added by django for i18n
-		"fixLanguageCode": true, // global function to correct window.language
-		"setFixtures": true,  // added globally by jasmine-jquery
-		"sinon": true // used for mocking
-	},
+    "extends": "eslint-config-edx",
+    "globals": {
+        "gettext": true, // added by django for i18n
+        "fixLanguageCode": true, // global function to correct window.language
+        "setFixtures": true,  // added globally by jasmine-jquery
+        "sinon": true // used for mocking
+    },
     "settings": {
         "import/resolver": {
             "node": {
@@ -26,14 +26,14 @@
                                 "json!cldr-data/supplemental/likelySubtags.json",
                                 "json!cldr-data/supplemental/numberingSystems.json"]
     },
-	"rules": {
+    "rules": {
         "import/no-unresolved": [2, {"amd": true}],
-	    "no-new" : "off",
-	    "no-param-reassign" : "off",
-	    "no-undef" : "off",
-	    "array-callback-return" : "off",
-	    "no-restricted-syntax" : "off",
-	    "vars-on-top" : "off",
-	    "global-require" : "off"
-	}
+        "no-new" : "off",
+        "no-param-reassign" : "off",
+        "no-undef" : "off",
+        "array-callback-return" : "off",
+        "no-restricted-syntax" : "off",
+        "vars-on-top" : "off",
+        "global-require" : "off"
+    }
 }


### PR DESCRIPTION
Resolves [AN-7514](https://openedx.atlassian.net/browse/AN-7514).

Enables `import/no-unresolved` and configures the resolver for this repo. 

**Caveat**
The eslint-plugin-import does not really support requirejs, unfortunately. If we want to, in the future, add a bower package, use one of the requirejs special characters (`!`), or reference a sub folder of a module, we will have to add that required string to the `"import/core-modules"` setting in the `.eslintrc.json` for the linter to succeed. I'm open to suggestions on how to best communicate this issue to developers.

The resolver can resolve npm packages in node_modules and javascript/json in the static folder.
