### PR TITLE
Revert "Upgraded edx-auth-backends to 1.0.2"

### DIFF
--- a/analytics_dashboard/settings/base.py
+++ b/analytics_dashboard/settings/base.py
@@ -342,7 +342,29 @@ SOCIAL_AUTH_REDIRECT_IS_HTTPS = False
 
 SOCIAL_AUTH_ADMIN_USER_SEARCH_FIELDS = ['username', 'email']
 
-SOCIAL_AUTH_STRATEGY = 'auth_backends.strategies.EdxDjangoStrategy'
+SOCIAL_AUTH_PIPELINE = (
+    'social.pipeline.social_auth.social_details',
+    'social.pipeline.social_auth.social_uid',
+    'social.pipeline.social_auth.auth_allowed',
+    'social.pipeline.social_auth.social_user',
+
+    # By default python-social-auth will simply create a new user/username if the username
+    # from the provider conflicts with an existing username in this system. This custom pipeline function
+    # loads existing users instead of creating new ones.
+    'auth_backends.pipeline.get_user_if_exists',
+    'social.pipeline.user.get_username',
+    'social.pipeline.user.create_user',
+    'social.pipeline.social_auth.associate_user',
+    'social.pipeline.social_auth.load_extra_data',
+    'social.pipeline.user.user_details'
+)
+
+SOCIAL_AUTH_USER_FIELDS = ['username', 'email', 'first_name', 'last_name']
+
+# Always raise auth exceptions so that they are properly logged. Otherwise, the PSA middleware will redirect to an
+# auth error page and attempt to display the error message to the user (via Django's message framework). We do not
+# want the uer to see the message; but, we do want our downstream exception handlers to log the message.
+SOCIAL_AUTH_RAISE_EXCEPTIONS = True
 
 # Set these to the correct values for your OAuth2/OpenID Connect provider
 SOCIAL_AUTH_EDX_OIDC_KEY = None

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,7 +14,7 @@ django-crispy-forms==1.6.0  # MIT
 django-soapbox==1.3         # BSD
 django-waffle==0.11.1		# BSD
 pinax-announcements==2.0.4   # MIT
-edx-auth-backends==1.0.2
+edx-auth-backends==0.7.0
 edx-django-release-util==0.3.0
 edx-i18n-tools==0.3.5
 edx-rest-api-client>=1.5.0, <1.6.0  # Apache


### PR DESCRIPTION
Reverts edx/edx-analytics-dashboard#665

The service first needs to be updated to use python-social-auth 0.2.21. See https://github.com/omab/python-social-auth/blob/master/MIGRATING_TO_SOCIAL.md#migrations.