### PR TITLE
Ginkgo: Update django-waffle to use clintonb's fix for django 1.8+ (#706)

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,10 +12,7 @@ djangorestframework-csv==2.0.0 # BSD
 # Dependency of djangorestframework
 django-crispy-forms==1.6.1  # MIT
 django-soapbox==1.3         # BSD
-# django-waffle==0.11.1		# BSD
-# FIXME: django-waffle management commands are broken on Django 1.10+. This repo is not the official django-waffle repo.
-# Check back with django-waffle later to see if it gets fixed.
-git+https://github.com/jdavidagudelo/django-waffle.git@349d43eea7e10ccb995c8987f0c4bd8a7a240b55#egg=django-waffle
+django-waffle==0.12.0		# BSD
 pinax-announcements==2.0.4   # MIT
 edx-auth-backends==1.1.2
 edx-django-release-util==0.3.1


### PR DESCRIPTION
This is @pomegranited's change to use the official pip version of django-waffle instead of a github URL of a fork that may disappear in the future.

@nedbat 