### PR TITLE
Fix JS karma tests under webpack

### DIFF
--- a/analytics_dashboard/static/apps/course-list/app/spec/controller-spec.js
+++ b/analytics_dashboard/static/apps/course-list/app/spec/controller-spec.js
@@ -5,10 +5,15 @@ import PageModel from 'components/generic-list/common/models/page';
 import TrackingModel from 'models/tracking-model';
 
 describe('CourseListController', () => {
+  let rootView;
+  let course;
+  let collection;
+  let controller;
+
   // convenience method for asserting that we are on the course list page
-  function expectCourseListPage(controller) {
-    expect(controller.options.rootView.$('.course-list')).toBeInDOM();
-    expect(controller.options.rootView.$('.course-list-header-region').html()).toContainText(
+  function expectCourseListPage(courseListController) {
+    expect(courseListController.options.rootView.$('.course-list')).toBeInDOM();
+    expect(courseListController.options.rootView.$('.course-list-header-region').html()).toContainText(
       'Course List',
     );
   }
@@ -65,17 +70,17 @@ describe('CourseListController', () => {
     const pageModel = new PageModel();
 
     setFixtures('<div class="root-view"><div class="main"></div></div>');
-    this.rootView = new RootView({
+    rootView = new RootView({
       el: '.root-view',
       pageModel,
       appClass: 'course-list',
     });
-    this.rootView.render();
-    this.course = fakeCourse('course1', 'Course');
-    this.collection = new CourseListCollection([this.course]);
-    this.controller = new CourseListController({
-      rootView: this.rootView,
-      courseListCollection: this.collection,
+    rootView.render();
+    course = fakeCourse('course1', 'Course');
+    collection = new CourseListCollection([course]);
+    controller = new CourseListController({
+      rootView,
+      courseListCollection: collection,
       hasData: true,
       pageModel,
       trackingModel: new TrackingModel(),
@@ -83,29 +88,29 @@ describe('CourseListController', () => {
   });
 
   it('should show the course list page', () => {
-    this.controller.showCourseListPage();
-    expectCourseListPage(this.controller);
+    controller.showCourseListPage();
+    expectCourseListPage(controller);
   });
 
   it('should show invalid parameters alert with invalid URL parameters', () => {
-    this.controller.showCourseListPage('text_search=foo=');
-    expect(this.controller.options.rootView.$('.course-list-alert-region').html()).toContainText(
+    controller.showCourseListPage('text_search=foo=');
+    expect(controller.options.rootView.$('.course-list-alert-region').html()).toContainText(
       'Invalid Parameters',
     );
-    expect(this.controller.options.rootView.$('.course-list-main-region').html()).toBe('');
+    expect(controller.options.rootView.$('.course-list-main-region').html()).toBe('');
   });
 
   it('should show the not found page', () => {
-    this.controller.showNotFoundPage();
+    controller.showNotFoundPage();
     // eslint-disable-next-line max-len
-    expect(this.rootView.$el.html()).toContainText(
+    expect(rootView.$el.html()).toContainText(
       "Sorry, we couldn't find the page you're looking for.",
     );
   });
   it('should sort the list with sort parameters', () => {
     const secondCourse = fakeCourse('course2', 'X Course');
-    this.collection.add(secondCourse);
-    this.controller.showCourseListPage('sortKey=catalog_course_title&order=desc');
-    expect(this.collection.at(0).toJSON()).toEqual(secondCourse);
+    collection.add(secondCourse);
+    controller.showCourseListPage('sortKey=catalog_course_title&order=desc');
+    expect(collection.at(0).toJSON()).toEqual(secondCourse);
   });
 });

--- a/analytics_dashboard/static/apps/course-list/app/spec/router-spec.js
+++ b/analytics_dashboard/static/apps/course-list/app/spec/router-spec.js
@@ -5,82 +5,87 @@ import CourseListRouter from 'course-list/app/router';
 import PageModel from 'components/generic-list/common/models/page';
 
 describe('CourseListRouter', () => {
+  let course;
+  let collection;
+  let controller;
+  let router;
+
   beforeEach(() => {
     Backbone.history.start({ silent: true });
-    this.course = {
+    course = {
       last_updated: new Date(2016, 1, 28),
     };
-    this.collection = new CourseListCollection([this.course]);
-    this.controller = new CourseListController({
-      courseListCollection: this.collection,
+    collection = new CourseListCollection([course]);
+    controller = new CourseListController({
+      courseListCollection: collection,
       pageModel: new PageModel(),
     });
-    spyOn(this.controller, 'showCourseListPage').and.stub();
-    spyOn(this.controller, 'showNotFoundPage').and.stub();
-    spyOn(this.controller, 'onShowPage').and.stub();
-    this.router = new CourseListRouter({
-      controller: this.controller,
+    spyOn(controller, 'showCourseListPage').and.stub();
+    spyOn(controller, 'showNotFoundPage').and.stub();
+    spyOn(controller, 'onShowPage').and.stub();
+    router = new CourseListRouter({
+      controller,
     });
   });
 
   afterEach(() => {
     // Clear previous route
-    this.router.navigate('');
+    router.navigate('');
     Backbone.history.stop();
   });
 
   it('triggers a showPage event for pages beginning with "show"', () => {
-    this.router.navigate('foo', { trigger: true });
-    expect(this.controller.onShowPage).toHaveBeenCalled();
-    this.router.navigate('/', { trigger: true });
-    expect(this.controller.onShowPage).toHaveBeenCalled();
+    router.navigate('foo', { trigger: true });
+    expect(controller.onShowPage).toHaveBeenCalled();
+    router.navigate('/', { trigger: true });
+    expect(controller.onShowPage).toHaveBeenCalled();
   });
 
   describe('showCourseListPage', () => {
     beforeEach(() => {
       // Backbone won't trigger a route unless we were on a previous url
-      this.router.navigate('initial-fragment', { trigger: false });
+      router.navigate('initial-fragment', { trigger: false });
     });
 
     it('should trigger on an empty URL fragment', () => {
-      this.router.navigate('', { trigger: true });
-      expect(this.controller.showCourseListPage).toHaveBeenCalled();
+      router.navigate('', { trigger: true });
+      expect(controller.showCourseListPage).toHaveBeenCalled();
     });
 
     it('should trigger on a single forward slash', () => {
-      this.router.navigate('/', { trigger: true });
-      expect(this.controller.showCourseListPage).toHaveBeenCalled();
+      router.navigate('/', { trigger: true });
+      expect(controller.showCourseListPage).toHaveBeenCalled();
     });
 
     it('should trigger on a URL fragment with a querystring', () => {
       const querystring = 'text_search=some_course';
-      this.router.navigate(`?${querystring}`, { trigger: true });
-      expect(this.controller.showCourseListPage).toHaveBeenCalledWith(querystring, null);
+      router.navigate(`?${querystring}`, { trigger: true });
+      expect(controller.showCourseListPage).toHaveBeenCalledWith(querystring, null);
     });
   });
 
   describe('showNotFoundPage', () => {
     it('should trigger on unmatched URLs', () => {
-      this.router.navigate('this/does/not/match', { trigger: true });
-      expect(this.controller.showNotFoundPage).toHaveBeenCalledWith('this/does/not/match', null);
+      router.navigate('this/does/not/match', { trigger: true });
+      expect(controller.showNotFoundPage).toHaveBeenCalledWith('this/does/not/match', null);
     });
   });
 
   it('URL fragment is updated on CourseListCollection loaded', (done) => {
-    this.collection.state.currentPage = 2;
-    this.collection.once('loaded', () => {
+    collection.state.currentPage = 2;
+    collection.once('loaded', () => {
       expect(Backbone.history.getFragment()).toBe('?sortKey=catalog_course_title&order=asc&page=2');
       done();
     });
-    this.collection.trigger('loaded');
+    collection.trigger('loaded');
   });
 
   it('URL fragment is updated on CourseListCollection refresh', (done) => {
-    this.collection.state.currentPage = 2;
-    this.collection.once('backgrid:refresh', () => {
+    collection.state.currentPage = 2;
+    collection.once('backgrid:refresh', () => {
       expect(Backbone.history.getFragment()).toBe('?sortKey=catalog_course_title&order=asc&page=2');
       done();
     });
-    this.collection.trigger('backgrid:refresh');
+    collection.trigger('backgrid:refresh');
   });
 });

--- a/analytics_dashboard/static/js/test/specs/spec-runner.js
+++ b/analytics_dashboard/static/js/test/specs/spec-runner.js
@@ -1,0 +1,5 @@
+var context = require.context('../../../', true, /.+spec\.jsx?$/);
+require('../../load/init-tooltips.js');
+require('axe-core');
+context.keys().forEach(context);
+module.exports = context;

--- a/analytics_dashboard/static/js/test/specs/spec-runner.js
+++ b/analytics_dashboard/static/js/test/specs/spec-runner.js
@@ -1,5 +1,4 @@
 var context = require.context('../../../', true, /.+spec\.jsx?$/);
 require('../../load/init-tooltips.js');
-require('axe-core');
 context.keys().forEach(context);
 module.exports = context;

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -28,11 +28,10 @@ module.exports = function(config) {
             {pattern: 'analytics_dashboard/static/js/models/**/*.js', included: false},
             {pattern: 'analytics_dashboard/static/js/views/**/*.js', included: false},
             {pattern: 'analytics_dashboard/static/js/utils/**/*.js', included: false},
-            {pattern: 'analytics_dashboard/static/apps/**/*.js', included: false},
             {pattern: 'analytics_dashboard/static/apps/**/*.underscore', included: false},
 
             // actual tests
-            {pattern: 'analytics_dashboard/static/js/test/specs/*.js', watched: false}
+            {pattern: 'analytics_dashboard/static/js/test/specs/spec-runner.js'}
         ],
 
         exclude: [
@@ -45,7 +44,7 @@ module.exports = function(config) {
         // preprocess matching files before serving them to the browser
         // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
         preprocessors: {
-            'analytics_dashboard/static/js/test/specs/*.js': ['webpack']
+            'analytics_dashboard/static/js/test/specs/spec-runner.js': ['webpack', 'sourcemap']
         },
 
         // plugins required for running the karma tests
@@ -57,7 +56,8 @@ module.exports = function(config) {
             'karma-coverage',
             'karma-sinon',
             'karma-chrome-launcher',
-            'karma-webpack'
+            'karma-webpack',
+            'karma-sourcemap-loader'
         ],
 
         webpack: {
@@ -106,6 +106,32 @@ module.exports = function(config) {
                             path.join(__dirname, 'node_modules')
                         ]
                     },
+                    // The babel-loader transforms newer ES2015 syntax to older ES5 for legacy browsers.
+                    {
+                        test: /\.js$/,
+                        exclude: /(node_modules|bower_components)/,
+                        use: {
+                            loader: 'babel-loader',
+                            options: {
+                                presets: [
+                                    ['env', {
+                                        targets: {
+                                            browsers: ['last 2 versions', 'ie >= 11']
+                                        }
+                                    }]
+                                ],
+                                plugins: [
+                                    'babel-plugin-syntax-dynamic-import',
+                                    ['istanbul', {
+                                        exclude: [
+                                            '**/*spec.js'
+                                        ]
+                                    }]
+                                ],
+                                cacheDirectory: true
+                            }
+                        }
+                    },
                     {
                         test: /\.scss$/,
                         use: [
@@ -149,19 +175,14 @@ module.exports = function(config) {
                         THEME_SCSS: 'sass/themes/open-edx.scss'
                     }
                 })
-            ]
+            ],
+
+            devtool: 'inline-source-map'
         },
 
         webpackMiddleware: {
-            // silences webpack log output
-            noInfo: true,
-            stats: {
-                assets: false,
-                chunks: false,
-                hash: false,
-                timings: false,
-                version: false
-            }
+            // silences most webpack log output
+            noInfo: true
         },
 
         // test results reporter to use

--- a/package.json
+++ b/package.json
@@ -57,8 +57,9 @@
     "webpack-merge": "^4.1.0"
   },
   "devDependencies": {
-    "axe-core": "^1.1.1",
+    "axe-core": "^2.0.0",
     "babel-eslint": "^7.2.3",
+    "babel-plugin-istanbul": "^4.1.4",
     "edx-custom-a11y-rules": "edx/edx-custom-a11y-rules#ff77f203ef5d9534c6200cc141e9d150155d0e12",
     "eslint": "^3.19.0",
     "eslint-config-edx": "^2.0.1",
@@ -79,6 +80,7 @@
     "karma-jasmine-jquery": "^0.1.1",
     "karma-phantomjs-launcher": "^1.0.2",
     "karma-sinon": "^1.0.5",
+    "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^2.0.3",
     "phantomjs-prebuilt": "^2.1.14",
     "prettier": "^1.5.2",


### PR DESCRIPTION
I forgot to include the tests under the `apps` directory in the karma config. Here's what I changed:

* Made a `spec-runner.js` file that uses [`require.context`](https://webpack.js.org/guides/dependency-management/#require-context) to require all files that end in `spec.js`
* Point the karma config at `spec-runner.js` instead of each individual test file so that webpack makes one bundle instead of one for every test file.
* Add sourcemaps (using `karma-sourcemap-loader`) so test errors/failures are meaningful
* Upgrade `axe-core` to 2.0.0+ which adds support for webpack
* Fix bad ES6 in `controller-spec.js` and `router-spec.js` that I never actually ran before
* Add `babel-plugin-istanbul` to the karma webpack config so that the `karma-coverage` reports coverage

@edx/educator-dahlia @dsjen 

Feel free to squash and merge while I'm on vacation!