### PR TITLE
Add -moz prefixed css column styles

### DIFF
--- a/analytics_dashboard/static/sass/_developer.scss
+++ b/analytics_dashboard/static/sass/_developer.scss
@@ -402,7 +402,9 @@ body.view-dashboard {
 
 .course-home-table-outer {
   columns: 3;
+  -moz-columns: 3;
   column-width: $bp-screen-lg / 3;
+  -moz-column-width: $bp-screen-lg / 3;
 
   header.heading-outer {
     display: table;


### PR DESCRIPTION
We discovered that the course home page question sections weren't being split up into columns in firefox. Adding these `-moz` prefixed styles solves the issue.
