### PR TITLE
Fixed course list search event naming.

### DIFF
--- a/analytics_dashboard/static/apps/course-list/list/views/search.js
+++ b/analytics_dashboard/static/apps/course-list/list/views/search.js
@@ -73,7 +73,7 @@ define(function(require) {
                 this.options.collection.unsetSearchString();
             } else {
                 this.options.collection.setSearchString(searchString);
-                this.options.trackingModel.trigger('segment:track', 'edx.bi.course-list.searched', {
+                this.options.trackingModel.trigger('segment:track', 'edx.bi.course_list.searched', {
                     category: 'search'
                 });
             }


### PR DESCRIPTION
I noticed this as I was working on the filtering functionality.