### PR TITLE
Updated Makefile and README to new waffle CLI syntax.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,10 +65,10 @@ validate_js: requirements.js
 validate: validate_python validate_js
 
 demo:
-	python manage.py switch show_engagement_forum_activity off --create
-	python manage.py switch enable_course_api off --create
-	python manage.py switch display_names_for_course_index off --create
-	python manage.py switch display_course_name_in_nav off --create
+	python manage.py waffle_switch show_engagement_forum_activity off --create
+	python manage.py waffle_switch enable_course_api off --create
+	python manage.py waffle_switch display_names_for_course_index off --create
+	python manage.py waffle_switch display_course_name_in_nav off --create
 
 compile_translations:
 	cd analytics_dashboard && i18n_tool generate -v

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ The following switches are available:
 | display_names_for_course_index | Display course names on course index page.            |
 | display_course_name_in_nav     | Display course name in navigation bar.                |
 
+[Waffle](http://waffle.readthedocs.org/en/latest/) flags are used to disable/enable
+functionality on request (e.g. turning on beta functionality for superusers). Create a
+[flag](http://waffle.readthedocs.io/en/latest/usage/cli.html#flags):
+
+        $ ./manage.py waffle_flag feature_name [on/off] --create
+
 The following flags are available:
 
 | Flag                           | Purpose                                               |

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Feature Gating
 Need a fallback to disable a feature? Create a [Waffle](http://waffle.readthedocs.org/en/latest/)
 [switch](http://waffle.readthedocs.org/en/latest/types/switch.html):
 
-        $ ./manage.py switch feature_name [on/off] --create
+        $ ./manage.py waffle_switch feature_name [on/off] --create
 
 See the [Waffle documentation](http://waffle.readthedocs.org/en/latest/) for
 details on utilizing features in code and templates.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Feature Gating
 Need a fallback to disable a feature? Create a [Waffle](http://waffle.readthedocs.org/en/latest/)
 [switch](http://waffle.readthedocs.org/en/latest/types/switch.html):
 
-        $ ./manage.py waffle_switch feature_name [on/off] --create
+        $ ./manage.py waffle_flag feature_name --percent=50 --rollout --create
 
 See the [Waffle documentation](http://waffle.readthedocs.org/en/latest/) for
 details on utilizing features in code and templates.


### PR DESCRIPTION
The command line interface for waffle has changed a bit.  `switch` is now `waffle_switch`.

Please review, @ajpal & @thallada 

@lamagnifica -- The examples in http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/installation/analytics/start_analytics.html#starting-open-edx-insights need to be updated from `switch` to `waffle_switch` too.  Is it best to create a doc story for this update?
