### PR TITLE
Fix engagement chart tooltip date format bug

### DIFF
--- a/analytics_dashboard/static/js/views/trends-view.js
+++ b/analytics_dashboard/static/js/views/trends-view.js
@@ -25,7 +25,7 @@ define(['moment', 'nvd3', 'underscore', 'views/chart-view'],
 
                 if (_(self.options).has('interactiveTooltipHeaderTemplate')) {
                     self.chart.interactiveLayer.tooltip.headerFormatter(function(d) {
-                        return self.options.interactiveTooltipHeaderTemplate({value: d});
+                        return self.options.interactiveTooltipHeaderTemplate({value: self.formatXTick(d)});
                     });
                 }
             },


### PR DESCRIPTION
I found a bug with the tooltip dates on charts that have a tooltip template (e.g. engagement). They show the raw seconds since epoch instead of the pretty moment.js date format.

I'm hoping to get this into staging quickly as 0.20.0-rc.3. @dsjen @ajpal 
