### PR TITLE
Fix pinax_announcements.

### DIFF
--- a/analytics_dashboard/static/js/application-main.js
+++ b/analytics_dashboard/static/js/application-main.js
@@ -12,7 +12,7 @@ require(['bootstrap',
 
         // Instantiate the announcement view(s)
         $('[data-view=announcement]').each(function(index, element) {
-            var announcement = AnnouncementView({el: element});
+            var announcement = new AnnouncementView({el: element});
             announcement.render();
         });
     }

--- a/analytics_dashboard/urls.py
+++ b/analytics_dashboard/urls.py
@@ -37,7 +37,7 @@ urlpatterns = [
     url(r'^accounts/logout/$', views.logout, name='logout'),
     url(r'^accounts/logout_then_login/$', views.logout_then_login, name='logout_then_login'),
     url(r'^test/auto_auth/$', views.AutoAuth.as_view(), name='auto_auth'),
-    url(r'^announcements/', include('pinax.announcements.urls')),
+    url(r'^announcements/', include('pinax.announcements.urls', namespace='pinax_announcements')),
 ]
 
 urlpatterns += [


### PR DESCRIPTION
[AN-7684](https://openedx.atlassian.net/browse/AN-7684)

There were more issues to the django_announcements -> pinax_announcements upgrade with Django 1.9 than I realized because we didn't actually test with an announcement active. Thanks to @stroilova for discovering the issue.

@ajpal @dsjen 
