### PR TITLE
ARCH-253 (was ARCH-223): Upgrade edx-django-utils.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ django-waffle==0.12.0		# BSD
 pinax-announcements==2.0.4   # MIT
 edx-auth-backends==1.1.3
 edx-django-release-util==0.3.1
-edx-django-utils==0.4.1
+edx-django-utils==1.0.1
 edx-drf-extensions==1.6.1
 edx-i18n-tools==0.4.2
 edx-rest-api-client==1.8.2  # Apache


### PR DESCRIPTION
ARCH-253 (was ARCH-223)