### PR TITLE
EDUCATOR-1184 Polyfill ES2015 Promise for IE11

### DIFF
--- a/analytics_dashboard/static/js/application-main.js
+++ b/analytics_dashboard/static/js/application-main.js
@@ -1,6 +1,7 @@
 /**
  * Load scripts needed across the application.
  */
+require('babel-polyfill');  // EDUCATOR-1184: this defines Promise for IE11
 require('sass/style-application.scss');
 require(process.env.THEME_SCSS);
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "babel-plugin-dynamic-import-node": "^1.0.2",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-plugin-transform-runtime": "^6.23.0",
+    "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-runtime": "^6.25.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,13 +6,6 @@ var Merge = require('webpack-merge'),
     djangoDevServer = process.env.DJANGO_DEV_SERVER || 'http://localhost:8110';
 
 module.exports = Merge.smart(commonConfig, {
-    entry: {
-        // Bundle the client for the webpack-dev-server and specify url to the server
-        devServer: 'webpack-dev-server/client?http://localhost:8080',
-        // Bundle the client for hot reloading. 'only-' means to only hot reload for successful updates.
-        hotReload: 'webpack/hot/only-dev-server'
-    },
-
     output: {
         // Tells clients to load bundles from the dev-server
         publicPath: 'http://localhost:8080/static/bundles/',
@@ -83,7 +76,6 @@ module.exports = Merge.smart(commonConfig, {
 
     devServer: {
         compress: true,
-        hot: true, // enable hot reloading on the server
         // Since the dev-server runs on a different port, browsers will complain about CORS violations unless we
         // explicitly tell them it's okay with this header.
         headers: {


### PR DESCRIPTION
This fixes Insights in IE11. I tested manually in IE11 in a Windows 7 VM to verify that the course list table loads and there aren't any "Promise is undefined" errors in the dev console.

I'm also sneaking in an extra change into this PR. I deleted some configuration from `webpack.config.js` that was not doing anything. The [webpack-dev-server options `--hot --inline`](https://webpack.js.org/configuration/dev-server/#devserver-hot) automatically does this configuration for us, and `npm start` always uses those options.

@edx/educator-dahlia 