### PR TITLE
Revert Insights docker tag back to latest

### DIFF
--- a/.travis/docker-compose-travis.yml
+++ b/.travis/docker-compose-travis.yml
@@ -12,7 +12,7 @@ services:
       ELASTICSEARCH_LEARNERS_UPDATE_INDEX: 'index_update'
     command: /edx/app/analytics_api/venvs/analytics_api/bin/python /edx/app/analytics_api/analytics_api/manage.py runserver 0.0.0.0:80
   insights:
-    image: edxops/insights:upgrade-django
+    image: edxops/insights:latest
     container_name: insights_testing
     volumes:
       - ..:/edx/app/insights/edx_analytics_dashboard


### PR DESCRIPTION
This is a follow up to the Django 1.11 upgrade PR. I uploaded a fresh image of Insights built off master as the tag "latest".

@edx/educator-dahlia 