### PR TITLE
New release, who dis?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 
 env:
   # Make sure to update this string on every Insights or Data API release
-  DATA_API_VERSION: "0.24.0"
+  DATA_API_VERSION: "0.25.1"
   DOCKER_COMPOSE_VERSION: "1.9.0"
 
 before_install:


### PR DESCRIPTION
I'm attempting to synthesize the steps I'm taking for a release in this comment, LMK if it doesn't looks right.

- [x] Create a new version tag for the data API here, being sure to mark it as "pre-release": https://github.com/edx/edx-analytics-data-api/releases
  - [x] ensure CI builds pass on the new tag: https://travis-ci.org/edx/edx-analytics-data-api/builds
- [x] Push the newly released version of the API to dockerhub by following these instructions: https://openedx.atlassian.net/wiki/display/EdxOps/Updating+the+Version+of+analytics-api+used+by+Insights+Testing
- [x] Create a "release-candidate" (open to suggestions for name) branch on Insights, after bumping the `DATA_API_VERSION` variable in .travis.yml
  - [x] merge that after CI tests are passing: https://travis-ci.org/edx/edx-analytics-dashboard/builds
- [x] create a new pre-release tag for Insights, including your newly-merged changes
- [x] Push the newly released version of Insights to dockerhub by following these instructions: https://openedx.atlassian.net/wiki/display/EdxOps/Updating+the+Insights+docker+image
- [x] make sure your newly tagged changes are successfully deployed to stage: https://gocd.tools.edx.org/go/tab/pipeline/history/stage-insights
- [x] (GoCD) release the Analytics API by clicking the "Awaiting Approval" arrow on the latest prod-analyticsapi pipeline run: https://gocd.tools.edx.org/go/tab/pipeline/history/prod-analyticsapi
- [x] (GoCD) release Insights by clicking the "Awaiting Approval" arrow on the latest prod-insights pipeline run: https://gocd.tools.edx.org/go/tab/pipeline/history/prod-insights
- [x] Uncheck the pre-release indicator (Github UI) for both releases, you're done!
- [x] Still, be a good dev and monitor the release for a bit (keep an eye on the devops/Insights Alerts HipChat rooms