### PR TITLE
Adds a "Download CSV" button to the Learner List View

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,8 @@ quality:
 
 validate_python: test.requirements test_python quality
 
-validate_js: requirements.js
+#FIXME validate_js: requirements.js
+validate_js:
 	$(NODE_BIN)/gulp test
 	$(NODE_BIN)/gulp lint
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The following switches are available:
 | display_names_for_course_index       | Display course names on course index page.            |
 | display_course_name_in_nav           | Display course name in navigation bar.                |
 | enable_performance_learning_outcome  | Enable performance section with learning outcome breakdown (functionality based on tagging questions in Studio) | 
+| enable_learner_download              | Display Download CSV button on Learner List page.     |
 
 [Waffle](http://waffle.readthedocs.org/en/latest/) flags are used to disable/enable
 functionality on request (e.g. turning on beta functionality for superusers). Create a

--- a/analytics_dashboard/learner_analytics_api/v0/clients.py
+++ b/analytics_dashboard/learner_analytics_api/v0/clients.py
@@ -1,5 +1,5 @@
 import requests
-from slumber import API, exceptions, Resource
+from slumber import API, exceptions, Resource, serialize
 
 from django.conf import settings
 
@@ -12,6 +12,21 @@ class TokenAuth(requests.auth.AuthBase):
     def __call__(self, r):
         r.headers['Authorization'] = 'Token {}'.format(self.token)
         return r
+
+
+class TextSerializer(serialize.BaseSerializer):
+    """
+    Slumber API Serializer for text data, e.g. CSV.
+    """
+    key = 'text'
+    content_types = ('text/csv', 'text/plain', )
+
+    def unchanged(self, data):
+        """Leaves the request/response data unchanged."""
+        return data
+
+    # Define the abstract methods from BaseSerializer
+    dumps = loads = unchanged
 
 
 class LearnerApiResource(Resource):
@@ -30,17 +45,28 @@ class LearnerApiResource(Resource):
         return response
 
     def _process_response(self, response):
+        response.serialized_content = self._try_to_serialize_response(response)
         return response
 
 
 class LearnerAPIClient(API):
     resource_class = LearnerApiResource
 
-    def __init__(self, timeout=5):
+    def __init__(self, timeout=5, serializer_type='json'):
         session = requests.session()
         session.timeout = timeout
+
+        serializers = serialize.Serializer(
+            default=serializer_type,
+            serializers=[
+                serialize.JsonSerializer(),
+                serialize.YamlSerializer(),
+                TextSerializer(),
+            ]
+        )
         super(LearnerAPIClient, self).__init__(
             settings.DATA_API_URL,
             session=session,
-            auth=TokenAuth(settings.DATA_API_AUTH_TOKEN)
+            auth=TokenAuth(settings.DATA_API_AUTH_TOKEN),
+            serializer=serializers,
         )

--- a/analytics_dashboard/learner_analytics_api/v0/renderers.py
+++ b/analytics_dashboard/learner_analytics_api/v0/renderers.py
@@ -1,0 +1,12 @@
+"""
+Custom Django REST Framework rendererers used by the learner analytics API views.
+"""
+from rest_framework.renderers import BaseRenderer
+
+
+class TextRenderer(BaseRenderer):
+    """Renders the REST response data without modification."""
+
+    def render(self, data, *_args, **_kwargs):
+        """Return the data unchanged."""
+        return data

--- a/analytics_dashboard/learner_analytics_api/v0/urls.py
+++ b/analytics_dashboard/learner_analytics_api/v0/urls.py
@@ -10,6 +10,7 @@ app_name = 'v0'
 urlpatterns = [
     url(r'^learners/{}/$'.format(USERNAME_PATTERN), views.LearnerDetailView.as_view(), name='LearnerDetail'),
     url(r'^learners/$', views.LearnerListView.as_view(), name='LearnerList'),
+    url(r'^learners.csv$', views.LearnerListCSV.as_view(), name='LearnerListCSV'),
     url(r'^engagement_timelines/{}/$'.format(USERNAME_PATTERN),
         views.EngagementTimelinesView.as_view(),
         name='EngagementTimeline'),

--- a/analytics_dashboard/learner_analytics_api/v0/views.py
+++ b/analytics_dashboard/learner_analytics_api/v0/views.py
@@ -1,5 +1,3 @@
-import json
-
 from requests.exceptions import ConnectTimeout
 
 from rest_framework.exceptions import PermissionDenied
@@ -9,15 +7,23 @@ from rest_framework.response import Response
 
 from .clients import LearnerAPIClient
 from .permissions import HasCourseAccessPermission
+from .renderers import TextRenderer
 
 
 # TODO: Consider caching responses from the data api when working on AN-6157
 class BaseLearnerApiView(RetrieveAPIView):
     permission_classes = (IsAuthenticated, HasCourseAccessPermission,)
 
+    # Serialize the the Learner Analytics API response to JSON, by default.
+    serializer_type = 'json'
+
+    # Do not return the HTTP headers from the Data API, by default.
+    # This will be further investigated in AN-6928.
+    include_headers = False
+
     def __init__(self, *args, **kwargs):
         super(BaseLearnerApiView, self).__init__(*args, **kwargs)
-        self.client = LearnerAPIClient()
+        self.client = LearnerAPIClient(serializer_type=self.serializer_type)
 
     def get_queryset(self):
         """
@@ -37,15 +43,26 @@ class BaseLearnerApiView(RetrieveAPIView):
             course_id = self.request.query_params.get('course_id')
         return course_id
 
-    def get(self, request, api_response, *args, **kwargs):
+    def get(self, request, *args, **kwargs):
         """
-        Return the same response as the one from the Data API EXCEPT for the
-        HTTP headers.  This will be further investigated in AN-6928.
+        Return the response from the Data API.
         """
-        return Response(
-            data=json.loads(api_response.content),
+        api_response = self.get_api_response(request, *args, **kwargs)
+        response_kwargs = dict(
+            data=api_response.serialized_content,
             status=api_response.status_code,
         )
+        if self.include_headers:
+            response_kwargs['headers'] = api_response.headers
+        return Response(**response_kwargs)
+
+    def get_api_response(self, request, *args, **kwargs):
+        """
+        Fetch the response from the API.
+
+        Must be implemented by subclasses.
+        """
+        raise NotImplementedError('Override this method to return the Learner Analytics API response for this view.')
 
     def handle_exception(self, exc):
         """
@@ -58,6 +75,26 @@ class BaseLearnerApiView(RetrieveAPIView):
                 status=504
             )
         return super(BaseLearnerApiView, self).handle_exception(exc)
+
+
+class DownloadLearnerApiViewMixin(object):
+    """
+    Requests text/csv data from the Learner Analytics API, and ensures that the REST framework returns it unparsed,
+    including the response headers.
+    """
+    include_headers = True
+    content_type = 'text/csv'
+    serializer_type = 'text'
+
+    def get_api_response(self, request, **kwargs):
+        """
+        Sets the HTTP_ACCEPT header on the request to tell the Learner Analytics API which format to return its data in.
+
+        And tells the REST framework to render as text.  NB: parent class must also define get_api_response()
+        """
+        request.META['Accept'] = self.content_type
+        request.accepted_renderer = TextRenderer()
+        return super(DownloadLearnerApiViewMixin, self).get_api_response(request, **kwargs)
 
 
 class NotFoundLearnerApiViewMixin(object):
@@ -93,16 +130,24 @@ class LearnerDetailView(NotFoundLearnerApiViewMixin, BaseLearnerApiView):
         message += 'for course {}.'.format(self.course_id) if self.course_id else '.'
         return message
 
-    def get(self, request, username, **kwargs):
-        return super(LearnerDetailView, self).get(request, self.client.learners(username).get(**request.query_params))
+    def get_api_response(self, request, username, **kwargs):
+        return self.client.learners(username).get(**request.query_params)
 
 
 class LearnerListView(BaseLearnerApiView):
     """
     Forwards requests to the Learner Analytics API's Learner List endpoint.
     """
-    def get(self, request, **kwargs):
-        return super(LearnerListView, self).get(request, self.client.learners.get(**request.query_params))
+    def get_api_response(self, request, **kwargs):
+        return self.client.learners.get(**request.query_params)
+
+
+class LearnerListCSV(DownloadLearnerApiViewMixin, LearnerListView):
+    """
+    Forwards text/csv requests to the Learner Analytics API's Learner List endpoint,
+    and returns a simple text response.
+    """
+    pass
 
 
 class EngagementTimelinesView(NotFoundLearnerApiViewMixin, BaseLearnerApiView):
@@ -118,17 +163,13 @@ class EngagementTimelinesView(NotFoundLearnerApiViewMixin, BaseLearnerApiView):
         message += 'for course {}.'.format(self.course_id) if self.course_id else '.'
         return message
 
-    def get(self, request, username, **kwargs):
-        return super(EngagementTimelinesView, self).get(
-            request, self.client.engagement_timelines(username).get(**request.query_params)
-        )
+    def get_api_response(self, request, username, **kwargs):
+        return self.client.engagement_timelines(username).get(**request.query_params)
 
 
 class CourseLearnerMetadataView(BaseLearnerApiView):
     """
     Forwards requests to the Learner Analytics API's Course Metadata endpoint.
     """
-    def get(self, request, course_id, **kwargs):
-        return super(CourseLearnerMetadataView, self).get(
-            request, self.client.course_learner_metadata(course_id).get(**request.query_params)
-        )
+    def get_api_response(self, request, course_id, **kwargs):
+        return self.client.course_learner_metadata(course_id).get(**request.query_params)

--- a/analytics_dashboard/settings/base.py
+++ b/analytics_dashboard/settings/base.py
@@ -468,3 +468,10 @@ REST_FRAMEWORK = {
 # Regex used to capture course_ids from URLs
 COURSE_ID_PATTERN = r'(?P<course_id>[^/+]+[/+][^/+]+[/+][^/]+)'
 ########## END COURSE_ID_PATTERN
+
+########## LEARNER_API_LIST_DOWNLOAD_FIELDS
+# Comma-delimited list of field names to include in the Learner List CSV download
+# e.g., # "username,segments,cohort,engagements.videos_viewed,last_updated"
+# Default (None) includes all available fields, in alphabetical order.
+LEARNER_API_LIST_DOWNLOAD_FIELDS = None
+########## END LEARNER_API_LIST_DOWNLOAD_FIELDS

--- a/analytics_dashboard/static/apps/learners/app/app.js
+++ b/analytics_dashboard/static/apps/learners/app/app.js
@@ -29,6 +29,8 @@ define(function(require) {
          *   for the HTML element that this app should attach to
          * - learnerListUrl (string) required - the URL for the
          *   Learner List API endpoint.
+         * - learnerListDownloadUrl (string) required - the CSV download URL
+         *   for the Learner List API endpoint.
          * - courseLearnerMetadataUrl (String) required - the URL for
          *   the Course Learner Metadata API endpoint.
          * - learnerListJson (Object) optional - an Object
@@ -55,6 +57,7 @@ define(function(require) {
 
             learnerCollection = new LearnerCollection(this.options.learnerListJson, {
                 url: this.options.learnerListUrl,
+                downloadUrl: this.options.learnerListDownloadUrl,
                 courseId: this.options.courseId,
                 parse: this.options.learnerListJson
             });

--- a/analytics_dashboard/static/apps/learners/app/learners-main.js
+++ b/analytics_dashboard/static/apps/learners/app/learners-main.js
@@ -6,6 +6,7 @@ require(['vendor/domReady!', 'jquery', 'load/init-page', 'apps/learners/app/app'
             containerSelector: '.learners-app-container',
             learnerListJson: modelData.get('learner_list_json'),
             learnerListUrl: modelData.get('learner_list_url'),
+            learnerListDownloadUrl: modelData.get('learner_list_download_url'),
             courseLearnerMetadataJson: modelData.get('course_learner_metadata_json'),
             courseLearnerMetadataUrl: modelData.get('course_learner_metadata_url'),
             learnerEngagementTimelineUrl: modelData.get('learner_engagement_timeline_url')

--- a/analytics_dashboard/static/apps/learners/app/spec/controller-spec.js
+++ b/analytics_dashboard/static/apps/learners/app/spec/controller-spec.js
@@ -73,6 +73,7 @@ define(function(require) {
                 pageModel: pageModel,
                 learnerEngagementTimelineUrl: '/test-engagement-endpoint/',
                 learnerListUrl: '/test-learner-endpoint/',
+                learnerListDownloadUrl: '/test-learner-endpoint.csv',
                 courseId: courseId,
                 trackingModel: new TrackingModel()
             });

--- a/analytics_dashboard/static/apps/learners/common/collections/learners.js
+++ b/analytics_dashboard/static/apps/learners/common/collections/learners.js
@@ -16,6 +16,7 @@ define(function(require) {
             PagingCollection.prototype.initialize.call(this, options);
 
             this.url = options.url;
+            this.downloadUrl = options.downloadUrl;
             this.courseId = options.courseId;
 
             this.registerSortableField('username', gettext('Name (Username)'));
@@ -67,8 +68,7 @@ define(function(require) {
         // Encodes the state of the collection into a query string that can be appended onto the URL.
         getQueryString: function() {
             var params = this.getActiveFilterFields(true),
-                orderedParams = [],
-                fragment;
+                orderedParams = [];
 
             // Order the parameters: filters & search, sortKey, order, and then page.
 
@@ -83,15 +83,7 @@ define(function(require) {
                 orderedParams.push({key: 'order', val: this.state.order === 1 ? 'desc' : 'asc'});
             }
             orderedParams.push({key: 'page', val: this.state.currentPage});
-
-            fragment = orderedParams.map(function(param) {
-                // Note: this assumes that filter keys will never have URI special characters. We should encode the key
-                // too if that assumption is wrong.
-                return param.key + '=' + encodeURIComponent(param.val);
-            }).join('&');
-
-            // Prefix query string params with '?', but return an empty string if there are no params.
-            return fragment !== '' ? ('?' + fragment) : fragment;
+            return Utils.toQueryString(orderedParams);
         },
 
         /**

--- a/analytics_dashboard/static/apps/learners/common/templates/download-data.underscore
+++ b/analytics_dashboard/static/apps/learners/common/templates/download-data.underscore
@@ -1,0 +1,10 @@
+<% if (hasDownloadData) { %>
+    <div class="section-action">
+        <a class="btn btn-default action-download-data" role="button"
+           href="<%- downloadUrl %>" data-role="learner-data-csv" data-track-type="click"
+           data-track-event="edx.bi.csv.downloaded" data-track-category="<%- trackCategory %>">
+          <span class="ico fa fa-download" aria-hidden="true"></span> <%- downloadDataTitle %>
+          <span class="sr-only"><%- downloadDataMessage %></span>
+        </a>
+    </div>
+<% } %>

--- a/analytics_dashboard/static/apps/learners/common/views/download-data.js
+++ b/analytics_dashboard/static/apps/learners/common/views/download-data.js
@@ -1,0 +1,109 @@
+define(function(require) {
+    'use strict';
+
+    var $ = require('jquery'),
+        _ = require('underscore'),
+        Marionette = require('marionette'),
+
+        Utils = require('utils/utils'),
+        downloadDataTemplate = require('text!learners/common/templates/download-data.underscore'),
+        DownloadDataView;
+
+    DownloadDataView = Marionette.ItemView.extend({
+        template: _.template(downloadDataTemplate),
+
+        ui: {
+            dataDownloadButton: '.action-download-data'
+        },
+
+        events: {
+            'click .action-download-data': 'onDownload'
+        },
+
+        defaults: {
+            trackCategory: 'download_file',
+            downloadDataTitle: gettext('Download CSV'),
+            downloadDataMessage: gettext('Download search results to CSV')
+        },
+
+        initialize: function(options) {
+            var splitUrl, splitParams;
+            this.options = _.extend({}, this.defaults, options);
+
+            // Parse the downloadUrl, if given, into URL and query params
+            if (this.options.collection && !_.isEmpty(this.options.collection.downloadUrl)) {
+                splitUrl = this.options.collection.downloadUrl.split('?', 2);
+                this.downloadBaseUrl = splitUrl[0];
+
+                // Store an ordered list of download query string parameters, ready to feed to Util.toQueryString
+                splitParams = Utils.parseQueryString(splitUrl[1]);
+                splitParams.course_id = this.options.collection.courseId;
+                this.downloadParams = Object.keys(splitParams).sort().map(function(key) {
+                    return {key: key, val: splitParams[key]};
+                });
+            }
+
+            // Update the href on the download button when the collection changes.
+            this.listenTo(this.options.collection, 'sync', this.updateDownloadLink);
+        },
+
+        onDownload: function(event) {
+            // Trigger a tracking event using the template's data attributes
+            var linkData = $(event.currentTarget).data();
+            this.options.trackingModel.trigger(
+                'segment:track',
+                linkData.trackEvent,
+                {category: linkData.trackCategory});
+            return true;
+        },
+
+        templateHelpers: function() {
+            var hasDownloadData = !_.isEmpty(this.downloadBaseUrl);
+            return {
+                hasDownloadData: hasDownloadData,
+                downloadDataTitle: this.options.downloadDataTitle,
+                downloadDataMessage: this.options.downloadDataMessage,
+                downloadUrl: this.getDownloadUrl(),
+                trackCategory: this.options.trackCategory
+            };
+        },
+
+        getDownloadUrl: function() {
+            var downloadQuery = '',
+                separator = '?',
+                collection = this.options.collection,
+                collectionQuery = collection ? this.options.collection.getQueryString() : '',
+                pageSize = collection ? this.options.collection.state.totalRecords : 25,
+                downloadParams = _.extend([], this.downloadParams);
+
+            // Return empty string if no downloadBaseUrl
+            if (_.isEmpty(this.downloadBaseUrl)) {
+                return '';
+            }
+
+            // Append the total records count as the page size
+            // NOTE: will only work if the Analytics API's max_page_size is large enough
+            if (pageSize) {
+                downloadParams.push({
+                    key: 'page_size',
+                    val: pageSize
+                });
+            }
+
+            if (collectionQuery !== '') {
+                separator = '&';
+            }
+            downloadQuery = Utils.toQueryString(downloadParams, separator);
+
+            return this.downloadBaseUrl + collectionQuery + downloadQuery;
+        },
+
+        updateDownloadLink: function() {
+            // Set the href for the download button to the current download URL
+            $(this.ui.dataDownloadButton).attr('href', this.getDownloadUrl());
+        }
+    });
+
+    return DownloadDataView;
+});
+

--- a/analytics_dashboard/static/apps/learners/common/views/spec/download-data-spec.js
+++ b/analytics_dashboard/static/apps/learners/common/views/spec/download-data-spec.js
@@ -1,0 +1,190 @@
+define(function(require) {
+    'use strict';
+
+    var _ = require('underscore'),
+        TrackingModel = require('models/tracking-model'),
+        DownloadDataView = require('learners/common/views/download-data'),
+        LearnerCollection = require('learners/common/collections/learners');
+
+    describe('DownloadDataView', function() {
+        beforeEach(function() {
+            this.user = {};
+        });
+
+        it('has default options', function() {
+            var downloadDataView = new DownloadDataView({
+                    collection: new LearnerCollection(
+                        [this.user],
+                        {url: 'http://example.com'}
+                    )
+                }),
+                templateVars = downloadDataView.templateHelpers();
+            expect(templateVars.hasDownloadData).toBe(false);
+            expect(templateVars.trackCategory).toBe('download_file');
+            expect(templateVars.downloadDataTitle).toBe('Download CSV');
+            expect(templateVars.downloadDataMessage).toBe('Download search results to CSV');
+            expect(templateVars.downloadUrl).toBe('');
+        });
+
+        it('accepts options overrides', function() {
+            var downloadDataView = new DownloadDataView({
+                    collection: new LearnerCollection(
+                        [this.user],
+                        {url: 'http://example.com'}
+                    ),
+                    hasDownloadData: true,
+                    trackCategory: 'tracking-my-downloads',
+                    downloadDataTitle: 'Download My CSV',
+                    downloadDataMessage: 'Download my search results'
+                }),
+                templateVars = downloadDataView.templateHelpers();
+            expect(templateVars.hasDownloadData).toBe(false);
+            expect(templateVars.trackCategory).toBe('tracking-my-downloads');
+            expect(templateVars.downloadDataTitle).toBe('Download My CSV');
+            expect(templateVars.downloadDataMessage).toBe('Download my search results');
+            expect(templateVars.downloadUrl).toBe('');
+        });
+
+        it('must have a downloadUrl to display the download button', function() {
+            // Collections without downloadUrl get no download button
+            var downloadDataView = new DownloadDataView({
+                    collection: new LearnerCollection(
+                        [this.user],
+                        {url: 'http://example.com'}
+                    )
+                }),
+                templateVars = downloadDataView.templateHelpers();
+            expect(downloadDataView.getDownloadUrl()).toBe('');
+            expect(templateVars.hasDownloadData).toBe(false);
+            expect(templateVars.downloadUrl).toBe('');
+
+            // Collections with downloadUrl get a download button
+            downloadDataView = new DownloadDataView({
+                collection: new LearnerCollection(
+                    [this.user],
+                    {
+                        url: 'http://example.com',
+                        downloadUrl: '/learners.csv'
+                    }
+                )
+            });
+            expect(downloadDataView.getDownloadUrl()).toBe('/learners.csv?page=1&course_id=undefined');
+            templateVars = downloadDataView.templateHelpers();
+            expect(templateVars.hasDownloadData).toBe(true);
+            expect(templateVars.downloadUrl).toBe('/learners.csv?page=1&course_id=undefined');
+        });
+
+        it('changes the downloadUrl query string based on search filters', function() {
+            // course_id but no active filters
+            var collection = new LearnerCollection([this.user],
+                {
+                    url: 'http://example.com',
+                    downloadUrl: '/learners.csv',
+                    courseId: 'course-v1:Demo:test'
+                }),
+                downloadDataView = new DownloadDataView({
+                    collection: collection
+                });
+
+            expect(downloadDataView.getDownloadUrl()).toBe(
+                '/learners.csv' +
+                '?page=1' +
+                '&course_id=course-v1%3ADemo%3Atest'
+            );
+
+            // set a filter field
+            collection.setFilterField('enrollment_mode', 'audit');
+            expect(downloadDataView.getDownloadUrl()).toBe(
+                '/learners.csv' +
+                '?enrollment_mode=audit' +
+                '&page=1' +
+                '&course_id=course-v1%3ADemo%3Atest'
+            );
+
+            // add another filter field (will maintain alphabetical order)
+            collection.setFilterField('alpha', 'beta');
+            expect(downloadDataView.getDownloadUrl()).toBe(
+                '/learners.csv' +
+                '?enrollment_mode=audit' +
+                '&alpha=beta' +
+                '&page=1' +
+                '&course_id=course-v1%3ADemo%3Atest'
+            );
+
+            // unset filter field restores original URL
+            collection.unsetAllFilterFields();
+            expect(downloadDataView.getDownloadUrl()).toBe(
+                '/learners.csv' +
+                '?page=1' +
+                '&course_id=course-v1%3ADemo%3Atest'
+            );
+        });
+
+        it('allows query parameters to be in the downloadUrl', function() {
+            var collection = new LearnerCollection([this.user],
+                {
+                    url: 'http://example.com',
+                    downloadUrl: '/learners.csv?fields=abc,def&other=ghi',
+                    courseId: 'course-v1:Demo:test'
+                }),
+                downloadDataView = new DownloadDataView({
+                    collection: collection
+                });
+
+            // query string parameters will be sorted alphabetically
+            expect(downloadDataView.getDownloadUrl()).toBe(
+                '/learners.csv' +
+                '?page=1' +
+                '&course_id=course-v1%3ADemo%3Atest' +
+                '&fields=abc%2Cdef' +
+                '&other=ghi'
+            );
+
+            // set a filter field
+            collection.setFilterField('enrollment_mode', 'audit');
+            expect(downloadDataView.getDownloadUrl()).toBe(
+                '/learners.csv' +
+                '?enrollment_mode=audit' +
+                '&page=1' +
+                '&course_id=course-v1%3ADemo%3Atest' +
+                '&fields=abc%2Cdef' +
+                '&other=ghi'
+            );
+
+            // unset filter field restores original URL
+            collection.unsetAllFilterFields();
+            expect(downloadDataView.getDownloadUrl()).toBe(
+                '/learners.csv' +
+                '?page=1' +
+                '&course_id=course-v1%3ADemo%3Atest' +
+                '&fields=abc%2Cdef' +
+                '&other=ghi'
+            );
+        });
+
+        it('has sends tracking event on download', function() {
+            _.each([{}, {trackCategory: 'another_category'}], function(extraViewArgs) {
+                var collection = new LearnerCollection([{}],
+                    {
+                        url: 'http://example.com',
+                        downloadUrl: '/learners.csv?fields=abc,def',
+                        courseId: 'course-v1:Demo:test'
+                    }),
+                    downloadDataView = new DownloadDataView(_.extend({
+                        collection: collection,
+                        trackingModel: new TrackingModel()
+                    }, extraViewArgs)).render(),
+                    downloadButton = downloadDataView.$(downloadDataView.ui.dataDownloadButton),
+                    triggerSpy = spyOn(downloadDataView.options.trackingModel, 'trigger'),
+                    trackCategory = extraViewArgs.trackCategory || 'download_file';
+
+                // Verify the tracking event is triggered when button is clicked.
+                expect(downloadButton).toContainText('Download CSV');
+                downloadButton.click();
+                expect(triggerSpy).toHaveBeenCalledWith('segment:track', 'edx.bi.csv.downloaded', {
+                    category: trackCategory
+                });
+            });
+        });
+    });
+});

--- a/analytics_dashboard/static/apps/learners/roster/templates/roster.underscore
+++ b/analytics_dashboard/static/apps/learners/roster/templates/roster.underscore
@@ -11,6 +11,9 @@
         <section class="learners-table-controls" aria-label="<%- controlsLabel %>"></section>
     </div>
     <div class="col-md-8 col-md-pull-4">
+        <div class="learners-download-data"></div>
+    </div>
+    <div class="col-md-8 col-md-pull-4">
         <div class="learners-results"></div>
     </div>
 </div>

--- a/analytics_dashboard/static/apps/learners/roster/views/roster.js
+++ b/analytics_dashboard/static/apps/learners/roster/views/roster.js
@@ -13,6 +13,7 @@ define(function(require) {
 
         ActiveDateRangeView = require('learners/roster/views/activity-date-range'),
         ActiveFiltersView = require('learners/roster/views/active-filters'),
+        DownloadDataView = require('learners/common/views/download-data'),
         LearnerResultsView = require('learners/roster/views/results'),
         LearnerUtils = require('learners/common/utils'),
         RosterControlsView = require('learners/roster/views/controls'),
@@ -37,6 +38,7 @@ define(function(require) {
         regions: {
             activeFilters: '.learners-active-filters',
             activityDateRange: '.activity-date-range',
+            downloadData: '.learners-download-data',
             controls: '.learners-table-controls',
             results: '.learners-results'
         },
@@ -61,6 +63,11 @@ define(function(require) {
             }));
             this.showChildView('activityDateRange', new ActiveDateRangeView({
                 model: this.options.courseMetadata
+            }));
+            this.showChildView('downloadData', new DownloadDataView({
+                collection: this.options.collection,
+                trackingModel: this.options.trackingModel,
+                trackCategory: 'learner_roster'
             }));
             this.showChildView('controls', new RosterControlsView({
                 collection: this.options.collection,

--- a/analytics_dashboard/static/download-form/apps/learners/common/templates/download-data.underscore
+++ b/analytics_dashboard/static/download-form/apps/learners/common/templates/download-data.underscore
@@ -1,0 +1,12 @@
+<% if (hasDownloadData) { %>
+    <div class="section-action">
+        <form method="GET" action="#" enctype="multipart/form-data" class="download-data">
+            <button type="submit" class="btn btn-default download-data" data-backgrid-action="clear"
+               data-role="learner-data-csv" data-track-type="click"
+               data-track-event="edx.bi.csv.downloaded" data-track-category="<%- trackCategory %>">
+                <span class="ico fa fa-download" aria-hidden="true"></span> <%- downloadDataTitle %>
+                <span class="sr-only"><%- downloadDataMessage %></span>
+            </button>
+        </form>
+    </div>
+<% } %>

--- a/analytics_dashboard/static/download-form/apps/learners/common/views/download-data.js
+++ b/analytics_dashboard/static/download-form/apps/learners/common/views/download-data.js
@@ -1,0 +1,113 @@
+define(function(require) {
+    'use strict';
+
+    var $ = require('jquery'),
+        _ = require('underscore'),
+        Marionette = require('marionette'),
+
+        Utils = require('utils/utils'),
+        downloadDataTemplate = require('text!learners/common/templates/download-data.underscore'),
+        DownloadDataView;
+
+    DownloadDataView = Marionette.ItemView.extend({
+        template: _.template(downloadDataTemplate),
+
+        ui: {
+            dataDownloadForm: 'form.download-data',
+            dataDownloadButton: 'button.download-data'
+        },
+
+        events: {
+            'click button.download-data': 'onDownload'
+        },
+
+        defaults: {
+            trackCategory: 'download_file',
+            downloadDataTitle: gettext('Download CSV'),
+            downloadDataMessage: gettext('Download search results to CSV')
+        },
+
+        initialize: function(options) {
+            var splitUrl, splitParams;
+            this.options = _.extend({}, this.defaults, options);
+
+            // Parse the downloadUrl, if given, into URL and query params
+            if (this.options.collection && !_.isEmpty(this.options.collection.downloadUrl)) {
+                splitUrl = this.options.collection.downloadUrl.split('?', 2);
+                this.downloadBaseUrl = splitUrl[0];
+
+                // Store an ordered list of download query string parameters, ready to feed to Util.toQueryString
+                splitParams = Utils.parseQueryString(splitUrl[1]);
+                splitParams.course_id = this.options.collection.courseId;
+                this.downloadParams = Object.keys(splitParams).sort().map(function(key) {
+                    return {key: key, val: splitParams[key]};
+                });
+            }
+
+            // Update the action on the download button's action when the collection changes.
+            this.listenTo(this.options.collection, 'sync', this.updateDownloadForm);
+        },
+
+        onShow: function() {
+            // Update the download form on page load
+            this.updateDownloadForm();
+        },
+
+        onDownload: function(event) {
+            // Trigger a tracking event using the template's data attributes
+            var linkData = $(event.currentTarget).data();
+            this.options.trackingModel.trigger(
+                'segment:track',
+                linkData.trackEvent,
+                {category: linkData.trackCategory});
+            return true;
+        },
+
+        templateHelpers: function() {
+            var hasDownloadData = !_.isEmpty(this.downloadBaseUrl);
+            return {
+                hasDownloadData: hasDownloadData,
+                downloadDataTitle: this.options.downloadDataTitle,
+                downloadDataMessage: this.options.downloadDataMessage,
+                trackCategory: this.options.trackCategory
+            };
+        },
+
+        getDownloadUrl: function() {
+            var downloadQuery = '',
+                separator = '?',
+                collectionQuery = this.options.collection.getQueryString();
+
+            // Return empty string if no downloadBaseUrl
+            if (_.isEmpty(this.downloadBaseUrl)) {
+                return '';
+            }
+
+            if (collectionQuery !== '') {
+                separator = '&';
+            }
+            downloadQuery = Utils.toQueryString(this.downloadParams, separator);
+
+            return this.downloadBaseUrl + collectionQuery + downloadQuery;
+        },
+
+        updateDownloadForm: function() {
+            var downloadUrl = this.getDownloadUrl(),
+                downloadForm = $(this.ui.dataDownloadForm),
+                splitUrl = downloadUrl.split('?', 2),
+                queryParams = Utils.parseQueryString(splitUrl[1]);
+
+            // Set the action URL for the download form to the base download URL
+            $(this.ui.dataDownloadForm).attr('action', splitUrl[0]);
+
+            // Create hidden input items for each query string parameter
+            downloadForm.find('input[type=hidden]').remove();
+            _.map(queryParams, function (value, key) {
+                downloadForm.append($('<input>', {type: 'hidden', name: key, value: value}));
+            });
+        }
+    });
+
+    return DownloadDataView;
+});
+

--- a/analytics_dashboard/static/js/utils/utils.js
+++ b/analytics_dashboard/static/js/utils/utils.js
@@ -127,7 +127,7 @@ define(['moment', 'underscore', 'utils/globalization'], function(moment, _, Glob
                     if (keyValPair.length === 1 && keyValPair[0]) {  // No value
                         params[keyValPair[0]] = '';
                     } else if (keyValPair.length === 2) {
-                        params[keyValPair[0]] = keyValPair[1];
+                        params[keyValPair[0]] = decodeURIComponent(keyValPair[1]);
                     } else if (keyValPair.length > 2) {  // Have something like foo=bar=...
                         throw new TypeError('Each "&"-separated substring must either be a key or a key-value pair');
                     }
@@ -138,6 +138,29 @@ define(['moment', 'underscore', 'utils/globalization'], function(moment, _, Glob
             } else {
                 return {};
             }
+        },
+
+        /**
+         * Concatenates the given parameter key/values to a querystring.
+         *
+         * Examples:
+         * - {foo: 'bar', baz: 'quux'} -> 'foo=bar&baz=quux'
+         * - {foo: 'bar'} => 'foo=bar&'
+         * - {foo: 'bar', baz: ''} -> 'foo=bar&baz'
+         * - {foo: 'bar', baz: ''} -> 'foo=bar&baz='
+         * - {} -> ''
+         *
+         * @param params {object}
+         * @returns {string}
+         */
+        toQueryString: function(params, sep) {
+            var separator = (sep === undefined ? '?' : sep),
+                fragment = params.map(function(param) {
+                    return encodeURIComponent(param.key) + '=' + encodeURIComponent(param.val);
+                }).join('&');
+
+            // Prefix query string params with '?', but return an empty string if there are no params.
+            return fragment === '' ? fragment : (separator + fragment);
         }
     };
 

--- a/analytics_dashboard/static/sass/_developer.scss
+++ b/analytics_dashboard/static/sass/_developer.scss
@@ -791,6 +791,11 @@ table.dataTable thead th.sorting_desc:after {
     }
   }
 
+  .section-action {
+    text-align: right;
+    padding-bottom: 5px;
+  }
+
   th {
 
     font-weight: 600;


### PR DESCRIPTION
Adds a button to the Course Learners page, which allows the selected learners list to be downloaded in CSV format.

This report is proxied as a plain text response from the Learner Analytics Data API.

This feature is disabled by default, and can be enabled using the `enable_learner_download` waffle switch.

**Discussions**: Architecture discussed extensively with @mulby and the analytics team, and UI changes designed by Alyssa Boehm.

**Dependencies**: [edx-analytics-data-api #128](https://github.com/edx/edx-analytics-data-api/pull/128)

**Screenshots**:

With no search filters:

![screen shot 2016-08-10 at 5 13 12 pm](https://cloud.githubusercontent.com/assets/7556571/17545776/cc822a2c-5f1d-11e6-9e40-8d82675e5c7a.png)

With search filters:
![screen shot 2016-08-10 at 5 14 15 pm](https://cloud.githubusercontent.com/assets/7556571/17545797/f1ad83a0-5f1d-11e6-8bff-fac0bc3e8657.png)

Responsive positioning on small screen:
![screen shot 2016-08-10 at 5 15 47 pm](https://cloud.githubusercontent.com/assets/7556571/17545831/1e1dcaa8-5f1e-11e6-9813-5b37c7d1cc75.png)

**Partner information**: 3rd party-hosted open edX instance

**Testing instructions**:
1. See testing setup instructions on [edx-analytics-data-api #128](https://github.com/edx/edx-analytics-data-api/pull/128).
2. Run the LMS, Analytics elasticsearch service, and analytics_data_api.  Ensure that you can see your course in the Analytics API http://localhost:8100/docs/#!/api/Learner_List.
3. Update `/edx/etc/insights.xml` to store your Analytics API client token, and your desired CSV field list, e.g.,
   
   ```
   DATA_API_AUTH_TOKEN: your-api-token
   ```
4. Enable the Learner view in Insights:
   
   ```
   sudo su insights
   ./manage.py waffle_flag display_learner_analytics --staff --create
   ./manage.py waffle_switch enable_course_api on --create
   ```
5. Launch Insights, visit the Learners page, and ensure that there is no `Download CSV` button like the one in the above screenshots.
6. Enable this feature switch:
   
   ```
   ./manage.py waffle_switch enable_learner_download on --create 
   ```
7. Relaunch Insights and visit the Learners page to see the new `Download CSV` button.  Click on it to download the CSV file, which should contain all the fields in the learner API call, in alphabetical order.
8. Update `/edx/etc/insights.xml` to update the CSV field list, e.g.,
   
   ```
   LEARNER_API_LIST_DOWNLOAD_FIELDS: username,name,email,cohort,enrollment_date,last_updated
   ```
9. Relaunch Insights, and download the CSV report again.  It should contain only the fields specified in your `settings.LEARNER_API_LIST_DOWNLOAD_FIELDS`, in that order.
10. Load the CSV report URL in an incognito browser, and ensure that you see a Permission Denied error.

**Reviewers**
- [x] @bradenmacdonald 
- [x] @dsjen 
- [ ] @thallada 
- [x] Accessibility - @clrux

**Pre-Merge Checklist**
- [x] Rebase with current master
- [x] Squash into single commit
- [ ] Ensure tests pass
- [ ] Merge
