### PR TITLE
AN-7761 Fix broken cldr require for some languages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,9 @@ update_translations: pull_translations generate_fake_translations
 
 static_no_compress:
 	$(NODE_BIN)/r.js -o build.js
-	python manage.py collectstatic --noinput
+	# collectstatic creates way too much output with the cldr-data directory output so silence that directory
+	echo "Running collectstatic while silencing cldr-data/main/* ..."
+	python manage.py collectstatic --noinput | sed -n '/.*bower_components\/cldr-data\/main\/.*/!p'
 
 static: static_no_compress
 	python manage.py compress

--- a/analytics_dashboard/static/js/test/specs/globalization-spec.js
+++ b/analytics_dashboard/static/js/test/specs/globalization-spec.js
@@ -1,30 +1,42 @@
-define(['utils/globalization'], function() {
+// eslint-disable-next-line import/no-unresolved
+define(['json!cldr-data/availableLocales.json', 'utils/globalization'], function(availableLocales) {
     'use strict';
+
+    var lowerLocalesMapping = {};
+    availableLocales.availableLocales.forEach(function(locale) {
+        lowerLocalesMapping[locale.toLowerCase()] = locale;
+    });
 
     describe('fixLanguageCode', function() {
         it('should default to English if an invalid argument is provided', function() {
-            expect(fixLanguageCode(null)).toEqual('en');
-            expect(fixLanguageCode('')).toEqual('en');
-            expect(fixLanguageCode(1)).toEqual('en');
-            expect(fixLanguageCode(true)).toEqual('en');
+            expect(fixLanguageCode(null, lowerLocalesMapping)).toEqual('en');
+            expect(fixLanguageCode('', lowerLocalesMapping)).toEqual('en');
+            expect(fixLanguageCode(1, lowerLocalesMapping)).toEqual('en');
+            expect(fixLanguageCode(true, lowerLocalesMapping)).toEqual('en');
         });
 
         it('should return zh if the given language code is either zh-cn, zh-sg and zh-hans(-*) ', function() {
-            expect(fixLanguageCode('zh-cn')).toEqual('zh');
-            expect(fixLanguageCode('zh-sg')).toEqual('zh');
-            expect(fixLanguageCode('zh-hans')).toEqual('zh');
-            expect(fixLanguageCode('zh-hans-cn')).toEqual('zh');
+            expect(fixLanguageCode('zh-cn', lowerLocalesMapping)).toEqual('zh');
+            expect(fixLanguageCode('zh-sg', lowerLocalesMapping)).toEqual('zh');
+            expect(fixLanguageCode('zh-hans', lowerLocalesMapping)).toEqual('zh');
+            expect(fixLanguageCode('zh-hans-cn', lowerLocalesMapping)).toEqual('zh');
         });
 
-        it('should return zh-hant if the given language code is either zh-tw, zh-hk, zh-mo and zh-hant-* ', function() {
-            expect(fixLanguageCode('zh-tw')).toEqual('zh-hant');
-            expect(fixLanguageCode('zh-hk')).toEqual('zh-hant');
-            expect(fixLanguageCode('zh-mo')).toEqual('zh-hant');
-            expect(fixLanguageCode('zh-hant-tw')).toEqual('zh-hant');
+        it('should return zh-Hant if the given language code is either zh-tw, zh-hk, zh-mo and zh-hant-* ', function() {
+            expect(fixLanguageCode('zh-tw', lowerLocalesMapping)).toEqual('zh-Hant');
+            expect(fixLanguageCode('zh-hk', lowerLocalesMapping)).toEqual('zh-Hant');
+            expect(fixLanguageCode('zh-mo', lowerLocalesMapping)).toEqual('zh-Hant');
+            expect(fixLanguageCode('zh-hant-tw', lowerLocalesMapping)).toEqual('zh-Hant');
         });
 
         it('should return en if the given language code is not known to CLDR', function() {
-            expect(fixLanguageCode('not-real')).toEqual('en');
+            expect(fixLanguageCode('not-real', lowerLocalesMapping)).toEqual('en');
+        });
+
+        it('should return correct-casing any given cased language code', function() {
+            expect(fixLanguageCode('en-gb', lowerLocalesMapping)).toEqual('en-GB');
+            expect(fixLanguageCode('en-GB', lowerLocalesMapping)).toEqual('en-GB');
+            expect(fixLanguageCode('EN-GB', lowerLocalesMapping)).toEqual('en-GB');
         });
     });
 });

--- a/analytics_dashboard/static/js/utils/globalization.js
+++ b/analytics_dashboard/static/js/utils/globalization.js
@@ -1,4 +1,8 @@
-function fixLanguageCode(languageCode) {
+if (window.language === undefined) { // should only occur in test environments
+    window.language = 'en';
+}
+
+function fixLanguageCode(languageCode, lowerLocalesMapping) {
     'use strict';
     var fixedLanguageCode;
 
@@ -11,35 +15,39 @@ function fixLanguageCode(languageCode) {
     // CLDR uses zh for Simplified Chinese, while Django may use different strings.
     if (fixedLanguageCode === 'zh-cn' || fixedLanguageCode === 'zh-sg' ||
         fixedLanguageCode.indexOf('zh-hans') === 0) {
-        return 'zh';
+        fixedLanguageCode = 'zh';
     }
     // CLDR uses zh-hant for Traditional Chinese, while Django may use different strings.
     if (fixedLanguageCode === 'zh-tw' || fixedLanguageCode === 'zh-hk' ||
         fixedLanguageCode === 'zh-mo' || fixedLanguageCode.indexOf('zh-hant') === 0) {
-        return 'zh-hant';
+        fixedLanguageCode = 'zh-hant';
     }
 
     // There doesn't seem to be an onFailure event for the text! plugin. Make sure we only pass valid language codes
     // so the plugin does not attempt to load non-existent files.
-    if (['ar', 'ca', 'cs', 'da', 'de', 'el', 'en-001', 'en-au', 'en-ca', 'en-gb', 'en-hk', 'en-in', 'en', 'es', 'fi',
-        'fr', 'he', 'hi', 'hr', 'hu', 'it', 'ja', 'ko', 'nb', 'nl', 'pl', 'pt-pt', 'pt', 'ro', 'root', 'ru', 'sk', 'sl',
-        'sr', 'sv', 'th', 'tr', 'uk', 'vi', 'zh-hant', 'zh'].indexOf(fixedLanguageCode) > -1) {
-        return fixedLanguageCode;
+    if (fixedLanguageCode in lowerLocalesMapping) {
+        return lowerLocalesMapping[fixedLanguageCode];
     }
 
     return 'en';
 }
 
-window.language = fixLanguageCode(window.language);
-
 define([
     'globalize',
     'json!cldr-data/supplemental/likelySubtags.json',
     'json!cldr-data/supplemental/numberingSystems.json',
+    'json!cldr-data/availableLocales.json',  // eslint-disable-line import/no-unresolved
     'json!cldr-data/main/' + window.language + '/numbers.json',
     'globalize/number'
-], function(Globalize, likelySubtags, numberingSystems, numbers) {
+], function(Globalize, likelySubtags, numberingSystems, availableLocales, numbers) {
     'use strict';
+
+    var lowerLocalesMapping = {};
+    availableLocales.availableLocales.forEach(function(locale) {
+        lowerLocalesMapping[locale.toLowerCase()] = locale;
+    });
+
+    window.language = fixLanguageCode(window.language, lowerLocalesMapping);
 
     Globalize.load(likelySubtags);
     Globalize.load(numberingSystems);

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "tests"
   ],
   "dependencies": {
-    "globalize": "1.0.0-alpha.17",
+    "globalize": "1.1.1",
     "requirejs-plugins": "~1.0.3",
     "bootstrap-sass-official": "v3.2.0+2",
     "jquery": "~1.11.1",
@@ -27,7 +27,7 @@
     "datatables": "~1.10.2",
     "font-awesome": "~4.6.3",
     "natural-sort": "overset/javascript-natural-sort#dbf4ca259b327a488bd1d7897fd46d80c414a7e0",
-    "cldr-data": "26.0.3",
+    "cldr-data": "29.0.0",
     "edx-ui-toolkit": "edx/edx-ui-toolkit#29759050aff2f4f3cb6921432855ad057bd69bb1",
     "marionette": "~2.4.4",
     "uri.js": "1.17",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "bower": "^1.3.12",
-    "cldr-data-downloader": "0.1.1",
+    "cldr-data-downloader": "0.2.5",
     "requirejs": "^2.1.14"
   },
   "devDependencies": {


### PR DESCRIPTION
This issue was preventing many users from loading parts of Insights. ~~I added a post-install task to rename cldr-data language directories that had mixed case to fully lowercase names. We already lowercase the language code that we get from `window.language`.~~ Update: Turns out that lowercasing all of the cldr-data locale directories did break things... Now we are converting the lowercase locales that the browser reports to the casing that cldr-data expects by doing a mapping in the javascript code instead. Much cleaner.

I tested this with my chrome browser set to `en-gb` and verified that the pages now load.

~~As far as I can tell, nothing else in the application is affected by lowercasing all of the cldr directory names.~~

I also did some improvements to globalization like use the cldr `availableLocales` instead of a static list, added a test for lowercasing the window.language, defaulted to "en" when undefined, and silenced all "Copying" log messages from `bower_components/cldr-data/main/*` during collectstatic (was causing Travis to error out because of the sheer number of lines of logs it produces).
