### PR TITLE
upgrade django from 1.11.2 to 1.11.5

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 awesome-slugify==1.6.5      # GPLv3
 bpython==0.16				# MIT License
-Django==1.11.2				# BSD License
+Django==1.11.5				# BSD License
 django-appconf==1.0.2
 django-braces==1.11.0		# BSD
 django-countries==4.5       # MIT


### PR DESCRIPTION
[EDUCATOR-1361](https://openedx.atlassian.net/browse/EDUCATOR-1361)
There are security and other bug fixes in [Django 1.11.5 release](https://docs.djangoproject.com/en/1.11/releases/1.11.5/).
Version is changed in requirement file. 
Is there any thing we need to look at for this update?
FYI: @awaisdar001