### PR TITLE
serve assets on devstack

### DIFF
--- a/analytics_dashboard/settings/base.py
+++ b/analytics_dashboard/settings/base.py
@@ -24,6 +24,7 @@ path.append(DJANGO_ROOT)
 ########## DEBUG CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#debug
 DEBUG = False
+ENABLE_INSECURE_STATIC_FILES = False
 ########## END DEBUG CONFIGURATION
 
 

--- a/analytics_dashboard/settings/production.py
+++ b/analytics_dashboard/settings/production.py
@@ -4,12 +4,14 @@ from analytics_dashboard.settings.base import *
 from analytics_dashboard.settings.yaml_config import *
 from analytics_dashboard.settings.logger import get_logger_config
 
-# Enable offline compression of CSS/JS
-COMPRESS_ENABLED = True
-COMPRESS_OFFLINE = True
 
-# Use r.js to combine RequireJS files
-RJS_OPTIMIZATION_ENABLED = True
+if not DEBUG:
+    # Enable offline compression of CSS/JS
+    COMPRESS_ENABLED = True
+    COMPRESS_OFFLINE = True
+
+    # Use r.js to combine RequireJS files
+    RJS_OPTIMIZATION_ENABLED = True
 
 # Minify CSS
 COMPRESS_CSS_FILTERS += [

--- a/analytics_dashboard/urls.py
+++ b/analytics_dashboard/urls.py
@@ -8,6 +8,7 @@ from django.core.urlresolvers import reverse_lazy
 from django.views import defaults
 from django.views.generic import RedirectView
 from django.views.i18n import javascript_catalog
+from django.contrib.staticfiles import views as static_views
 
 # pylint suggests importing analytics_dashboard.core, which causes errors in our AMI
 # pylint: disable=relative-import
@@ -66,4 +67,9 @@ if settings.DEBUG:  # pragma: no cover
 
         urlpatterns += [
             url(r'^__debug__/', include(debug_toolbar.urls)),
+        ]
+
+    if settings.ENABLE_INSECURE_STATIC_FILES:
+        urlpatterns += [
+            url(r'^static/(?P<path>.*)$', static_views.serve),
         ]


### PR DESCRIPTION
This emulates the handling of static assets that you get when you run "./manage.py runserver" but allows us to turn on that behavior using a setting.

This allows us to use production-like settings and run Insights using gunicorn while still having it dynamically re-compile all static assets on an as-needed basis when pages are rendered.

This PR is part of the dockerization of the analyticstack, most of the documentation can be found here: https://github.com/edx/configuration/pull/3582

FYI: @HassanJaveed84 @brianhw @tobz @fredsmith @feanil @clintonb 