### PR TITLE
Removed use of intermediary *-partial.mo & *-partial.po file.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,13 +73,14 @@ demo:
 	python manage.py waffle_switch display_names_for_course_index off --create
 	python manage.py waffle_switch display_course_name_in_nav off --create
 
-# compiles the *.po & *.mo files
+# compiles djangojs and django .po and .mo files
 compile_translations:
-	cd analytics_dashboard && i18n_tool generate -v
+	python manage.py compilemessages
 
-# creates the django-partial.po & django-partial.mo files
+# creates the source django & djangojs files
 extract_translations:
-	cd analytics_dashboard && i18n_tool extract -v
+	cd analytics_dashboard && python ../manage.py makemessages -l en -v1 --ignore="docs/*" --ignore="src/*" --ignore="i18n/*" --ignore="assets/*" -d django
+	cd analytics_dashboard && python ../manage.py makemessages -l en -v1 --ignore="docs/*" --ignore="src/*" --ignore="i18n/*" --ignore="assets/*" -d djangojs
 
 dummy_translations:
 	cd analytics_dashboard && i18n_tool dummy -v
@@ -97,6 +98,7 @@ detect_changed_source_translations:
 
 # extract, compile, and check if translation files are up-to-date
 validate_translations: extract_translations compile_translations detect_changed_source_translations
+	cd analytics_dashboard && i18n_tool validate
 
 static_no_compress:
 	$(NODE_BIN)/r.js -o build.js

--- a/analytics_dashboard/.tx/config
+++ b/analytics_dashboard/.tx/config
@@ -2,13 +2,13 @@
 host = https://www.transifex.com
 
 [edx-platform.analytics-dashboard]
-file_filter = conf/locale/<lang>/LC_MESSAGES/django-partial.po
-source_file = conf/locale/en/LC_MESSAGES/django-partial.po
+file_filter = conf/locale/<lang>/LC_MESSAGES/django.po
+source_file = conf/locale/en/LC_MESSAGES/django.po
 source_lang = en
 type = PO
 
 [edx-platform.analytics-dashboard-js]
-file_filter = conf/locale/<lang>/LC_MESSAGES/djangojs-partial.po
-source_file = conf/locale/en/LC_MESSAGES/djangojs-partial.po
+file_filter = conf/locale/<lang>/LC_MESSAGES/djangojs.po
+source_file = conf/locale/en/LC_MESSAGES/djangojs.po
 source_lang = en
 type = PO


### PR DESCRIPTION
`i18n_tools` extracts source translations into `*-partial.po` and `*-partial.mo` files, which are then compiled/generated into non-partial `.po` and `.mo` files and was useful at one point for the edx platform.  Insights only doesn't need this.

This change uses the underlying django management commands that `i18n_tools` calls to extract and compile translated strings and adds a call to `i18n_tool validate`.  At the moment, the validation command doesn't fail the build, but at the very least will display translation errors (NB: translation errors in javascript aren't caught in the compilation, but are caught in the validation).

This change will also enable better integration with our automated translations system.