### PR TITLE
AN-7774 Fix flaky a11y test

### DIFF
--- a/a11y_tests/test_course_enrollment_demographics_axs.py
+++ b/a11y_tests/test_course_enrollment_demographics_axs.py
@@ -31,7 +31,7 @@ class CourseEnrollmentDemographicsAgeTests(CoursePageTestsMixin, WebAppTest):
 
         # Wait for the datatable to finish loading
         ready_promise = EmptyPromise(
-            lambda: 'Loading' not in self.q(css='div.section-data-table').text,
+            lambda: 'Loading' not in self.page.q(css='div.section-data-table').text,
             "Page finished loading"
         ).fulfill()
 

--- a/a11y_tests/test_course_enrollment_demographics_axs.py
+++ b/a11y_tests/test_course_enrollment_demographics_axs.py
@@ -1,4 +1,5 @@
 from bok_choy.web_app_test import WebAppTest
+from bok_choy.promise import EmptyPromise
 from a11y_tests.pages import CourseEnrollmentDemographicsAgePage
 from a11y_tests.mixins import CoursePageTestsMixin
 
@@ -27,6 +28,12 @@ class CourseEnrollmentDemographicsAgeTests(CoursePageTestsMixin, WebAppTest):
                 'icon-aria-hidden',  # TODO: AN-6187
             ],
         })
+
+        # Wait for the datatable to finish loading
+        ready_promise = EmptyPromise(
+            lambda: 'Loading' not in self.q(css='div.section-data-table').text,
+            "Page finished loading"
+        ).fulfill()
 
         # Check the page for accessibility errors
         report = self.page.a11y_audit.check_for_accessibility_errors()

--- a/a11y_tests/test_course_enrollment_demographics_axs.py
+++ b/a11y_tests/test_course_enrollment_demographics_axs.py
@@ -1,7 +1,6 @@
-from bok_choy.web_app_test import WebAppTest
-from bok_choy.promise import EmptyPromise
-from a11y_tests.pages import CourseEnrollmentDemographicsAgePage
 from a11y_tests.mixins import CoursePageTestsMixin
+from a11y_tests.pages import CourseEnrollmentDemographicsAgePage
+from bok_choy.web_app_test import WebAppTest
 
 _multiprocess_can_split_ = True
 

--- a/a11y_tests/test_course_enrollment_demographics_axs.py
+++ b/a11y_tests/test_course_enrollment_demographics_axs.py
@@ -1,5 +1,6 @@
 from a11y_tests.mixins import CoursePageTestsMixin
 from a11y_tests.pages import CourseEnrollmentDemographicsAgePage
+from bok_choy.promise import EmptyPromise
 from bok_choy.web_app_test import WebAppTest
 
 _multiprocess_can_split_ = True

--- a/analytics_dashboard/static/js/views/data-table-view.js
+++ b/analytics_dashboard/static/js/views/data-table-view.js
@@ -253,6 +253,10 @@ define(['dataTablesBootstrap', 'jquery', 'naturalSort', 'underscore', 'utils/uti
 
                 $table.dataTable(dtConfig);
 
+                // Fix the aria role usage
+                $table.find('th').attr('role', 'columnheader').attr('scope', 'col');
+                $table.find('td').attr('role', 'gridcell');
+
                 return self;
             }
 


### PR DESCRIPTION
[AN-7774](https://openedx.atlassian.net/browse/AN-7774) This has been a source of annoyance for a while...

To fix this, I first made the test wait until the data-table on the page has loaded. This made the test consistently fail. Then, I added the proper aria roles to the table elements so that the a11y tests passed.
