### PR TITLE
Add Problem Response Report Download button

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The following switches are available:
 | display_course_name_in_nav           | Display course name in navigation bar.                |
 | enable_performance_learning_outcome  | Enable performance section with learning outcome breakdown (functionality based on tagging questions in Studio) | 
 | enable_learner_download              | Display Download CSV button on Learner List page.     |
+| enable_problem_response_download     | Enable downloadable CSV of problem responses          |
 
 [Waffle](http://waffle.readthedocs.org/en/latest/) flags are used to disable/enable
 functionality on request (e.g. turning on beta functionality for superusers). Create a

--- a/analytics_dashboard/courses/presenters/performance.py
+++ b/analytics_dashboard/courses/presenters/performance.py
@@ -605,3 +605,35 @@ class TagsDistributionPresenter(CourseAPIPresenterMixin, BasePresenter):
                 result.append(intermediate[key])
 
         return result
+
+
+class CourseReportDownloadPresenter(BasePresenter):
+    """
+    Presenter that can fetch temporary CSV download URLs from the data API
+    """
+    PROBLEM_RESPONSES = 'problem_response'
+
+    def get_report_info(self, report_name):
+        """
+        Get a temporary download URL and status information such as the "last modified" date for
+        a downloadable report.
+
+        Does not check any permissions.
+
+        Will raise NotFoundError if the course or the report does not exist.
+
+        Example return value (only the first three fields are guaranteed; see API for details):
+            {
+              "course_id": "Example_Demo_2016-08",
+              "report_name": "problem_response",
+              "download_url": "https://bucket.s3.amazonaws.com/Example_Demo_2016-08_problem_response.csv?Signature=...",
+              "last_modified": "2016-08-12T043411",
+              "file_size": 3419,
+              "expiration_date": "2016-08-12T233704",
+            }
+        """
+        data = self.course.reports(report_name)
+        for field in ('last_modified', 'expiration_date'):
+            if field in data:
+                data[field] = self.parse_api_datetime(data[field])
+        return data

--- a/analytics_dashboard/courses/templates/courses/home.html
+++ b/analytics_dashboard/courses/templates/courses/home.html
@@ -56,6 +56,12 @@
                     <span class="ico fa fa-caret-right" aria-hidden="true"></span>
                   {% endif %}
                 {% endfor %}
+                {% if item.format == "csv" %}
+                  {# Translators: This indicates that the adjacent link will trigger a CSV download. '{{download_icon}}' will be replaced with an icon. #}
+                  {% blocktrans with download_icon='<span class="ico fa fa-download" aria-hidden="true"></span>' %}
+                    ({{download_icon}} CSV Download)
+                  {% endblocktrans %}
+                {% endif %}
               </div>
             </div>
           {% endfor %}

--- a/analytics_dashboard/courses/tests/test_presenters.py
+++ b/analytics_dashboard/courses/tests/test_presenters.py
@@ -27,7 +27,11 @@ from courses.exceptions import NoVideosError
 from courses.presenters import BasePresenter
 from courses.presenters.engagement import (CourseEngagementActivityPresenter, CourseEngagementVideoPresenter)
 from courses.presenters.enrollment import (CourseEnrollmentPresenter, CourseEnrollmentDemographicsPresenter)
-from courses.presenters.performance import CoursePerformancePresenter, TagsDistributionPresenter
+from courses.presenters.performance import (
+    CoursePerformancePresenter,
+    CourseReportDownloadPresenter,
+    TagsDistributionPresenter,
+)
 from courses.tests import utils
 from courses.tests.factories import (CourseEngagementDataFactory, CoursePerformanceDataFactory,
                                      TagsDistributionDataFactory)
@@ -1105,3 +1109,44 @@ class TagsDistributionPresenterTests(TestCase):
                 modules = self.presenter.get_modules_marked_with_tag('learning_outcome', slugify('Learned nothing'))
                 expected_modules = factory.get_expected_modules_marked_with_tag('learning_outcome', 'Learned nothing')
                 self.assertEqual(modules, expected_modules)
+
+
+class CourseReportDownloadPresenterTests(TestCase):
+
+    def setUp(self):
+        cache.clear()
+        self.course_id = PERFORMER_PRESENTER_COURSE_ID
+        self.presenter = CourseReportDownloadPresenter(self.course_id)
+
+    @mock.patch('analyticsclient.course.Course.reports')
+    def test_report_presenter(self, mock_reports):
+        api_data = {
+            "course_id": "Test_Course_Run",
+            "report_name": "problem_response",
+            "download_url": "https://bucket.s3.amazonaws.com/Test_Course_Run_problem_response.csv?Signature=...",
+            "last_modified": "2016-08-12T043411",
+            "file_size": 3419,
+            "expiration_date": "2016-08-12T233704",
+        }
+        mock_reports.return_value = api_data
+        info = self.presenter.get_report_info(CourseReportDownloadPresenter.PROBLEM_RESPONSES)
+        mock_reports.assert_called_once_with("problem_response")
+        for field in ("course_id", "report_name", "download_url", "file_size"):
+            self.assertEqual(info[field], api_data[field])
+        self.assertIsInstance(info["last_modified"], datetime.datetime)
+        self.assertIsInstance(info["expiration_date"], datetime.datetime)
+
+    @mock.patch('analyticsclient.course.Course.reports')
+    def test_report_presenter_limited_data(self, mock_reports):
+        """
+        Test the presenter when the API returns only the minimum guaranteed set of fields
+        """
+        api_data = {
+            "course_id": "Test_Course_Run",
+            "report_name": "problem_response",
+            "download_url": "",
+        }
+        mock_reports.return_value = api_data
+        info = self.presenter.get_report_info(CourseReportDownloadPresenter.PROBLEM_RESPONSES)
+        mock_reports.assert_called_once_with("problem_response")
+        self.assertEqual(info, api_data)

--- a/analytics_dashboard/courses/tests/test_views/__init__.py
+++ b/analytics_dashboard/courses/tests/test_views/__init__.py
@@ -104,6 +104,9 @@ class MockApiTestMixin(object):
 # pylint: disable=not-callable,abstract-method
 @ddt
 class AuthTestMixin(MockApiTestMixin, PermissionsTestMixin, RedirectTestCaseMixin, UserTestCaseMixin):
+    follow = True  # Should test_authentication() and test_authorization() follow redirects
+    success_status = 200
+
     def setUp(self):
         super(AuthTestMixin, self).setUp()
         self.grant_permission(self.user, DEMO_COURSE_ID, DEPRECATED_DEMO_COURSE_ID)
@@ -119,8 +122,8 @@ class AuthTestMixin(MockApiTestMixin, PermissionsTestMixin, RedirectTestCaseMixi
             with mock.patch(self.api_method, return_value=self.get_mock_data(course_id)):
                 # Authenticated users should go to the course page
                 self.login()
-                response = self.client.get(self.path(course_id=course_id), follow=True)
-                self.assertEqual(response.status_code, 200)
+                response = self.client.get(self.path(course_id=course_id), follow=self.follow)
+                self.assertEqual(response.status_code, self.success_status)
 
                 # Unauthenticated users should be redirected to the login page
                 self.client.logout()
@@ -138,12 +141,12 @@ class AuthTestMixin(MockApiTestMixin, PermissionsTestMixin, RedirectTestCaseMixi
             with mock.patch(self.api_method, return_value=self.get_mock_data(course_id)):
                 # Authorized users should be able to view the page
                 self.grant_permission(self.user, course_id)
-                response = self.client.get(self.path(course_id=course_id), follow=True)
-                self.assertEqual(response.status_code, 200)
+                response = self.client.get(self.path(course_id=course_id), follow=self.follow)
+                self.assertEqual(response.status_code, self.success_status)
 
                 # Unauthorized users should be redirected to the 403 page
                 self.revoke_permissions(self.user)
-                response = self.client.get(self.path(course_id=course_id), follow=True)
+                response = self.client.get(self.path(course_id=course_id), follow=self.follow)
                 self.assertEqual(response.status_code, 403)
 
 

--- a/analytics_dashboard/courses/tests/test_views/test_performance.py
+++ b/analytics_dashboard/courses/tests/test_views/test_performance.py
@@ -49,20 +49,20 @@ class CoursePerformanceViewTestMixin(PatchMixin, CourseStructureViewMixin, Cours
         }
         self.assertDictEqual(nav, expected)
 
-    def get_expected_secondary_nav(self, _course_id):
+    def get_expected_secondary_nav(self, course_id):
         """ Override this for each page. """
         return [
             {
-                'active': True,
+                'active': False,
                 'name': 'graded_content',
                 'label': _('Graded Content'),
-                'href': '#'
+                'href': reverse('courses:performance:graded_content', kwargs={'course_id': course_id}),
             },
             {
-                'active': True,
+                'active': False,
                 'name': 'ungraded_content',
                 'label': _('Ungraded Problems'),
-                'href': '#'
+                'href': reverse('courses:performance:ungraded_content', kwargs={'course_id': course_id}),
             }
         ]
 
@@ -128,9 +128,9 @@ class CoursePerformanceGradedMixin(CoursePerformanceViewTestMixin):
 
     def get_expected_secondary_nav(self, course_id):
         expected = super(CoursePerformanceGradedMixin, self).get_expected_secondary_nav(course_id)
-        expected[1].update({
-            'href': reverse('courses:performance:ungraded_content', kwargs={'course_id': course_id}),
-            'active': False
+        expected[0].update({
+            'href': '#',
+            'active': True,
         })
         return expected
 
@@ -169,9 +169,9 @@ class CoursePerformanceUngradedMixin(CoursePerformanceViewTestMixin):
 
     def get_expected_secondary_nav(self, course_id):
         expected = super(CoursePerformanceUngradedMixin, self).get_expected_secondary_nav(course_id)
-        expected[0].update({
-            'href': reverse('courses:performance:graded_content', kwargs={'course_id': course_id}),
-            'active': False
+        expected[1].update({
+            'href': '#',
+            'active': True,
         })
         return expected
 

--- a/analytics_dashboard/courses/urls.py
+++ b/analytics_dashboard/courses/urls.py
@@ -108,6 +108,7 @@ CSV_URLS = ([
                                                                                    PROBLEM_PART_ID_PATTERN),
         csv.PerformanceAnswerDistributionCSV.as_view(),
         name='performance_answer_distribution'),
+    url(r'problem_responses/', csv.PerformanceProblemResponseCSV.as_view(), name='performance_problem_responses')
 ], 'csv')
 
 LEARNER_URLS = ([

--- a/analytics_dashboard/courses/views/__init__.py
+++ b/analytics_dashboard/courses/views/__init__.py
@@ -27,6 +27,7 @@ from core.exceptions import ServiceUnavailableError
 from core.utils import CourseStructureApiClient, sanitize_cache_key
 
 from courses import permissions
+from courses.presenters.performance import CourseReportDownloadPresenter
 from courses.serializers import LazyEncoder
 from courses.utils import is_feature_enabled
 
@@ -538,6 +539,22 @@ class CourseHome(CourseTemplateWithNavView):
                     'breadcrumbs': [_('Learning Outcomes')],
                     'fragment': ''
                 })
+
+            if switch_is_active('enable_problem_response_download'):
+                try:
+                    info = CourseReportDownloadPresenter(self.course_id).get_report_info(
+                        report_name=CourseReportDownloadPresenter.PROBLEM_RESPONSES
+                    )
+                except NotFoundError:
+                    info = {}
+                if 'download_url' in info:
+                    # A problem response report CSV is available:
+                    subitems.append({
+                        'title': _('How are students responding to questions?'),
+                        'view': 'courses:csv:performance_problem_responses',
+                        'breadcrumbs': [_('Problem Response Report')],
+                        'format': 'csv',
+                    })
 
             items.append({
                 'name': _('Performance'),

--- a/analytics_dashboard/courses/views/csv.py
+++ b/analytics_dashboard/courses/views/csv.py
@@ -2,11 +2,12 @@ import datetime
 import logging
 import urllib
 
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseRedirect
 
 from analyticsclient.constants import data_format, demographic
 from analyticsclient.client import Client
 
+from courses.presenters.performance import CourseReportDownloadPresenter
 from courses.views import CourseView
 
 
@@ -91,3 +92,14 @@ class PerformanceAnswerDistributionCSV(CSVResponseMixin, CourseView):
     def get_data(self):
         modules = self.client.modules(self.course_id, self.kwargs['content_id'])
         return modules.answer_distribution(data_format=data_format.CSV)
+
+
+class PerformanceProblemResponseCSV(CourseView):
+    """
+    Query the Data API to get a temporary secure download URL, and redirect to that.
+    """
+    # pylint: disable=unused-argument
+    def render_to_response(self, context, **response_kwargs):
+        presenter = CourseReportDownloadPresenter(self.course_id)
+        data = presenter.get_report_info(CourseReportDownloadPresenter.PROBLEM_RESPONSES)
+        return HttpResponseRedirect(data['download_url'], **response_kwargs)

--- a/analytics_dashboard/courses/views/performance.py
+++ b/analytics_dashboard/courses/views/performance.py
@@ -8,6 +8,7 @@ from slugify import slugify
 from waffle import switch_is_active
 
 from courses.presenters.performance import CoursePerformancePresenter, TagsDistributionPresenter
+
 from courses.views import (
     CourseTemplateWithNavView,
     CourseAPIMixin,

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -25,7 +25,7 @@ python-social-auth==0.2.19
 requests==2.10.0            # Apache 2.0
 
 git+https://github.com/edx/django-lang-pref-middleware.git@0.1.0#egg=django-lang-pref-middleware
-git+https://github.com/edx/edx-analytics-data-api-client.git@0.8.0#egg=edx-analytics-data-api-client==0.8.0  # edX
+git+https://github.com/edx/edx-analytics-data-api-client.git@0.9.0#egg=edx-analytics-data-api-client==0.9.0  # edX
 git+https://github.com/edx/i18n-tools.git@0d7847f9dfa2281640527b4dc51f5854f950f9b7#egg=i18n_tools
 git+https://github.com/edx/opaque-keys.git@d45d0bd8d64c69531be69178b9505b5d38806ce0#egg=opaque-keys
 # custom opaque-key implementations for ccx


### PR DESCRIPTION
OpenCraft ticket: [OC-1823](https://tasks.opencraft.com/browse/OC-1823)

**Description**:

With https://github.com/edx/edx-analytics-pipeline/pull/274 , the analytics pipeline gained the ability to generate Problem Response Reports, which are CSV files stored on S3 that contain all responses to all problems by each learner in a course.

With https://github.com/edx/edx-analytics-data-api/pull/131 , the data API gained and endpoint that can be used to retrieve secure, temporary download URLs to access those reports.

Now, with this PR, there is an optional UI in Insights that can be used to download those reports, where available.

This feature is off by default, and can be enabled with the new `enable_problem_response_download` switch.

**Contribution Type**
This is an open source contribution developed by OpenCraft for the Harvard Kennedy School.

**Dependencies**:
- https://github.com/edx/edx-analytics-pipeline/pull/274
- https://github.com/edx/edx-analytics-data-api/pull/131
- https://github.com/edx/edx-analytics-data-api-client/pull/27

**Screenshots**:
New menu item on each course home page:
![screen shot 2016-08-12 at 6 06 17 pm](https://cloud.githubusercontent.com/assets/945577/17640580/85b75798-60b7-11e6-813d-38cea72e273a.png)

Clicking on that opens this new page:
![screen shot 2016-08-12 at 6 32 59 pm](https://cloud.githubusercontent.com/assets/945577/17640727/3df31038-60bb-11e6-8dff-f9801965fcf2.png)

The button will (almost) immediately download the CSV.

If this feature is enabled but the data API reports that the Problem Responses Report is not available for the current course:
![screen shot 2016-08-12 at 6 08 22 pm](https://cloud.githubusercontent.com/assets/945577/17640589/cb817970-60b7-11e6-8833-f55e405e3dc5.png)

**Testing Instructions**
On devstack: 
1. Generate some reports and store them on S3 according to the test instructions in https://github.com/edx/edx-analytics-data-api/pull/131 ; ensure you can go to http://localhost:8100/docs/#!/api/Report_Download and query for the `problem_response` report and a particular course ID to get some data from the API.
2. Apply [**this patch**](https://github.com/open-craft/edx-analytics-data-api/commit/004d1794831544169f2963c62a67a6d0e2f590d3) if it hasn't yet been included in https://github.com/edx/edx-analytics-data-api/pull/131
3. Checkout this branch and update the Insights requirements (`make requirements`). Ensure https://github.com/edx/edx-analytics-data-api-client/pull/27 is installed
4. Run Insights and ensure that this new feature is disabled by default and doesn't appear anywhere in the Performance UI nor on any course home page
5. Enable the switch: `./manage.py waffle_switch enable_problem_response_download on --create`
6. Relaunch Insights and look for the new report links and download button as shown in the screenshots.
7. Test both a course that has CSV reports available, and one that doesn't. Ensure the "last updated" and file size information shown below the download button is correct.
8. Clicking the button should download the CSV.
9. In an incognito window, login to Insights as a user who does not have access to the test course you are using. Ensure that both `/courses/:course_id/performance/problem_responses/` and the direct download URL ("Copy Link Address" from the download button seen by the authorized user) return a permissions error for that user.

**Notes**
- Before merging, fix `requirements/base.txt` to once again refer to `edx-analytics-data-api-client` by version number
