### PR TITLE
Added validate_translations to makefile.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ install:
     - pip install coveralls
 script:
     - make static_no_compress
+    - make validate_translations
     - make validate
     - make generate_fake_translations
     - make accept

--- a/Makefile
+++ b/Makefile
@@ -73,9 +73,11 @@ demo:
 	python manage.py waffle_switch display_names_for_course_index off --create
 	python manage.py waffle_switch display_course_name_in_nav off --create
 
+# compiles the *.po & *.mo files
 compile_translations:
 	cd analytics_dashboard && i18n_tool generate -v
 
+# creates the django-partial.po & django-partial.mo files
 extract_translations:
 	cd analytics_dashboard && i18n_tool extract -v
 
@@ -88,6 +90,13 @@ pull_translations:
 	cd analytics_dashboard && tx pull -a
 
 update_translations: pull_translations generate_fake_translations
+
+# check if translation files are up-to-date
+detect_changed_source_translations:
+	cd analytics_dashboard && i18n_tool changed
+
+# extract, compile, and check if translation files are up-to-date
+validate_translations: extract_translations compile_translations detect_changed_source_translations
 
 static_no_compress:
 	$(NODE_BIN)/r.js -o build.js

--- a/README.md
+++ b/README.md
@@ -110,12 +110,14 @@ Navigate to a page and verify that you see fake translations. If you see plain E
 properly translated.
 
 ###Updating Translations###
-Once development is complete, translation source files (.po) must be generated. The command below handle this.
+Once development is complete, translation source files (.po) must be generated. The command below will generate the
+necessary source files and verify that an updated is needed:
 
-        $ cd analytics_dashboard && i18n_tool extract
+        $ make validate_translations
 
-The generated files located in `analytics_dashboard/conf/locale/en/LC_MESSAGES` should be uploaded to
-the [analytics-dashboard](https://www.transifex.com/projects/p/edx-platform/resource/analytics-dashboard/) and
+If not [automated](https://docs.transifex.com/projects/updating-content#automatic-updates), the generated files located
+in `analytics_dashboard/conf/locale/en/LC_MESSAGES` should be uploaded to the
+[analytics-dashboard](https://www.transifex.com/projects/p/edx-platform/resource/analytics-dashboard/) and
 [analytics-dashboard-js](https://www.transifex.com/projects/p/edx-platform/resource/analytics-dashboard-js/) resources
 at Transifex where translators will begin the translation process. This task can be completed using the [Transifex
 Client](http://docs.transifex.com/developer/client/):


### PR DESCRIPTION
`make validate_translations` will be run via travis and error if updated source files aren't found.  New PRs will need to update the translations files in `analytics_dashboard/conf/locale/en/LC_MESSAGES/` in order to pass if strings that require translations are updated.

Example error can be seen in https://travis-ci.org/edx/edx-analytics-dashboard/builds/187077118:
![screen shot 2016-12-27 at 4 35 27 pm](https://cloud.githubusercontent.com/assets/5265058/21509485/62265d54-cc57-11e6-85dd-5d9f1d7cfb75.png)
