### PR TITLE
Change edx-django-release-util version.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,7 +14,7 @@ django-soapbox==1.3         # BSD
 django-waffle==0.11.1		# BSD
 pinax-announcements==2.0.4   # MIT
 edx-auth-backends==0.7.0
-edx-django-release-util==0.2.0
+edx-django-release-util==0.2.1
 edx-i18n-tools==0.3.5
 edx-rest-api-client>=1.5.0, <1.6.0  # Apache
 


### PR DESCRIPTION
Change the required version of edx-django-release-util to 0.2.1.

@edx-ops/pipeline-team Please review and tag appropriate parties.