### PR TITLE
Pin pip version to 9.0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ before_install:
     # Fix intermittent "resource temporarily unavailable" and "write" errors failing the Travis builds.
     # See: https://github.com/travis-ci/travis-ci/issues/8920
     - python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
+    # pin to 9.0.3 until tox-battery upgrades
+    - pip install --upgrade pip==9.0.3
     # Install a newer version of docker-compose
     # Remove once dockers default is this version: https://docs.travis-ci.com/user/docker/#Using-Docker-Compose
     - sudo rm /usr/local/bin/docker-compose

--- a/.travis/run_tests.sh
+++ b/.travis/run_tests.sh
@@ -19,6 +19,9 @@ export PATH=$PATH:$PWD/node_modules/.bin
 node --version
 npm --version
 
+# Pin pip version
+make pin_pip
+
 make develop
 make migrate
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ DJANGO_SETTINGS_MODULE ?= "analytics_dashboard.settings.local"
 
 .PHONY: requirements clean
 
+# pin to 9.0.3 until tox-battery upgrades
+pin_pip:
+	pip install --upgrade pip==9.0.3
+
 requirements: requirements.py requirements.js
 
 requirements.py:


### PR DESCRIPTION
Pin pip version to 9.0.3 until version becomes stable again

Related to: https://github.com/edx/edx-proctoring/pull/429 & needed in order to merge: https://github.com/edx/edx-analytics-dashboard/pull/760