### PR TITLE
Fix the no percentages bug in engagement summary cards on stage

### DIFF
--- a/analytics_dashboard/courses/presenters/engagement.py
+++ b/analytics_dashboard/courses/presenters/engagement.py
@@ -105,8 +105,20 @@ class CourseEngagementActivityPresenter(BasePresenter):
                 week['active_percent'] = num_active / float(week['enrollment'])
             else:
                 week['active_percent'] = None  # Avoid divide-by-zero but add an entry for this column so it appears
-        most_recent = trends[-1]
-        summary_enrollment = enrollment_by_day.get(most_recent['weekEnding'])
+
+        # Find the latest weekEnding in the trends that we have enrollment data for.
+        # (should usually be trends[-1] unless the enrollment data somehow got behind)
+        summary_enrollment = None
+        trends_step_back = 1
+        while not summary_enrollment:
+            if trends_step_back > len(trends):
+                # No enrollment data for any of the dates in the activity trend data.
+                # This should never be executed because of the has_enrollment_data check above.
+                return
+            most_recent = trends[-trends_step_back]
+            summary_enrollment = enrollment_by_day.get(most_recent['weekEnding'])
+            trends_step_back += 1
+
         if summary_enrollment:
             for key in self.get_activity_types():
                 if summary.get(key):

--- a/analytics_dashboard/courses/tests/test_presenters.py
+++ b/analytics_dashboard/courses/tests/test_presenters.py
@@ -141,7 +141,6 @@ class CourseEngagementActivityPresenterTests(TestCase):
             del expected_summary[AT.POSTED_FORUM]
             del expected_summary['posted_forum_percent_str']
 
-
         expected_summary['last_updated'] = utils.CREATED_DATETIME
 
         return expected_summary
@@ -157,7 +156,7 @@ class CourseEngagementActivityPresenterTests(TestCase):
             'played_video_percent_str': u"15.0% of current students",
             'any_percent_str': u"5.0% of current students",
         })
-        
+
         if not include_forum_data:
             del expected_summary['posted_forum_percent_str']
 

--- a/analytics_dashboard/courses/tests/utils.py
+++ b/analytics_dashboard/courses/tests/utils.py
@@ -489,6 +489,23 @@ def get_mock_api_course_activity(course_id):
 def mock_course_activity(start_date=None, end_date=None):
     return get_mock_api_course_activity(u'edX/DemoX/Demo_Course')
 
+# pylint: disable=unused-argument
+def mock_course_activity_week_ahead(start_date=None, end_date=None):
+    course_id = u'edX/DemoX/Demo_Course'
+    activity = get_mock_api_course_activity(course_id)
+    activity.append(
+        {
+            'course_id': unicode(course_id),
+            'interval_end': '2014-09-15T000000',
+            AT.ANY: 500,
+            AT.ATTEMPTED_PROBLEM: 701,
+            AT.PLAYED_VIDEO: 1500,
+            AT.POSTED_FORUM: 32,
+            'created': CREATED_DATETIME_STRING
+        },
+    )
+    return activity
+
 
 def get_mock_api_answer_distribution_multiple_questions_first_last_data(course_id):
     # First and last response counts were added, insights can handle both types of API responses at the moment.

--- a/analytics_dashboard/courses/tests/utils.py
+++ b/analytics_dashboard/courses/tests/utils.py
@@ -489,6 +489,7 @@ def get_mock_api_course_activity(course_id):
 def mock_course_activity(start_date=None, end_date=None):
     return get_mock_api_course_activity(u'edX/DemoX/Demo_Course')
 
+
 # pylint: disable=unused-argument
 def mock_course_activity_week_ahead(start_date=None, end_date=None):
     course_id = u'edX/DemoX/Demo_Course'


### PR DESCRIPTION
We recently ran the engagement (course_activity) task on stage without also running the enrollment task which created an interesting scenario that we haven't experienced before. The engagement presenter tries to find the enrollment count at the lastest "weekEnding" date it has. Because the engagement data was so far ahead of the enrollment data, that date didn't exist and Insights fell back to showing nothing in the summary cards.

To make the presenter a little more robust, it now looks back to the latest enrollment count instead of displaying nothing at all.

FYI @katymyw and @lamagnifica
