### PR TITLE
AN-7716 Use new grades API endpoint

### DIFF
--- a/analytics_dashboard/courses/presenters/performance.py
+++ b/analytics_dashboard/courses/presenters/performance.py
@@ -44,7 +44,6 @@ class CoursePerformancePresenter(CourseAPIPresenterMixin, BasePresenter):
 
     def __init__(self, access_token, course_id, timeout=settings.LMS_DEFAULT_TIMEOUT):
         super(CoursePerformancePresenter, self).__init__(access_token, course_id, timeout)
-        # the deprecated course structure API has grading policy. This will be replaced in AN-7716
         self.grading_policy_client = CourseStructureApiClient(settings.GRADING_POLICY_API_URL, access_token)
 
     def course_module_data(self):
@@ -185,7 +184,7 @@ class CoursePerformancePresenter(CourseAPIPresenterMixin, BasePresenter):
 
         if not grading_policy:
             logger.debug('Retrieving grading policy for course: %s', self.course_id)
-            grading_policy = self.grading_policy_client.grading_policies(self.course_id).get()
+            grading_policy = self.grading_policy_client.courses(self.course_id).policy.get()
 
             # Remove empty assignment types as they are not useful and will cause issues downstream.
             grading_policy = [item for item in grading_policy if item['assignment_type']]

--- a/analytics_dashboard/courses/tests/test_views/__init__.py
+++ b/analytics_dashboard/courses/tests/test_views/__init__.py
@@ -32,7 +32,7 @@ class CourseAPIMixin(object):
     COURSE_BLOCKS_API_TEMPLATE = \
         settings.COURSE_API_URL + \
         '/blocks/?course_id={course_id}&requested_fields=children,graded&depth=all&all_blocks=true'
-    GRADING_POLICY_API_TEMPLATE = settings.GRADING_POLICY_API_URL + '/grading_policies/{course_id}/'
+    GRADING_POLICY_API_TEMPLATE = settings.GRADING_POLICY_API_URL + '/courses/{course_id}/policy/'
 
     def mock_course_api(self, url, body=None, **kwargs):
         """

--- a/analytics_dashboard/settings/dev.py
+++ b/analytics_dashboard/settings/dev.py
@@ -83,7 +83,7 @@ HELP_URL = '#'
 SEGMENT_IO_KEY = os.environ.get('SEGMENT_WRITE_KEY')
 ########## END SEGMENT.IO
 
-GRADING_POLICY_API_URL = 'http://127.0.0.1:8000/api/course_structure/v0/'
+GRADING_POLICY_API_URL = 'http://127.0.0.1:8000/api/grades/v0/'
 COURSE_API_URL = 'http://127.0.0.1:8000/api/courses/v1/'
 
 LOGGING = get_logger_config(debug=DEBUG, dev_env=True, local_loglevel='DEBUG')


### PR DESCRIPTION
The grading policy endpoint in the deprecated course_structure api was moved to it's own grades api. The new api returns the exact same data, but lives at a different url. This points Insights to the url for that new endpoint.

There will be an accompanying edx/configuration change with this PR since production is configured by files in that repo.

I tested this in my devstack.
