### PR TITLE
Adds a short description of the Activity Over Time report

### DIFF
--- a/docs/en_us/dashboard/source/learners/Learner_Activity.rst
+++ b/docs/en_us/dashboard/source/learners/Learner_Activity.rst
@@ -23,7 +23,7 @@ previous day (23:59 UTC).
 Gaining Insight into Individual Learner Activities
 **************************************************
 
-EdX Insights delivers data about the activities of individual learners in a
+Insights delivers data about the activities of individual learners in a
 report and in charts of activity over time. Descriptions of the report and
 charts follow; for detailed information about the computations, see
 :ref:`Learner Computations`.
@@ -32,7 +32,7 @@ charts follow; for detailed information about the computations, see
 Learner Roster and Key Activity Report
 =========================================
 
-EdX Insights delivers data about the engagement of individual learners by
+Insights delivers data about the engagement of individual learners by
 providing counts for the following key activities.
 
 * Problems Tried
@@ -161,6 +161,16 @@ instructor dashboard of an edx.org course.
 
 When you use Insights, be sure to follow your organization's guidelines for
 communicating with learners.
+
+=========================
+Activity Over Time Report
+=========================
+
+A report of specific course activities that the learner completed each day is
+available for review. Columns show the counts of **Discussion Contributions**,
+**Problems Correct**, and **Videos Viewed**.
+
+See the :ref:`Reference` section for a detailed description of each value.
 
 **************************************************************
 Analytics in Action: Interpreting Individual Activity Patterns


### PR DESCRIPTION
## [DOC-3120](https://openedx.atlassian.net/browse/DOC-3120)

Adds a description of the Activity Over Time report (available onscreen only) for a selected learner. Example: https://stage-insights.edx.org/courses/course-v1%3AMITProfessionalX%2BIOTx%2B2016_T1/learners/#ABWheeler 
### Reviewers

Possible roles follow. PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [ ] Subject matter expert: @ajpal 
- [x] Subject matter expert: @dsjen 
- [x] Doc team review (sanity check/copy edit/dev edit): @catong @srpearce @pdesjardins 
- [x] Product review: @stroilova 
- [ ] Partner support: 
- [ ] PM review: 

FYI: @watsonemily
### Testing
- [x] Ran make html without warnings or errors
### Post-review
- [ ] Squash commits
