### PR TITLE
AN-8269: fix chrome course home one-column bug

### DIFF
--- a/analytics_dashboard/static/sass/_developer.scss
+++ b/analytics_dashboard/static/sass/_developer.scss
@@ -404,8 +404,10 @@ body.view-dashboard {
 .course-home-table-outer {
   columns: 3;
   -moz-columns: 3;
+  -webkit-columns: 3;
   column-width: $bp-screen-lg / 3;
   -moz-column-width: $bp-screen-lg / 3;
+  -webkit-column-width: $bp-screen-lg / 3;
 
   header.heading-outer {
     display: table;


### PR DESCRIPTION
Some Chrome users were experiencing a bug where the Course Home page content was displaying in one column instead of three. I suspect it is because older chrome versions require the `-webkit-` prefix on the CSS properties `column` and `column-width` [[1]][[2]]. I have no way of verifying this without knowing the version of chrome that is experiencing the issue, but this change does not hurt anything so it seems sensible to add.

[1]: https://developer.mozilla.org/en-US/docs/Web/CSS/columns#compat-desktop
[2]: https://developer.mozilla.org/en-US/docs/Web/CSS/column-width#compat-desktop
