### PR TITLE
Removes performance testing note

### DIFF
--- a/docs/en_us/dashboard/source/Reference.rst
+++ b/docs/en_us/dashboard/source/Reference.rst
@@ -578,10 +578,6 @@ in a different spreadsheet application or a text editor.
 Individual Learner Computations
 *******************************
 
-.. note:: Performance testing is currently in progress for the learner
-  activity feature. While this testing is in progress, this feature is
-  available to a limited number of users at a given time.
-
 For information about the report and charts that are available in Insights
 for individual learner activities, see :ref:`Learner Activity`.
 

--- a/docs/en_us/dashboard/source/learners/Learner_Activity.rst
+++ b/docs/en_us/dashboard/source/learners/Learner_Activity.rst
@@ -4,10 +4,6 @@
 Learner Activity
 ################
 
-.. note:: Performance testing is currently in progress for the learner
-  activity feature. While this testing is in progress, this feature is
-  available to a limited number of users at a given time.
-
 Which learners, specifically, are engaging with my course? Who is struggling,
 and who is doing well? Investigating and comparing the activities of individual
 learners helps you focus on those who are most likely to benefit from

--- a/docs/en_us/dashboard/source/learners/index.rst
+++ b/docs/en_us/dashboard/source/learners/index.rst
@@ -4,10 +4,6 @@
 Individual Learners
 ######################
 
-.. note:: Performance testing is currently in progress for the learner
-  activity feature. While this testing is in progress, this feature is
-  available to a limited number of users at a given time.
-
 You can access information about what individual learners are doing in your
 course, and how frequently: from the edX Insights menu select **Learners**. A
 report of the key activity metrics for all enrolled learners appears, including


### PR DESCRIPTION
## [DOC-3231](https://openedx.atlassian.net/browse/DOC-3231)

Prepares for full release of learner analytics dashboard by removing the performance testing note (3 occurrences).
### Date Needed

By release date.
### Reviewers

Possible roles follow. PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Subject matter expert: @mulby 
- [ ] Subject matter expert: 
- [x] Doc team review (sanity check): @catong @pdesjardins 
- [ ] Product review: @katymyw
- [ ] Partner support: 
- [ ] PM review: 

FYI: @watsonemily
### Testing
- [x] Ran make html without warnings or errors
### Post-review
- [x] Add description to release notes task as a comment
- [x] Squash commits
