### PR TITLE
Decrease content area padding on small screens

### DIFF
--- a/analytics_dashboard/static/sass/_base.scss
+++ b/analytics_dashboard/static/sass/_base.scss
@@ -393,11 +393,14 @@ dl {
 // --------------------
 .view-dashboard, .view-course-list {
   .main {
-    padding: ($padding-large-vertical*2) ($padding-large-horizontal*3);
+    padding: ($padding-large-vertical*2) $padding-small-horizontal;
   }
 
   // CASE: larger than small screen breakpoint
   @media (min-width: $screen-sm-min) {
+    .main {
+      padding: ($padding-large-vertical*2) ($padding-large-horizontal*3);
+    }
 
     .sidebar {
       position: fixed;


### PR DESCRIPTION
Just a small tweak to make the mobile experience of Insights a little more usable. I noticed that we have a lot of padding around the main content area, and it takes up a lot of space on a small screen, so I decreased it for small screens.

Before:
![screenshot-20170606164323-414x735](https://user-images.githubusercontent.com/1505923/26851109-ec8dce7e-4ad7-11e7-9260-0aec7c2130d7.png)

After:
![screenshot-20170606164248-412x737](https://user-images.githubusercontent.com/1505923/26851117-f46e5ab4-4ad7-11e7-88a5-38aa6a6b1ea6.png)

@edx/educator-dahlia 