### PR TITLE
AN-8634 Soapbox messages acceptance tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,12 +47,16 @@ endif
 ifeq ("${ENABLE_COURSE_LIST_FILTERS}", "True")
 	./manage.py waffle_switch enable_course_filters on --create
 endif
+	./manage.py create_acceptance_test_soapbox_messages
 	nosetests -v acceptance_tests -e NUM_PROCESSES=1 --exclude-dir=acceptance_tests/course_validation
+	./manage.py delete_acceptance_test_soapbox_messages
 
 # local acceptance tests are typically run with by passing in environment variables on the commandline
 # e.g. API_SERVER_URL="http://localhost:9001/api/v0" API_AUTH_TOKEN="edx" make accept_local
 accept_local:
+	./manage.py create_acceptance_test_soapbox_messages
 	nosetests -v acceptance_tests --exclude-dir=acceptance_tests/course_validation
+	./manage.py delete_acceptance_test_soapbox_messages
 
 a11y:
 ifeq ("${DISPLAY_LEARNER_ANALYTICS}", "True")

--- a/acceptance_tests/__init__.py
+++ b/acceptance_tests/__init__.py
@@ -19,8 +19,8 @@ RESEARCH_URL = os.environ.get('RESEARCH_URL', 'http://example.com/')
 SHOW_LANDING_RESEARCH = str2bool(os.environ.get('SHOW_LANDING_RESEARCH', True))
 
 # Analytics data API settings
-API_SERVER_URL = os.environ['API_SERVER_URL']
-API_AUTH_TOKEN = os.environ['API_AUTH_TOKEN']
+API_SERVER_URL = os.environ.get('API_SERVER_URL', 'http://localhost:9001')
+API_AUTH_TOKEN = os.environ.get('API_AUTH_TOKEN', 'edx')
 
 # Test configuration
 ENABLE_AUTO_AUTH = str2bool(os.environ.get('ENABLE_AUTO_AUTH', False))
@@ -81,3 +81,9 @@ DISPLAY_LEARNER_ANALYTICS = str2bool(os.environ.get('DISPLAY_LEARNER_ANALYTICS',
 
 # Learner analytics
 ENABLE_COURSE_LIST_FILTERS = str2bool(os.environ.get('ENABLE_COURSE_LIST_FILTERS', False))
+
+# Soapbox Messages tests constants
+SOAPBOX_GLOBAL_MESSAGE = 'Test global message'
+SOAPBOX_SINGLE_PAGE_MESSAGE = 'Test single-page message'
+SOAPBOX_SINGLE_PAGE_VIEW = 'insights_home'
+SOAPBOX_SINGLE_PAGE_PATH = 'courses/'

--- a/acceptance_tests/__init__.py
+++ b/acceptance_tests/__init__.py
@@ -85,5 +85,6 @@ ENABLE_COURSE_LIST_FILTERS = str2bool(os.environ.get('ENABLE_COURSE_LIST_FILTERS
 # Soapbox Messages tests constants
 SOAPBOX_GLOBAL_MESSAGE = 'Test global message'
 SOAPBOX_SINGLE_PAGE_MESSAGE = 'Test single-page message'
+SOAPBOX_INACTIVE_MESSAGE = 'Test inactive message'
 SOAPBOX_SINGLE_PAGE_VIEW = 'insights_home'
 SOAPBOX_SINGLE_PAGE_PATH = 'courses/'

--- a/acceptance_tests/mixins.py
+++ b/acceptance_tests/mixins.py
@@ -18,6 +18,7 @@ from acceptance_tests import (
     LMS_PASSWORD,
     LMS_USERNAME,
     SOAPBOX_GLOBAL_MESSAGE,
+    SOAPBOX_INACTIVE_MESSAGE,
     SOAPBOX_SINGLE_PAGE_MESSAGE,
     SOAPBOX_SINGLE_PAGE_PATH,
     SUPPORT_EMAIL,
@@ -281,6 +282,7 @@ class SoapboxMessagesMixin(object):
         element = self.page.q(css=self.soapbox_selector)
         self.assertTrue(element.present)
         self.assertTrue(SOAPBOX_GLOBAL_MESSAGE in element.text)
+        self.assertFalse(SOAPBOX_INACTIVE_MESSAGE in element.text)
 
         if self.page.path == SOAPBOX_SINGLE_PAGE_PATH:
             element = self.page.q(css=self.soapbox_selector)

--- a/acceptance_tests/mixins.py
+++ b/acceptance_tests/mixins.py
@@ -1,14 +1,13 @@
-import locale
 import datetime
+import locale
 from unittest import skip
 
 from bok_choy.promise import EmptyPromise
-from analyticsclient.client import Client
 from selenium.webdriver.common.keys import Keys
 
 from acceptance_tests import (
-    API_SERVER_URL,
     API_AUTH_TOKEN,
+    API_SERVER_URL,
     COURSE_API_KEY,
     COURSE_API_URL,
     DASHBOARD_FEEDBACK_EMAIL,
@@ -16,11 +15,15 @@ from acceptance_tests import (
     DOC_BASE_URL,
     ENABLE_AUTO_AUTH,
     ENABLE_COURSE_API,
-    LMS_USERNAME,
     LMS_PASSWORD,
+    LMS_USERNAME,
+    SOAPBOX_GLOBAL_MESSAGE,
+    SOAPBOX_SINGLE_PAGE_MESSAGE,
+    SOAPBOX_SINGLE_PAGE_PATH,
     SUPPORT_EMAIL,
 )
 from acceptance_tests.pages import LMSLoginPage
+from analyticsclient.client import Client
 from common.clients import CourseStructureApiClient
 
 
@@ -270,8 +273,26 @@ class ContextSensitiveHelpMixin(object):
         self.assertHrefEqual('#help', self.help_url)
 
 
+class SoapboxMessagesMixin(object):
+    soapbox_selector = "div[class=announcement-container]"
+
+    def _test_soapbox_messages(self):
+        # make sure we have the correct soapbox messages displayed
+        element = self.page.q(css=self.soapbox_selector)
+        self.assertTrue(element.present)
+        self.assertTrue(SOAPBOX_GLOBAL_MESSAGE in element.text)
+
+        if self.page.path == SOAPBOX_SINGLE_PAGE_PATH:
+            element = self.page.q(css=self.soapbox_selector)
+            self.assertTrue(SOAPBOX_SINGLE_PAGE_MESSAGE in element.text)
+
+    def test_page(self):
+        super(SoapboxMessagesMixin, self).test_page()
+        self._test_soapbox_messages()
+
+
 class AnalyticsDashboardWebAppTestMixin(FooterMixin, PrimaryNavMixin, ContextSensitiveHelpMixin, AssertMixin,
-                                        LoginMixin):
+                                        LoginMixin, SoapboxMessagesMixin):
     def test_page(self):
         self.login()
         self.page.visit()

--- a/analytics_dashboard/core/management/commands/create_acceptance_test_soapbox_messages.py
+++ b/analytics_dashboard/core/management/commands/create_acceptance_test_soapbox_messages.py
@@ -1,0 +1,10 @@
+from django.core.management.base import BaseCommand
+
+from core.utils import create_fake_soapbox_messages
+
+class Command(BaseCommand):
+    """A command to create fake soapbox messages that the acceptance tests will check if displayed."""
+    help = 'Create fake soapbox messages for testing.'
+
+    def handle(self, *args, **options):
+        create_fake_soapbox_messages()

--- a/analytics_dashboard/core/management/commands/create_acceptance_test_soapbox_messages.py
+++ b/analytics_dashboard/core/management/commands/create_acceptance_test_soapbox_messages.py
@@ -2,6 +2,7 @@ from django.core.management.base import BaseCommand
 
 from core.utils import create_fake_soapbox_messages
 
+
 class Command(BaseCommand):
     """A command to create fake soapbox messages that the acceptance tests will check if displayed."""
     help = 'Create fake soapbox messages for testing.'

--- a/analytics_dashboard/core/management/commands/delete_acceptance_test_soapbox_messages.py
+++ b/analytics_dashboard/core/management/commands/delete_acceptance_test_soapbox_messages.py
@@ -2,6 +2,7 @@ from django.core.management.base import BaseCommand
 
 from core.utils import delete_fake_soapbox_messages
 
+
 class Command(BaseCommand):
     """A command to delete the fake soapbox messages that the acceptance tests have completed checking."""
     help = 'Delete fake soapbox messages for testing.'

--- a/analytics_dashboard/core/management/commands/delete_acceptance_test_soapbox_messages.py
+++ b/analytics_dashboard/core/management/commands/delete_acceptance_test_soapbox_messages.py
@@ -1,0 +1,10 @@
+from django.core.management.base import BaseCommand
+
+from core.utils import delete_fake_soapbox_messages
+
+class Command(BaseCommand):
+    """A command to delete the fake soapbox messages that the acceptance tests have completed checking."""
+    help = 'Delete fake soapbox messages for testing.'
+
+    def handle(self, *args, **options):
+        delete_fake_soapbox_messages()

--- a/analytics_dashboard/core/utils.py
+++ b/analytics_dashboard/core/utils.py
@@ -1,5 +1,6 @@
 from hashlib import md5
 
+from soapbox.models import Message
 from waffle import switch_is_active
 
 from django.conf import settings
@@ -99,3 +100,18 @@ def remove_keys(d, keys):
                 if key in keys:
                     del d[key]
     return d
+
+
+def create_fake_soapbox_messages():
+    # Importing here so acceptance_tests/__init__.py doesn't start checking for env vars on every management command.
+    from acceptance_tests import SOAPBOX_GLOBAL_MESSAGE, SOAPBOX_SINGLE_PAGE_MESSAGE, SOAPBOX_SINGLE_PAGE_VIEW
+    Message.objects.get_or_create(message=SOAPBOX_GLOBAL_MESSAGE, is_active=True, is_global=True)
+    Message.objects.get_or_create(message=SOAPBOX_SINGLE_PAGE_MESSAGE, is_active=True, is_global=False,
+                                  url=SOAPBOX_SINGLE_PAGE_VIEW)
+
+
+def delete_fake_soapbox_messages():
+    from acceptance_tests import SOAPBOX_GLOBAL_MESSAGE, SOAPBOX_SINGLE_PAGE_MESSAGE, SOAPBOX_SINGLE_PAGE_VIEW
+    Message.objects.get(message=SOAPBOX_GLOBAL_MESSAGE, is_active=True, is_global=True).delete()
+    Message.objects.get(message=SOAPBOX_SINGLE_PAGE_MESSAGE, is_active=True, is_global=False,
+                        url=SOAPBOX_SINGLE_PAGE_VIEW).delete()

--- a/analytics_dashboard/core/utils.py
+++ b/analytics_dashboard/core/utils.py
@@ -104,14 +104,18 @@ def remove_keys(d, keys):
 
 def create_fake_soapbox_messages():
     # Importing here so acceptance_tests/__init__.py doesn't start checking for env vars on every management command.
-    from acceptance_tests import SOAPBOX_GLOBAL_MESSAGE, SOAPBOX_SINGLE_PAGE_MESSAGE, SOAPBOX_SINGLE_PAGE_VIEW
+    from acceptance_tests import (SOAPBOX_INACTIVE_MESSAGE, SOAPBOX_GLOBAL_MESSAGE, SOAPBOX_SINGLE_PAGE_MESSAGE,
+                                  SOAPBOX_SINGLE_PAGE_VIEW)
     Message.objects.get_or_create(message=SOAPBOX_GLOBAL_MESSAGE, is_active=True, is_global=True)
     Message.objects.get_or_create(message=SOAPBOX_SINGLE_PAGE_MESSAGE, is_active=True, is_global=False,
                                   url=SOAPBOX_SINGLE_PAGE_VIEW)
+    Message.objects.get_or_create(message=SOAPBOX_INACTIVE_MESSAGE, is_active=False, is_global=True)
 
 
 def delete_fake_soapbox_messages():
-    from acceptance_tests import SOAPBOX_GLOBAL_MESSAGE, SOAPBOX_SINGLE_PAGE_MESSAGE, SOAPBOX_SINGLE_PAGE_VIEW
+    from acceptance_tests import (SOAPBOX_INACTIVE_MESSAGE, SOAPBOX_GLOBAL_MESSAGE, SOAPBOX_SINGLE_PAGE_MESSAGE,
+                                  SOAPBOX_SINGLE_PAGE_VIEW)
     Message.objects.get(message=SOAPBOX_GLOBAL_MESSAGE, is_active=True, is_global=True).delete()
     Message.objects.get(message=SOAPBOX_SINGLE_PAGE_MESSAGE, is_active=True, is_global=False,
                         url=SOAPBOX_SINGLE_PAGE_VIEW).delete()
+    Message.objects.get(message=SOAPBOX_INACTIVE_MESSAGE, is_active=False, is_global=True).delete()


### PR DESCRIPTION
We thought that the per-page soapbox messages were not working, but it was actually because the page names changed and we weren't specifying the correct names in the `url` field of the message (e.g. needed to be `course_enrollment_activity`, not `enrollment_activity`).

To ensure the soapbox messages are working in the future, I added soapbox messages acceptance tests.

To avoid having to log into the admin panel in the acceptance tests, I added a call to a management command to create the soapbox messages manually before running the tests, and deleting them afterwards.