### PR TITLE
Temporarily revert changes to CourseSummariesPresenter

### DIFF
--- a/analytics_dashboard/courses/presenters/course_summaries.py
+++ b/analytics_dashboard/courses/presenters/course_summaries.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+from django.core.cache import cache
 from waffle import switch_is_active
 
 from courses.presenters import BasePresenter
@@ -6,8 +8,33 @@ from courses.presenters import BasePresenter
 class CourseSummariesPresenter(BasePresenter):
     """ Presenter for the course enrollment data. """
 
+    CACHE_KEY = 'summaries'
     NON_NULL_STRING_FIELDS = ['course_id', 'catalog_course', 'catalog_course_title',
                               'start_date', 'end_date', 'pacing_type', 'availability']
+
+    @staticmethod
+    def filter_summaries(all_summaries, course_ids=None):
+        """Filter results to just the course IDs specified."""
+        if course_ids is None:
+            return all_summaries
+        return [summary for summary in all_summaries if summary['course_id'] in course_ids]
+
+    def _get_all_summaries(self):
+        """
+        Returns all course summaries. If not cached, summaries will be fetched
+        from the analytics data API.
+        """
+        all_summaries = cache.get(self.CACHE_KEY)
+        if all_summaries is None:
+            exclude = ['programs']  # we make a separate call to the programs endpoint
+            if not switch_is_active('enable_course_passing'):
+                exclude.append('passing_users')
+            all_summaries = self.client.course_summaries().course_summaries(exclude=exclude)
+            all_summaries = [
+                {field: ('' if val is None and field in self.NON_NULL_STRING_FIELDS else val)
+                 for field, val in summary.items()} for summary in all_summaries]
+            cache.set(self.CACHE_KEY, all_summaries, settings.COURSE_SUMMARIES_CACHE_TIMEOUT)
+        return all_summaries
 
     def _get_last_updated(self, summaries):
         # all the create times should be the same, so just use the first one
@@ -21,27 +48,15 @@ class CourseSummariesPresenter(BasePresenter):
         Returns course summaries that match those listed in course_ids.  If
         no course IDs provided, all data will be returned.
         """
-        exclude = ['programs']  # we make a separate call to the programs endpoint
-        if not switch_is_active('enable_course_passing'):
-            exclude.append('passing_users')
-        summaries = self.client.course_summaries().course_summaries(course_ids=course_ids, exclude=exclude)
-        summaries = [
-            {
-                field: (
-                    '' if val is None and field in self.NON_NULL_STRING_FIELDS
-                    else val
-                )
-                for field, val in summary.items()
-            } for summary in summaries
-        ]
+        all_summaries = self._get_all_summaries()
+        filtered_summaries = self.filter_summaries(all_summaries, course_ids)
 
         # sort by title by default with "None" values at the end
-        summaries = sorted(
-            summaries,
-            key=lambda x: (not x['catalog_course_title'], x['catalog_course_title'])
-        )
+        filtered_summaries = sorted(
+            filtered_summaries,
+            key=lambda x: (not x['catalog_course_title'], x['catalog_course_title']))
 
-        return summaries, self._get_last_updated(summaries)
+        return filtered_summaries, self._get_last_updated(filtered_summaries)
 
     def get_course_summary_metrics(self, summaries):
         summary = {


### PR DESCRIPTION
[This PR](https://github.com/edx/edx-analytics-dashboard/pull/690) changed CourseSummariesPresenter (used in the course index view) to POST a list of desired course IDs to the course_summaries/ Analytics API endpoint, instead of GETting all of the them. While this (presumably) improved performance for users with low numbers of viewable courses, it hurt performance for those with view access to many (or all 4000+) courses, causing API timeouts that in turn caused the course index page to 500.

**Solutions**
- The short-term solution to this is this PR, which simply undoes the entire change.
- The medium-term solution is described in [this ticket](https://openedx.atlassian.net/browse/EDUCATOR-770): only pass a list of course IDs for users with a lower number (<500) of viewable courses; otherwise get all course summaries.
- The long-term, ideal solution would be to optimize the API so that passing in any number of course IDs is performant. [This profile](https://rpm.newrelic.com/accounts/88178/key_transactions/26509/x_rays/3677/profiles) shows that ~66% of the API call time is being spent in `get_queryset`, which I believe is very possible to optimize

**Other Notes**
- The required versions of edx-analytics-data-api and edx-analytics-data-api-client are NOT reverted back to what they were before the course summaries change, as the new versions still work with the old Insights code

@edx/educator-dahlia 