### PR TITLE
Use course blocks API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,8 +233,9 @@ when executing either of the commands above.
 | APPLICATION_NAME             | Name of this application                   | Insights                         |
 | SUPPORT_EMAIL                | Email where error pages should link        | support@example.com              |
 | ENABLE_COURSE_API            | Indicates if the course API is enabled on the server being tested. Also, determines if course performance tests should be run. | False     |
+| GRADING_POLICY_API_URL       | URL where the grading policy API is served | (None)                           |
 | COURSE_API_URL               | URL where the course API is served         | (None)                           |
-| COURSE_API_KEY               | API key used to access the course  API     | (None)                           |
+| COURSE_API_KEY               | API key used to access the course API     | (None)                           |
 
 
 Override example:

--- a/acceptance_tests/__init__.py
+++ b/acceptance_tests/__init__.py
@@ -67,9 +67,10 @@ ENABLE_FORUM_POSTS = str2bool(os.environ.get('ENABLE_FORUM_POSTS', False))
 # Course API settings
 ENABLE_COURSE_API = str2bool(os.environ.get('ENABLE_COURSE_API', False))
 COURSE_API_URL = os.environ.get('COURSE_API_URL')
+GRADING_POLICY_API_URL = os.environ.get('GRADING_POLICY_API_URL')
 COURSE_API_KEY = os.environ.get('COURSE_API_KEY')
 
-if ENABLE_COURSE_API and not (COURSE_API_URL and COURSE_API_KEY):
+if ENABLE_COURSE_API and not (GRADING_POLICY_API_URL and COURSE_API_URL and COURSE_API_KEY):
     raise Exception('Course API details not supplied!')
 
 # Video preview

--- a/acceptance_tests/mixins.py
+++ b/acceptance_tests/mixins.py
@@ -5,9 +5,20 @@ from unittest import skip
 from bok_choy.promise import EmptyPromise
 from analyticsclient.client import Client
 
-from acceptance_tests import API_SERVER_URL, API_AUTH_TOKEN, DASHBOARD_FEEDBACK_EMAIL, SUPPORT_EMAIL, LMS_USERNAME, \
-    LMS_PASSWORD, DASHBOARD_SERVER_URL, ENABLE_AUTO_AUTH, DOC_BASE_URL, COURSE_API_URL, \
-    COURSE_API_KEY, ENABLE_COURSE_API
+from acceptance_tests import (
+    API_SERVER_URL,
+    API_AUTH_TOKEN,
+    COURSE_API_KEY,
+    COURSE_API_URL,
+    DASHBOARD_FEEDBACK_EMAIL,
+    DASHBOARD_SERVER_URL,
+    DOC_BASE_URL,
+    ENABLE_AUTO_AUTH,
+    ENABLE_COURSE_API,
+    LMS_USERNAME,
+    LMS_PASSWORD,
+    SUPPORT_EMAIL,
+)
 from acceptance_tests.pages import LMSLoginPage
 from common.clients import CourseStructureApiClient
 

--- a/acceptance_tests/test_course_performance.py
+++ b/acceptance_tests/test_course_performance.py
@@ -63,15 +63,15 @@ class CoursePerformancePageTestsMixin(CoursePageTestsMixin):
         return {problem['module_id']: problem for problem in problems}
 
     def _get_assignments(self, assignment_type=None):
-        structure = self.course_api_client.course_structures(self.page.course_id).get()
-        assignments = CourseStructure.course_structure_to_assignments(structure, graded=True,
+        blocks = self.course_api_client.blocks().get()
+        assignments = CourseStructure.course_structure_to_assignments(blocks, graded=True,
                                                                       assignment_type=assignment_type)
 
         return self._build_submissions(assignments, self._get_problems_dict())
 
     def _get_sections(self):
-        structure = self.course_api_client.course_structures(self.page.course_id).get()
-        sections = CourseStructure.course_structure_to_sections(structure, 'problem', graded=False)
+        blocks = self.course_api_client.blocks().get()
+        sections = CourseStructure.course_structure_to_sections(blocks, 'problem', graded=False)
         problems = self._get_problems_dict()
         for section in sections:
             self._build_submissions(section['children'], problems)

--- a/analytics_dashboard/courses/presenters/__init__.py
+++ b/analytics_dashboard/courses/presenters/__init__.py
@@ -69,7 +69,13 @@ class CourseAPIPresenterMixin(object):
         structure = cache.get(key)
         if not structure:
             logger.debug('Retrieving structure for course: %s', self.course_id)
-            structure = self.course_api_client.course_structures(self.course_id).get()
+            blocks_kwargs = {
+                'course_id': self.course_id,
+                'depth': 'all',
+                'all_blocks': 'true',
+                'requested_fields': 'children,format,graded',
+            }
+            structure = self.course_api_client.blocks().get(**blocks_kwargs)
             cache.set(key, structure)
 
         return structure

--- a/analytics_dashboard/courses/tests/test_views/test_engagement.py
+++ b/analytics_dashboard/courses/tests/test_views/test_engagement.py
@@ -149,7 +149,7 @@ class CourseEngagementVideoMixin(CourseEngagementViewTestMixin, CourseStructureV
 
     @httpretty.activate
     def test_invalid_course(self):
-        self._test_invalid_course('course_structures/{}/')
+        self._test_invalid_course(self.COURSE_BLOCKS_API_TEMPLATE)
 
     def setUp(self):
         super(CourseEngagementVideoMixin, self).setUp()

--- a/analytics_dashboard/courses/tests/test_views/test_performance.py
+++ b/analytics_dashboard/courses/tests/test_views/test_performance.py
@@ -90,7 +90,7 @@ class CoursePerformanceViewTestMixin(PatchMixin, CourseStructureViewMixin, Cours
         # Nearly all course performance pages rely on retrieving the grading policy.
         # Break that endpoint to simulate an error.
         course_id = DEMO_COURSE_ID
-        api_path = 'grading_policies/{}/'.format(course_id)
+        api_path = self.GRADING_POLICY_API_TEMPLATE.format(course_id=course_id)
         self.mock_course_api(api_path, status=500)
 
         self._test_api_error()
@@ -111,7 +111,7 @@ class CoursePerformanceGradedMixin(CoursePerformanceViewTestMixin):
 
     @httpretty.activate
     def test_invalid_course(self):
-        self._test_invalid_course('grading_policies/{}/')
+        self._test_invalid_course(self.GRADING_POLICY_API_TEMPLATE)
 
     def assertValidContext(self, context):
         """
@@ -158,7 +158,7 @@ class CoursePerformanceUngradedMixin(CoursePerformanceViewTestMixin):
 
     @httpretty.activate
     def test_invalid_course(self):
-        self._test_invalid_course('course_structures/{}/')
+        self._test_invalid_course(self.COURSE_BLOCKS_API_TEMPLATE)
 
     def assertValidContext(self, context):
         expected = {

--- a/analytics_dashboard/courses/views/__init__.py
+++ b/analytics_dashboard/courses/views/__init__.py
@@ -56,7 +56,7 @@ class CourseAPIMixin(object):
 
         if self.course_api_enabled and request.user.is_authenticated():
             self.access_token = settings.COURSE_API_KEY or request.user.access_token
-            self.course_api = CourseStructureApiClient(settings.COURSE_API_URL, self.access_token).courses
+            self.course_api = CourseStructureApiClient(settings.COURSE_API_URL, self.access_token)
 
         return super(CourseAPIMixin, self).dispatch(request, *args, **kwargs)
 
@@ -78,7 +78,7 @@ class CourseAPIMixin(object):
         if not info:
             try:
                 logger.debug("Retrieving detail for course: %s", course_id)
-                info = self.course_api(course_id).get()
+                info = self.course_api.courses(course_id).get()
                 cache.set(key, info)
             except HttpClientError as e:
                 logger.error("Unable to retrieve course info for %s: %s", course_id, e)
@@ -99,7 +99,7 @@ class CourseAPIMixin(object):
             while page:
                 try:
                     logger.debug('Retrieving page %d of course info...', page)
-                    response = self.course_api.get(page=page, page_size=100)
+                    response = self.course_api.courses.get(page=page, page_size=100)
                     course_details = response['results']
 
                     # Cache the information so that it doesn't need to be retrieved later.
@@ -110,7 +110,7 @@ class CourseAPIMixin(object):
 
                     courses += course_details
 
-                    if response['next']:
+                    if response['pagination']['next']:
                         page += 1
                     else:
                         page = None

--- a/analytics_dashboard/settings/base.py
+++ b/analytics_dashboard/settings/base.py
@@ -420,6 +420,7 @@ THEME_SCSS = 'sass/themes/open-edx.scss'
 
 ########## COURSE API
 COURSE_API_URL = None
+GRADING_POLICY_API_URL = None
 
 # If no key is specified, the authenticated user's OAuth2 access token will be used.
 COURSE_API_KEY = None

--- a/analytics_dashboard/settings/dev.py
+++ b/analytics_dashboard/settings/dev.py
@@ -83,7 +83,8 @@ HELP_URL = '#'
 SEGMENT_IO_KEY = os.environ.get('SEGMENT_WRITE_KEY')
 ########## END SEGMENT.IO
 
-COURSE_API_URL = 'http://127.0.0.1:8000/api/course_structure/v0/'
+GRADING_POLICY_API_URL = 'http://127.0.0.1:8000/api/course_structure/v0/'
+COURSE_API_URL = 'http://127.0.0.1:8000/api/courses/v1/'
 
 LOGGING = get_logger_config(debug=DEBUG, dev_env=True, local_loglevel='DEBUG')
 

--- a/analytics_dashboard/settings/test.py
+++ b/analytics_dashboard/settings/test.py
@@ -24,6 +24,7 @@ SOCIAL_AUTH_EDX_OIDC_URL_ROOT = 'http://example.com'
 
 LMS_COURSE_SHORTCUT_BASE_URL = 'http://lms-host'
 CMS_COURSE_SHORTCUT_BASE_URL = 'http://cms-host'
+GRADING_POLICY_API_URL = 'http://grading-policy-api-host'
 COURSE_API_URL = 'http://course-api-host'
 COURSE_API_KEY = 'test_course_api_key'
 

--- a/common/course_structure.py
+++ b/common/course_structure.py
@@ -25,14 +25,15 @@ class CourseStructure(object):
 
         if matched:
             if require_format:
-                if block[u'format']:
+                if u'format' in block and block[u'format']:
                     return [block]
             else:
                 return [block]
 
         children = []
-        for child in block[u'children']:
-            children += CourseStructure._filter_children(blocks, child, require_format=require_format, **kwargs)
+        if u'children' in block:
+            for child in block[u'children']:
+                children += CourseStructure._filter_children(blocks, child, require_format=require_format, **kwargs)
 
         return children
 


### PR DESCRIPTION
- use course blocks API for course blocks/structure
- decouple course blocks from grading policy (using original API)

COURSE_API_KEY points to the course blocks API and GRADING_POLICY_API_URL points to the original/deprecated course structure API.
