### PR TITLE
Updated owner.

### DIFF
--- a/openedx.yaml
+++ b/openedx.yaml
@@ -4,6 +4,6 @@
 nick: dash
 oeps: {}
 openedx-release: {ref: master, requirements: requirements/base.txt}
-owner: edx/analytics
+owner: edx/educator-dahlia
 tags: [analytics]
 track-pulls: true


### PR DESCRIPTION
The "owner" field is used in weekly auto-merge translations job to notify the "owner" github team of failures.

@edx/educator-dahlia 