### PR TITLE
Don't rename some vendor CSS to SCSS.

### DIFF
--- a/analytics_dashboard/static/sass/style-application.scss
+++ b/analytics_dashboard/static/sass/style-application.scss
@@ -22,7 +22,7 @@
 @import "~bootstrap-accessibility-plugin/plugins/css/bootstrap-accessibility";
 @import "~font-awesome/scss/font-awesome";
 @import "~datatables-bootstrap3-plugin/media/css/datatables-bootstrap3.css";
-@import "~nvd3/build/nv.d3.scss";
+@import "~nvd3/build/nv.d3";
 
 // import edx pattern library variables so it's available to Insights styles
 @import '~bourbon/app/assets/stylesheets/bourbon';

--- a/npm-post-install.sh
+++ b/npm-post-install.sh
@@ -3,19 +3,6 @@
 NPM_PATH="node_modules"
 NPM_BIN="${NPM_PATH}/.bin"
 
-function CSS2SCSS() {
-    filename=$1
-    css_filename=${filename}.css
-
-    if [ -f ${css_filename} ]; then
-        mv ${css_filename} ${filename}.scss
-    fi
-}
-
-# Rename the CSS to SCSS since SASS can only import .scss files.
-CSS2SCSS ${NPM_PATH}/bootstrap-accessibility-plugin/plugins/css/bootstrap-accessibility
-CSS2SCSS ${NPM_PATH}/nvd3/build/nv.d3
-
 # Download the CLDR data for all locales
 CLDR_DATA_PATH=${NPM_PATH}/cldr-data
 node ./node_modules/cldr-data-downloader/bin/download.js -i ${CLDR_DATA_PATH}/urls.json -o ${CLDR_DATA_PATH}


### PR DESCRIPTION
I thought that SCSS did not allow @importing css files, but apparently it does,
so I'm removing this fragile CSS2SCSS step in the npm-post-install.sh which
seems to be breaking deploys at the moment.

@edx/educator-dahlia 