### PR TITLE
AN-8091 Fix enrollment geography tooltip bug

### DIFF
--- a/analytics_dashboard/static/sass/_developer.scss
+++ b/analytics_dashboard/static/sass/_developer.scss
@@ -111,6 +111,7 @@ button.chart-info {
   .chart-tooltip {
     position: absolute;
     right: 0;
+    z-index: 1;
   }
 }
 


### PR DESCRIPTION
Hovering over the tooltip icon on the world map on the enrollment geography page was not showing a tooltip. This raises the z-index on the icon so it's above the map so that hovering will activate the hover event and show the tooltip.