### PR TITLE
ARCH-233: Add JWT Auth Middleware.

### DIFF
--- a/analytics_dashboard/settings/base.py
+++ b/analytics_dashboard/settings/base.py
@@ -181,6 +181,8 @@ MIDDLEWARE_CLASSES = (
     'help.middleware.HelpURLMiddleware',
     'edx_django_utils.cache.middleware.TieredCacheMiddleware',
     'edx_rest_framework_extensions.middleware.RequestMetricsMiddleware',
+    'edx_rest_framework_extensions.auth.jwt.middleware.EnsureJWTAuthSettingsMiddleware',
+    'edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware',
 )
 ########## END MIDDLEWARE CONFIGURATION
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ pinax-announcements==2.0.4   # MIT
 edx-auth-backends==1.1.3
 edx-django-release-util==0.3.1
 edx-django-utils==1.0.1
-edx-drf-extensions==1.6.1
+edx-drf-extensions==1.10.0
 edx-i18n-tools==0.4.2
 edx-rest-api-client==1.8.2  # Apache
 


### PR DESCRIPTION
**NOTE**: This is not rebased off of master, but off my previous PR.

From edx-drf-extensions:
1. EnsureJWTAuthSettingsMiddleware: Ensures proper JWT auth settings
   for endpoints.
2. JwtAuthCookieMiddleware: Combines the JWT auth cookie parts into a
   JWT auth cookie.

ARCH-233