### PR TITLE
Wrap long filter names and add some padding.

### DIFF
--- a/analytics_dashboard/static/sass/_mixins.scss
+++ b/analytics_dashboard/static/sass/_mixins.scss
@@ -135,11 +135,13 @@
       // bootstrap defaults are to bold the labels
       label {
         font-weight: normal;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
         display: inline-block;
         margin: 0;
+        margin-bottom: $padding-base-vertical;
+
+        // indent all lines that wrap so that they're aligned with the text instead of the checkbox
+        text-indent: -$padding-large-horizontal;
+        padding-left: $padding-large-horizontal;
       }
 
       // for the set of filters (e.g. label for the collection of checkboxes)


### PR DESCRIPTION
![screen shot 2017-05-08 at 3 35 30 pm](https://cloud.githubusercontent.com/assets/5265058/25821825/94b18b3a-3404-11e7-8c44-1a9d0967a319.png)

@roderickmorales, @katymyw, @srpearce -- this PR tweaks the styles of the filters to wrap long program names in addition to extra padding around the labels.

@edx/educator-dahlia -- looking for a single approval!