### PR TITLE
Add variable to .travis.yml for Data API checkout version for acceptance tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ language:
 python: "2.7"
 node_js: "5.2.0"
 sudo: false
+env:
+  # Make sure to update this string on every Insights or Data API release
+  - DATA_API_VERSION="0.17.0-rc.1"
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
@@ -14,7 +17,7 @@ addons:
 install:
     - make develop
     - make migrate
-    - ./scripts/install_analytics_data_api.sh
+    - ./scripts/install_analytics_data_api.sh $DATA_API_VERSION
     - pip install coveralls
 script:
     - make static_no_compress

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
 addons:
+    firefox: "46.0"
     apt:
         packages:
             - language-pack-en

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -16,6 +16,6 @@ pep257==0.7.0
 pep8==1.7.0
 pylint==1.6.4
 logilab-common==1.2.2
-selenium>=2.44.0
+selenium>=2.44.0,<3.0.0
 sure==1.4.0
 testfixtures==4.10.0

--- a/scripts/install_analytics_data_api.sh
+++ b/scripts/install_analytics_data_api.sh
@@ -2,6 +2,11 @@
 
 git clone https://github.com/edx/edx-analytics-data-api.git
 cd edx-analytics-data-api
+if [ -z $1 ]; then
+  git checkout master
+else
+  git checkout $1
+fi
 virtualenv venv
 source venv/bin/activate
 make requirements


### PR DESCRIPTION
The build for eucalyptus.master is currently failing because, in the script for running the acceptance tests in travis, it pulls the master branch of the Data API. The master branch has progressed enough now that it is no longer compatible with the eucalyptus branch of Insights.

This is what I think we should have done: specify the specific version of the Data API that the Insights code is compatible with. I set this in the .travis.yml because that's where we need it.

To fix the bug on eucalyptus.master, we will have to cherry-pick this commit and edit the DATA_API_VERSION in the .travis.yml to the version of the Data API when its eucalyptus branch was cut.

If we agree that this is the best solution, then I will add a step to the [Analytics Release Process page](https://openedx.atlassian.net/wiki/display/AN/Analytics+Release+Process) to make sure the variable in the .travis.yml is up to date on every release of Insights or the Data API. Ideally, whenever there is a change in the API that requires us to change code in Insights to accommodate it, we would also update the variable in that Insights PR.

FYI: @cpennington 
