### PR TITLE
Display correct sort arrow direction on learner roster table load

### DIFF
--- a/analytics_dashboard/static/apps/learners/roster/views/base-header-cell.js
+++ b/analytics_dashboard/static/apps/learners/roster/views/base-header-cell.js
@@ -41,7 +41,7 @@ define(function(require) {
         render: function() {
             var directionWord;
             if (this.collection.state.sortKey && this.collection.state.sortKey === this.column.attributes.name) {
-                directionWord = this.collection.state.order ? 'ascending' : 'descending';
+                directionWord = this.collection.state.order ? 'descending' : 'ascending';
                 this.column.attributes.direction = directionWord;
             }
 


### PR DESCRIPTION
I noticed that we had the logic flipped for which arrow to display for which sort currently applied (ascending or descending) on initial learner roster page load. This fix will make sure we display a down arrow for descending sort and an up arrow for ascending sort.
