### PR TITLE
Show full date with year in trend charts

### DIFF
--- a/analytics_dashboard/static/apps/learners/detail/views/spec/engagement-timeline-spec.js
+++ b/analytics_dashboard/static/apps/learners/detail/views/spec/engagement-timeline-spec.js
@@ -30,7 +30,7 @@ define(function(require) {
             var dates,
                 xLabels;
             dates = _.map(view.model.get('days'), function(day) {
-                return moment.utc(Date.parse(day.date)).format('M/D');
+                return moment.utc(Date.parse(day.date)).format('D MMM YYYY');
             });
             // Note that NVD3 unfortunately doesn't semantically order the
             // x-axis labels in the DOM, so we can't verify each label in order.

--- a/analytics_dashboard/static/js/test/specs/trends-view-spec.js
+++ b/analytics_dashboard/static/js/test/specs/trends-view-spec.js
@@ -12,7 +12,7 @@ define(['models/course-model', 'views/trends-view'], function(CourseModel, Trend
                     key: 'date'
                 }
             });
-            expect(view.formatXTick('2014-06-15')).toBe('6/15');
+            expect(view.formatXTick('2014-06-15')).toBe('15 Jun 2014');
         });
 
         it('should parse x data as a timestamp', function() {

--- a/analytics_dashboard/static/js/views/chart-view.js
+++ b/analytics_dashboard/static/js/views/chart-view.js
@@ -8,7 +8,7 @@ define(['d3', 'jquery', 'nvd3', 'underscore', 'utils/utils', 'views/attribute-li
         var ChartView = AttributeListenerView.extend({
 
             defaults: _.extend({}, AttributeListenerView.prototype.defaults, {
-                displayExplicitTicksThreshold: 11,
+                displayExplicitTicksThreshold: 9,
                 excludeData: [],  // e.g. excludes data rows from chart (e.g. 'Unknown')
                 dataType: 'int',  // e.g. int, percent
                 xAxisMargin: 6,
@@ -208,7 +208,7 @@ define(['d3', 'jquery', 'nvd3', 'underscore', 'utils/utils', 'views/attribute-li
                 var self = this;
 
                 // minimize the spacing, but leave enough for point at the top to be shown w/o being clipped
-                chart.margin({top: self.options.xAxisMargin})
+                chart.margin({top: self.options.xAxisMargin, right: 60})
                     .height(300)    // This should be the same as the height set on the chart container in CSS.
                     .forceY(0)
                     .x(function(d) {
@@ -294,6 +294,10 @@ define(['d3', 'jquery', 'nvd3', 'underscore', 'utils/utils', 'views/attribute-li
                     }
                 }
 
+                if (_.isFunction(self.chart.xScale)) {
+                    self.chart.xScale(d3.time.scale.utc());
+                }
+                self.chart.xAxis.ticks(d3.time.month);
                 self.chart.xAxis.tickFormat(self.options.truncateXTicks ? self.truncateXTick : self.formatXTick);
 
                 self.chart.yAxis

--- a/analytics_dashboard/static/js/views/chart-view.js
+++ b/analytics_dashboard/static/js/views/chart-view.js
@@ -8,7 +8,7 @@ define(['d3', 'jquery', 'nvd3', 'underscore', 'utils/utils', 'views/attribute-li
         var ChartView = AttributeListenerView.extend({
 
             defaults: _.extend({}, AttributeListenerView.prototype.defaults, {
-                displayExplicitTicksThreshold: 9,
+                displayExplicitTicksThreshold: 11,
                 excludeData: [],  // e.g. excludes data rows from chart (e.g. 'Unknown')
                 dataType: 'int',  // e.g. int, percent
                 xAxisMargin: 6,
@@ -294,10 +294,6 @@ define(['d3', 'jquery', 'nvd3', 'underscore', 'utils/utils', 'views/attribute-li
                     }
                 }
 
-                if (_.isFunction(self.chart.xScale)) {
-                    self.chart.xScale(d3.time.scale.utc());
-                }
-                self.chart.xAxis.ticks(d3.time.month);
                 self.chart.xAxis.tickFormat(self.options.truncateXTicks ? self.truncateXTick : self.formatXTick);
 
                 self.chart.yAxis

--- a/analytics_dashboard/static/js/views/trends-view.js
+++ b/analytics_dashboard/static/js/views/trends-view.js
@@ -32,7 +32,7 @@ define(['moment', 'nvd3', 'underscore', 'views/chart-view'],
 
             formatXTick: function(d) {
                 // overriding default to display a formatted date
-                return moment.utc(d).format('M/D');
+                return moment.utc(d).format('D MMM YYYY');
             },
 
             parseXData: function(d) {


### PR DESCRIPTION
[AN-4035](https://openedx.atlassian.net/browse/AN-4035)

Instead of dates like "1/11", display full dates like "11 Jan 2016". See ticket for images.

@dsjen @ajpal 
