### PR TITLE
Bump Analytics API version to 0.26.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 
 env:
   # Make sure to update this string on every Insights or Data API release
-  DATA_API_VERSION: "0.26.0"
+  DATA_API_VERSION: "0.26.1"
   DOCKER_COMPOSE_VERSION: "1.9.0"
 
 before_install:


### PR DESCRIPTION
Takes advantage of fix for bug where number of items in request to course_summaries/ was capped at 1000, causing a 500 error on Insights home pages with close to or greater than 1000 courses.

See [Analytics API PR #175](https://github.com/edx/edx-analytics-data-api/pull/175).