### PR TITLE
AN-8109 Upgrade bower to 1.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "git://github.com/edx/edx-analytics-dashboard"
   },
   "dependencies": {
-    "bower": "^1.3.12",
+    "bower": "1.7.2",
     "cldr-data-downloader": "0.2.5",
     "requirejs": "^2.1.14"
   },


### PR DESCRIPTION
Our builds in Travis started failing (inconsistently) despite no code changes on our part. Something in the bower ecosystem must have changed, especially since it suspiciously started happening around the same time Bower 1.8.0 was released.

The error message is just a very short and cryptic nodejs exception:
```
events.js:72
        throw er; // Unhandled 'error' event
              ^
Error: ENOENT, rename '/tmp/travis/bower/.../archive.tar.gz...'
```

It seems that bower trying to unpack a downloaded package that does not exist. Which might be related to a bunch of previous errors about failing to download packages and retrying.

[This bower bug](https://github.com/bower/bower/issues/2118), marked as resolved, suggested that the issue would be fixed for Bower versions 1.7.2 or later. I at first tried upgrading all the way to 1.8.0, but the issue was still there. But, going to 1.7.2 has yet to break the build, so I'm thinking 1.8.0, or another recent version, might have introduced a regression to that earlier bug.

I have no way of confirming that this actually fixes the bug besides the fact that I've run this almost 10 times both locally in a Travis docker container and in our Travis environment for this repo and it hasn't failed yet today. I think we should use this version of Bower for a while to see if it resolves the issue.