### PR TITLE
A11y: Update the title element on learner page change.

### DIFF
--- a/analytics_dashboard/static/apps/learners/app/controller.js
+++ b/analytics_dashboard/static/apps/learners/app/controller.js
@@ -161,6 +161,8 @@ define(function(require) {
             var message = gettext("Sorry, we couldn't find the page you're looking for."),
                 notFoundView;
 
+            this.options.pageModel.set('title', gettext('Page Not Found'));
+
             notFoundView = new (Backbone.View.extend({
                 render: function() {
                     this.$el.text(message);

--- a/analytics_dashboard/static/apps/learners/common/models/page.js
+++ b/analytics_dashboard/static/apps/learners/common/models/page.js
@@ -2,6 +2,7 @@ define(function(require) {
     'use strict';
 
     var Backbone = require('backbone'),
+        $ = require('jquery'),
 
         PageModel;
 
@@ -9,6 +10,17 @@ define(function(require) {
         defaults: {
             title: '',  // title displayed in header
             lastUpdated: undefined  // last updated date displayed in header
+        },
+
+        initialize: function() {
+            this.bind('change:title', this.updateTitleElement);
+        },
+
+        updateTitleElement: function() {
+            var self = this;
+            $('title').text(function() {
+                return $(this).text().replace(/^.*[-]/, self.get('title') + ' -');
+            });
         }
     });
 

--- a/analytics_dashboard/static/apps/learners/common/models/spec/page-spec.js
+++ b/analytics_dashboard/static/apps/learners/common/models/spec/page-spec.js
@@ -1,0 +1,29 @@
+define(function(require) {
+    'use strict';
+
+    var PageModel = require('learners/common/models/page'),
+        $ = require('jquery');
+
+    describe('PageModel', function() {
+        var titleConstantPart = 'edx/DemoX/Demo_Course | Open edX Insights';
+
+        beforeEach(function() {
+            // Setup default page title
+            $('title').text('Learners - ' + titleConstantPart);
+        });
+
+        it('should have all the expected default fields', function() {
+            var page = new PageModel();
+            expect(page.attributes).toEqual({
+                title: '',
+                lastUpdated: undefined
+            });
+        });
+
+        it('should update <title> element on title attribute change', function() {
+            var page = new PageModel();
+            page.set('title', 'foo');
+            expect($('title').text()).toEqual('foo - ' + titleConstantPart);
+        });
+    });
+});


### PR DESCRIPTION
[AN-7776](https://openedx.atlassian.net/browse/AN-7776)

I'm injecting this quick a11y improvement. Single page apps should update the title element on page change. I would have liked to have a better solution than a regex replace, but the `<title>` element is outside the scope of the learners app container.

You'll see the tab name change in your browser when navigating between the learner roster and learner detail pages now.

Another effect of these changes is that the learner app's page_not_found page actually says "Page Not Found" in the page header instead of "Learner Detail".

P.S. typing an unquoted `<title>` in a github comment breaks the markdown to html renderer :scream:
