### PR TITLE
Update travis DATA_API_VERSION to 0.22.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 
 env:
   # Make sure to update this string on every Insights or Data API release
-  DATA_API_VERSION: "0.21.0"
+  DATA_API_VERSION: "0.22.0"
   DOCKER_COMPOSE_VERSION: "1.9.0"
 
 before_install:


### PR DESCRIPTION
Releasing 0.22.0 of the data api first, and need to keep this variable up to date.