### PR TITLE
update edx-auth-backends to edx-auth-backends==1.1.3-- EDUCATOR-2056

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,7 +13,7 @@ django-crispy-forms==1.6.1  # MIT
 django-soapbox==1.3         # BSD
 django-waffle==0.12.0		# BSD
 pinax-announcements==2.0.4   # MIT
-edx-auth-backends==1.1.2
+edx-auth-backends==1.1.3
 edx-django-release-util==0.3.1
 edx-i18n-tools==0.4.2
 edx-rest-api-client==1.7.1  # Apache


### PR DESCRIPTION
As per [LEARNER-3015](https://openedx.atlassian.net/browse/LEARNER-3015) I am updating `edx-auth-backends` to `1.1.3`

Reviewers, please acknowledge if this is the right change and any other IDAs which needs to be updated for Educator. 
  