### PR TITLE
Switch to Clinton's fork of django-waffle

### DIFF
--- a/.travis/docker-compose-travis.yml
+++ b/.travis/docker-compose-travis.yml
@@ -12,7 +12,7 @@ services:
       ELASTICSEARCH_LEARNERS_UPDATE_INDEX: 'index_update'
     command: /edx/app/analytics_api/venvs/analytics_api/bin/python /edx/app/analytics_api/analytics_api/manage.py runserver 0.0.0.0:80
   insights:
-    image: edxops/insights:latest
+    image: edxops/insights:waffle-fork
     container_name: insights_testing
     volumes:
       - ..:/edx/app/insights/edx_analytics_dashboard

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ django-soapbox==1.3         # BSD
 # django-waffle==0.11.1		# BSD
 # FIXME: django-waffle management commands are broken on Django 1.10+. This repo is not the official django-waffle repo.
 # Check back with django-waffle later to see if it gets fixed.
-git+https://github.com/jdavidagudelo/django-waffle.git@349d43eea7e10ccb995c8987f0c4bd8a7a240b55#egg=django-waffle
+git+https://github.com/clintonb/django-waffle.git@24fae488a841d8b0a0ed2115925151689212e1ea#egg=django-waffle
 pinax-announcements==2.0.4   # MIT
 edx-auth-backends==1.1.2
 edx-django-release-util==0.3.1


### PR DESCRIPTION
Switching to @clintonb's fork of django-waffle, which has an [open pull request](https://github.com/jsocol/django-waffle/pull/244/) against the main repo. Clinton's fork is more well-tested than the other fork we were on.

Hopefully this is only temporary and once the [status of django-waffle](https://github.com/jsocol/django-waffle/issues/245) is figured out, we can go back to installing from pip.

@edx/educator-dahlia 