### PR TITLE
Upgrade nodeenv to 1.1.1

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -6,4 +6,4 @@ MySQL-python==1.2.5		# GPL License
 PyYAML==3.11			# MIT License
 gunicorn==0.17.4		# MIT
 python-memcached==1.53
-nodeenv==0.13.3		# BSD
+nodeenv==1.1.1	# BSD


### PR DESCRIPTION
This fixes a bug in the Ansible provisioning process where an existing nodeenv could fail to be created when the node version was changed.

See https://github.com/edx/configuration/pull/3648 and https://github.com/ekalinin/nodeenv/pull/183 for more details.