### PR TITLE
Stop analyzing analytics api in health check

### DIFF
--- a/acceptance_tests/test_status.py
+++ b/acceptance_tests/test_status.py
@@ -17,7 +17,6 @@ class StatusTests(TestCase):
             'overall_status': self.POSITIVE_STATUS,
             'detailed_status': {
                 'database_connection': self.POSITIVE_STATUS,
-                'analytics_api': self.POSITIVE_STATUS
             }
         }
         self.assertDictEqual(response.json(), expected_status)

--- a/analytics_dashboard/core/views.py
+++ b/analytics_dashboard/core/views.py
@@ -10,8 +10,6 @@ from django.http import HttpResponse, Http404
 from django.shortcuts import redirect
 from django.views.generic import View, TemplateView
 from django.core.urlresolvers import reverse_lazy
-from analyticsclient.client import Client
-from analyticsclient.exceptions import TimeoutError
 
 from analytics_dashboard.courses import permissions
 try:


### PR DESCRIPTION
Insights keeps falling out of the load balancer because analytics api doesn't respond within 350ms. Insights shouldn't fall out of the ELB just because Analytics API is slow or down.