### PR TITLE
Change tracking identifier to user_tracking_id.

### DIFF
--- a/analytics_dashboard/courses/permissions.py
+++ b/analytics_dashboard/courses/permissions.py
@@ -71,7 +71,7 @@ def refresh_user_course_permissions(user):
     Arguments
         user (User) --  User whose permissions should be refreshed
     """
-    # The authorized courses can come form different claims according to the user role. For example there could be a
+    # The authorized courses can come from different claims according to the user role. For example there could be a
     # list of courses the user has access as staff and another that the user has access as instructor. The variable
     # `settings.COURSE_PERMISSIONS_CLAIMS` is a list of the claims that contain the courses.
     claims = settings.COURSE_PERMISSIONS_CLAIMS

--- a/analytics_dashboard/courses/tests/test_permissions.py
+++ b/analytics_dashboard/courses/tests/test_permissions.py
@@ -34,8 +34,11 @@ class PermissionsTests(TestCase):
                 mock.Mock(return_value={'user_tracking_id': 56789}))
     def test_get_user_tracking_id(self):
         G(UserSocialAuth, user=self.user, provider='edx-oidc', extra_data={'access_token': '1234'})
-        tracking_id = permissions.get_user_tracking_id(self.user)
-        self.assertEqual(tracking_id, 56789)
+        actual_tracking_id = permissions.get_user_tracking_id(self.user)
+        expected_tracking_id = 56789
+        self.assertEqual(actual_tracking_id, expected_tracking_id)
+        # make sure tracking ID is cached
+        self.assertEqual(cache.get('user_tracking_id_{}'.format(self.user.id)), expected_tracking_id)
 
     @override_settings(USER_TRACKING_CLAIM=None)
     def test_no_user_tracking_id(self):

--- a/analytics_dashboard/courses/views/__init__.py
+++ b/analytics_dashboard/courses/views/__init__.py
@@ -188,6 +188,7 @@ class CourseContextMixin(CourseAPIMixin, TrackedViewMixin, LazyEncoderMixin):
             },
             'user': {
                 'username': user.get_username(),
+                'userTrackingID': permissions.get_user_tracking_id(self.request.user),
                 'name': user.get_full_name(),
                 'email': user.email,
                 'ignoreInReporting': self._ignore_in_reporting(user)

--- a/analytics_dashboard/settings/base.py
+++ b/analytics_dashboard/settings/base.py
@@ -393,6 +393,9 @@ ENABLE_COURSE_PERMISSIONS = True
 # What scopes and claims should be used to get courses
 EXTRA_SCOPE = ['permissions', 'course_staff']
 COURSE_PERMISSIONS_CLAIMS = ['staff_courses']
+
+# claim for the identifier to track users
+USER_TRACKING_CLAIM = 'user_tracking_id'
 ########## END AUTHENTICATION
 
 # The application and platform display names to be used in templates, emails, etc.

--- a/analytics_dashboard/settings/test.py
+++ b/analytics_dashboard/settings/test.py
@@ -22,6 +22,8 @@ DATABASES = {
 ENABLE_AUTO_AUTH = True
 SOCIAL_AUTH_EDX_OIDC_URL_ROOT = 'http://example.com'
 
+USER_TRACKING_CLAIM = None
+
 LMS_COURSE_SHORTCUT_BASE_URL = 'http://lms-host'
 CMS_COURSE_SHORTCUT_BASE_URL = 'http://cms-host'
 GRADING_POLICY_API_URL = 'http://grading-policy-api-host'

--- a/analytics_dashboard/static/js/test/specs/tracking-view-spec.js
+++ b/analytics_dashboard/static/js/test/specs/tracking-view-spec.js
@@ -4,7 +4,7 @@ define(['jquery', 'models/course-model', 'models/tracking-model', 'models/user-m
 
         describe('Tracking View', function() {
             var USER_DETAILS = {
-                username: 'edX',
+                userTrackingID: 12345,
                 name: 'Ed Xavier',
                 email: 'edx@example.com',
                 ignoreInReporting: true
@@ -43,7 +43,7 @@ define(['jquery', 'models/course-model', 'models/tracking-model', 'models/user-m
 
                 view.logUser();
 
-                expect(view.segment.identify).toHaveBeenCalledWith(USER_DETAILS.username, {
+                expect(view.segment.identify).toHaveBeenCalledWith(USER_DETAILS.userTrackingID, {
                     name: USER_DETAILS.name,
                     email: USER_DETAILS.email,
                     ignoreInReporting: true

--- a/analytics_dashboard/static/js/test/specs/tracking-view-spec.js
+++ b/analytics_dashboard/static/js/test/specs/tracking-view-spec.js
@@ -6,6 +6,7 @@ define(['jquery', 'models/course-model', 'models/tracking-model', 'models/user-m
             var USER_DETAILS = {
                 userTrackingID: 12345,
                 name: 'Ed Xavier',
+                username: 'edxavier',
                 email: 'edx@example.com',
                 ignoreInReporting: true
             };
@@ -45,6 +46,7 @@ define(['jquery', 'models/course-model', 'models/tracking-model', 'models/user-m
 
                 expect(view.segment.identify).toHaveBeenCalledWith(USER_DETAILS.userTrackingID, {
                     name: USER_DETAILS.name,
+                    username: USER_DETAILS.username,
                     email: USER_DETAILS.email,
                     ignoreInReporting: true
                 });

--- a/analytics_dashboard/static/js/views/tracking-view.js
+++ b/analytics_dashboard/static/js/views/tracking-view.js
@@ -106,6 +106,7 @@ define(['backbone', 'jquery', 'underscore', 'utils/utils'],
                     userModel = self.options.userModel;
                 self.segment.identify(userModel.get('userTrackingID'), {
                     name: userModel.get('name'),
+                    username: userModel.get('username'),
                     email: userModel.get('email'),
                     ignoreInReporting: userModel.get('ignoreInReporting')
                 });

--- a/analytics_dashboard/static/js/views/tracking-view.js
+++ b/analytics_dashboard/static/js/views/tracking-view.js
@@ -104,7 +104,7 @@ define(['backbone', 'jquery', 'underscore', 'utils/utils'],
             logUser: function() {
                 var self = this,
                     userModel = self.options.userModel;
-                self.segment.identify(userModel.get('username'), {
+                self.segment.identify(userModel.get('userTrackingID'), {
                     name: userModel.get('name'),
                     email: userModel.get('email'),
                     ignoreInReporting: userModel.get('ignoreInReporting')

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,7 +13,7 @@ django-crispy-forms==1.6.0  # MIT
 django-soapbox==1.3         # BSD
 django-waffle==0.11.1		# BSD
 pinax-announcements==2.0.4   # MIT
-edx-auth-backends==0.5.0
+edx-auth-backends==0.7.0
 edx-django-release-util==0.2.0
 edx-i18n-tools==0.3.5
 edx-rest-api-client>=1.5.0, <1.6.0  # Apache


### PR DESCRIPTION
This leverages the work from https://github.com/edx/edx-platform/pull/14386 and https://github.com/edx/auth-backends/pull/32 to get the `user_tracking_id` claim and pass it to `tracking-view.js`.  It is then used by the segment identify call.

I did some refactoring to use the same code that was being used to get the `staff_courses` claim.  You'll also notice that I set a default value for the `USER_TRACKING_CLAIM` setting and set it to `None` for the tests.  This was helpful because otherwise most view tests were failing because the tracking ID is retrieved from the auth workflow--mocking that for all tests was a bit much. :)  The claim is tested explicitly in `test_permissions.py`.