### PR TITLE
Fixed run_coverage.sh

### DIFF
--- a/.travis/run_coverage.sh
+++ b/.travis/run_coverage.sh
@@ -2,8 +2,6 @@
 . /edx/app/insights/venvs/insights/bin/activate
 . /edx/app/insights/nodeenvs/insights/bin/activate
 
-cd /edx/app/insights/insights
-
 coverage xml
 
 bash ./scripts/build-stats-to-datadog.sh


### PR DESCRIPTION
This fixes the coverage step of the travis build (e.g. https://api.travis-ci.org/jobs/196994983/log.txt?deansi=true): 

`/edx/app/insights/edx_analytics_dashboard/.travis/run_coverage.sh: line 5: cd: /edx/app/insights/insights: No such file or directory`