### PR TITLE
Change edx-django-release-util version.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,7 +14,7 @@ django-soapbox==1.3         # BSD
 django-waffle==0.11.1		# BSD
 pinax-announcements==2.0.4   # MIT
 edx-auth-backends==0.5.0
-edx-django-release-util==0.0.3      # AGPLv3
+edx-django-release-util==0.1.0
 edx-rest-api-client>=1.5.0, <1.6.0  # Apache
 
 libsass==0.11.1              # MIT


### PR DESCRIPTION
Change the required version of edx-django-release-util to 0.1.0.

@edx/pipeline-team  Please review and tag appropriate parties.
