### PR TITLE
Specify utc in moment.js and pass datetime to api

### DIFF
--- a/acceptance_tests/test_course_engagement.py
+++ b/acceptance_tests/test_course_engagement.py
@@ -64,7 +64,7 @@ class CourseEngagementContentTests(CourseEngagementPageTestsMixin, WebAppTest):
 
     def _test_engagement_metrics(self):
         """ Verify the metrics tiles display the correct information. """
-        end_date = datetime.datetime.utcnow().strftime(self.analytics_api_client.DATE_FORMAT)
+        end_date = datetime.datetime.utcnow().strftime(self.analytics_api_client.DATETIME_FORMAT)
         recent_activity = self.course.activity(end_date=end_date)[-1]
 
         # Verify the activity values
@@ -85,7 +85,7 @@ class CourseEngagementContentTests(CourseEngagementPageTestsMixin, WebAppTest):
         date_time_format = self.analytics_api_client.DATETIME_FORMAT
 
         end_date = datetime.datetime.utcnow()
-        end_date_string = end_date.strftime(self.analytics_api_client.DATE_FORMAT)
+        end_date_string = end_date.strftime(self.analytics_api_client.DATETIME_FORMAT)
 
         trend_activity = self.course.activity(start_date=None, end_date=end_date_string)
         trend_activity = sorted(trend_activity, reverse=True, key=lambda item: item['interval_end'])

--- a/acceptance_tests/test_course_enrollment.py
+++ b/acceptance_tests/test_course_enrollment.py
@@ -24,7 +24,7 @@ class CourseEnrollmentActivityTests(CoursePageTestsMixin, WebAppTest):
         Returns all historical enrollment data for enrollment count collection.
         """
         end_date = datetime.datetime.utcnow()
-        end_date_string = end_date.strftime(self.analytics_api_client.DATE_FORMAT)
+        end_date_string = end_date.strftime(self.analytics_api_client.DATETIME_FORMAT)
         return self.course.enrollment('mode', start_date=None, end_date=end_date_string)
 
     def test_page(self):

--- a/acceptance_tests/test_course_enrollment_demographics.py
+++ b/acceptance_tests/test_course_enrollment_demographics.py
@@ -122,7 +122,7 @@ class CourseEnrollmentDemographicsGenderTests(CourseDemographicsPageTestsMixin, 
         self.course = self.analytics_api_client.courses(self.page.course_id)
 
         end_date = datetime.datetime.utcnow()
-        end_date_string = end_date.strftime(self.analytics_api_client.DATE_FORMAT)
+        end_date_string = end_date.strftime(self.analytics_api_client.DATETIME_FORMAT)
         response = self.course.enrollment(self.demographic_type, end_date=end_date_string)
         self.demographic_data = sorted(response, key=lambda x: datetime.datetime.strptime(x['date'], '%Y-%m-%d'),
                                        reverse=True)

--- a/analytics_dashboard/courses/presenters/engagement.py
+++ b/analytics_dashboard/courses/presenters/engagement.py
@@ -122,8 +122,7 @@ class CourseEngagementActivityPresenter(BasePresenter):
         """
         Retrieve recent summary and all historical trend data.
         """
-        # setting the end date (exclusive) to the next day retrieves data as soon as it's available
-        end_date = (datetime.datetime.utcnow() + datetime.timedelta(days=1)).strftime(Client.DATE_FORMAT)
+        end_date = datetime.datetime.utcnow().strftime(Client.DATETIME_FORMAT)
         api_trends = self.course.activity(start_date=None, end_date=end_date)
         summary = self._build_summary(api_trends)
         trends = self._build_trend(api_trends)

--- a/analytics_dashboard/static/apps/learners/detail/views/spec/engagement-timeline-spec.js
+++ b/analytics_dashboard/static/apps/learners/detail/views/spec/engagement-timeline-spec.js
@@ -30,7 +30,7 @@ define(function(require) {
             var dates,
                 xLabels;
             dates = _.map(view.model.get('days'), function(day) {
-                return moment(Date.parse(day.date)).format('M/D');
+                return moment.utc(Date.parse(day.date)).format('M/D');
             });
             // Note that NVD3 unfortunately doesn't semantically order the
             // x-axis labels in the DOM, so we can't verify each label in order.

--- a/analytics_dashboard/static/js/utils/utils.js
+++ b/analytics_dashboard/static/js/utils/utils.js
@@ -46,7 +46,7 @@ define(['moment', 'underscore', 'utils/globalization'], function(moment, _, Glob
             } else {
                 moment.locale(window.language);
             }
-            return moment(date).format('LL');
+            return moment.utc(date).format('LL');
         },
 
         /**

--- a/analytics_dashboard/static/js/views/trends-view.js
+++ b/analytics_dashboard/static/js/views/trends-view.js
@@ -32,7 +32,7 @@ define(['moment', 'nvd3', 'underscore', 'views/chart-view'],
 
             formatXTick: function(d) {
                 // overriding default to display a formatted date
-                return moment(d).format('M/D');
+                return moment.utc(d).format('M/D');
             },
 
             parseXData: function(d) {


### PR DESCRIPTION
Resolves [AN-5991](https://openedx.atlassian.net/browse/AN-5991).
1. Use `moment.utc()` when parsing UTC dates from the API.
   - This corrects the week end dates in the chart's X-axis. (for all trend charts in Insights)
2. For the engagement views, instead of having Insights pass the current day + 1 day to the API, pass the full date AND time to the API.
   - This is just less hacky. It shouldn't effect what the user is seeing.
   - The API documentation states that passing a time component with the dates is supported, but it actually was not. I had to make a bug fix in the API repo.
   - The engagements API uses the time component for start and end dates. However the enrollment API does not, so we still only pass date without time for enrollment.

Note: The "Download CSV" button downloads the raw data from the API. Instead of the data table that displays the "Week Ending" date, the API returns an interval start and interval end. The interval end is exclusive, so it would say Monday at 00:00, whereas the data table and chart would show Sunday as the latest day. We decided this is okay since we are explicitly stating the time 00:00.

The acceptance tests are failing because [my PR in edx-analytics-data-api](https://github.com/edx/edx-analytics-data-api/pull/127) needs to be merged first.

@dsjen @ajpal 
