### PR TITLE
Add navigation click tracking to course-list

### DIFF
--- a/analytics_dashboard/static/apps/course-list/list/templates/course-id-and-name-cell.underscore
+++ b/analytics_dashboard/static/apps/course-list/list/templates/course-id-and-name-cell.underscore
@@ -1,4 +1,8 @@
-<a href="/courses/<%- course_id %>">
+<a href="/courses/<%- course_id %>"
+    data-track-type="click" data-track-event="edx.bi.ui.menu.navigated"
+    data-track-text="<%- catalog_course_title %> | <%- course_id %>"
+    data-track-url="/courses/<%- course_id %>" data-track-target-scope="course"
+    data-track-target-lens="home" data-track-menu-depth="insights" data-track-link-name="course_row">
   <div class="course-name">
     <%- catalog_course_title %>
   </div>

--- a/analytics_dashboard/static/apps/course-list/list/views/course-id-and-name-cell.js
+++ b/analytics_dashboard/static/apps/course-list/list/views/course-id-and-name-cell.js
@@ -15,9 +15,15 @@ define(function(require) {
     CourseIdAndNameCell = Backgrid.Cell.extend({
         className: 'course-name-cell',
         template: _.template(courseIdAndNameCellTemplate),
+        events: {
+            click: 'emitTracking'
+        },
         render: function() {
             this.$el.html(this.template(this.model.toJSON()));
             return this;
+        },
+        emitTracking: function() {
+            this.$el.find('a').trigger('clicked.tracking');
         }
     });
 

--- a/analytics_dashboard/static/js/test/specs/tracking-view-spec.js
+++ b/analytics_dashboard/static/js/test/specs/tracking-view-spec.js
@@ -306,22 +306,16 @@ define(['jquery', 'models/course-model', 'models/tracking-model', 'models/user-m
                     showTooltip: function() {
                         $sandbox.trigger('shown.bs.tooltip');
                     },
+                    triggerClick: function() {
+                        $sandbox.trigger('clicked.tracking');
+                    },
                     expectNoEventToHaveBeenEmitted: function() {
                         expect(view.segment.track).not.toHaveBeenCalled();
                     },
                     expectEventEmitted: function(eventType, properties) {
                         expect(view.segment.track).toHaveBeenCalledWith(eventType, properties);
-                    }
-                };
-            }
-
-            it('should emit an event when tooltips are shown', function() {
-                var test = setupTest();
-
-                test.showTooltip();
-
-                test.expectEventEmitted(
-                    'trackingEvent', {
+                    },
+                    expectedProperties: {
                         label: 'course_mylens_myreport',
                         courseId: 'my/course/id',
                         org: 'org',
@@ -335,31 +329,57 @@ define(['jquery', 'models/course-model', 'models/tracking-model', 'models/user-m
                             name: 'course_mylens_myreport'
                         }
                     }
-                );
+                };
+            }
+
+            it('should emit an event when tooltips are shown', function() {
+                var test = setupTest();
+
+                test.showTooltip();
+
+                test.expectEventEmitted('trackingEvent', test.expectedProperties);
             });
 
-            it('should not emit an event when tooltips are shown when tracking is not enabled', function() {
+            it('should emit an event when tracked element is clicked', function() {
+                var test = setupTest();
+
+                test.triggerClick();
+
+                test.expectEventEmitted('trackingEvent', test.expectedProperties);
+            });
+
+
+            it('should not emit an event when tracking is not enabled', function() {
                 var test = setupTest();
 
                 test.trackingModel.unset('segmentApplicationId');
 
                 test.showTooltip();
                 test.expectNoEventToHaveBeenEmitted();
+
+                test.triggerClick();
+                test.expectNoEventToHaveBeenEmitted();
             });
 
-            it('should not emit an event when tooltips are shown when event type is empty', function() {
+            it('should not emit an event when event type is empty', function() {
                 var test = setupTest();
 
                 test.sandbox.attr('data-track-event', '');
                 test.showTooltip();
                 test.expectNoEventToHaveBeenEmitted();
+
+                test.triggerClick();
+                test.expectNoEventToHaveBeenEmitted();
             });
 
-            it('should not emit an event when tooltips are shown when event type is undefined', function() {
+            it('should not emit an event when event type is undefined', function() {
                 var test = setupTest();
 
                 test.sandbox.removeAttr('data-track-event');
                 test.showTooltip();
+                test.expectNoEventToHaveBeenEmitted();
+
+                test.triggerClick();
                 test.expectNoEventToHaveBeenEmitted();
             });
 

--- a/analytics_dashboard/static/js/views/tracking-view.js
+++ b/analytics_dashboard/static/js/views/tracking-view.js
@@ -19,7 +19,8 @@ define(['backbone', 'jquery', 'underscore', 'utils/utils'],
             segment: undefined,
 
             events: {
-                'shown.bs.tooltip': 'trackElementEvent'
+                'shown.bs.tooltip': 'trackElementEvent',
+                'clicked.tracking': 'trackElementEvent'
             },
 
             initialize: function(options) {


### PR DESCRIPTION
Elements that trigger a 'clicked.tracking' event will now be tracked if they have `data-track` html attributes set-up. I used this to track the course name/id cells in the Course List, which are added to the DOM via Javascript after the page is loaded.