### PR TITLE
Update bower to 1.8.0 to fix Travis builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "git://github.com/edx/edx-analytics-dashboard"
   },
   "dependencies": {
-    "bower": "^1.3.12",
+    "bower": "^1.8.0",
     "cldr-data-downloader": "0.2.5",
     "requirejs": "^2.1.14"
   },


### PR DESCRIPTION
All of our builds on Travis started throwing errors during the build install process. I haven't pin-pointed the problem, but this branch with bower updated to 1.8.0 (from 1.3.12) seems to work.

We should get this into master quickly, it's blocking my ability to test other branches in Travis.