### PR TITLE
AN-8411 Use edx grayscale colors for pagination

### DIFF
--- a/analytics_dashboard/static/sass/_mixins.scss
+++ b/analytics_dashboard/static/sass/_mixins.scss
@@ -127,6 +127,15 @@
     ul {
       // remove default padding around the paging controls
       padding: 0;
+
+      .disabled a {
+        color: $palette-grayscale-base;
+      }
+
+      .active a {
+        color: $palette-grayscale-base;
+        background-color: $palette-grayscale-x-back;
+      }
     }
 
   }


### PR DESCRIPTION
The default pagination gray colors had too little contrast. This PR overwrites them with edx grayscale colors that we know have high enough contrast with each other (http://ux.edx.org/design_elements/colors/).

Before: 
![screenshot from 2017-02-28 16-21-25](https://cloud.githubusercontent.com/assets/1505923/23433825/5b76beb6-fdd2-11e6-8860-289589b51032.png)


After:
![screenshot from 2017-02-28 16-20-50](https://cloud.githubusercontent.com/assets/1505923/23436913/26a76ad4-fdda-11e6-84ba-18d49588e7f7.png)