### PR TITLE
Add sentence to Courses Page doc about search

### DIFF
--- a/docs/en_us/dashboard/source/Courses_Page.rst
+++ b/docs/en_us/dashboard/source/Courses_Page.rst
@@ -34,6 +34,9 @@ Computations`.  Note that the enrollment data that the computations include is
 the same as the summary metrics presented in the :ref:`Enrollment_Activity`
 report.
 
+If you want to view a specific course or courses, enter any part of the course
+name or course ID in the **Find a Course** field and click the search icon.
+
 .. note::
  On Edge, the summary table does not include course name, start date, or end
  date. 


### PR DESCRIPTION
We added a new feature to the Courses Page in Insights: a search input that can filter the course list by course id and name.

You can see the new feature right now on stage: https://stage-insights.edx.org/courses/

FYI @katymyw