### PR TITLE
EDUCATOR-3839 | fix graded content api endpoint

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,3 +10,4 @@ Tyler Hallada <thallada@edx.org>
 Dmitry Viskov <dmitry.viskov@webenterprise.ru>
 Kyle McCormick <kylemccor@gmail.com>
 Robert Raposa <rraposa@edx.org>
+Rabia Iftikhar <rabiaiftikhar2392@gmail.com>

--- a/analytics_dashboard/courses/presenters/performance.py
+++ b/analytics_dashboard/courses/presenters/performance.py
@@ -184,7 +184,7 @@ class CoursePerformancePresenter(CourseAPIPresenterMixin, CoursePresenter):
 
         if not grading_policy:
             logger.debug('Retrieving grading policy for course: %s', self.course_id)
-            grading_policy = self.grading_policy_client.courses(self.course_id).policy.get()
+            grading_policy = self.grading_policy_client.policy.courses(self.course_id).get()
 
             # Remove empty assignment types as they are not useful and will cause issues downstream.
             grading_policy = [item for item in grading_policy if item['assignment_type']]

--- a/analytics_dashboard/courses/tests/test_views/__init__.py
+++ b/analytics_dashboard/courses/tests/test_views/__init__.py
@@ -35,7 +35,7 @@ class CourseAPIMixin(object):
     COURSE_BLOCKS_API_TEMPLATE = \
         settings.COURSE_API_URL + \
         '/blocks/?course_id={course_id}&requested_fields=children,graded&depth=all&all_blocks=true'
-    GRADING_POLICY_API_TEMPLATE = settings.GRADING_POLICY_API_URL + '/courses/{course_id}/policy/'
+    GRADING_POLICY_API_TEMPLATE = settings.GRADING_POLICY_API_URL + '/policy/courses/{course_id}/'
 
     def mock_course_api(self, url, body=None, **kwargs):
         """

--- a/analytics_dashboard/settings/dev.py
+++ b/analytics_dashboard/settings/dev.py
@@ -83,7 +83,7 @@ HELP_URL = '#'
 SEGMENT_IO_KEY = os.environ.get('SEGMENT_WRITE_KEY')
 ########## END SEGMENT.IO
 
-GRADING_POLICY_API_URL = 'http://127.0.0.1:18000/api/grades/v0/'
+GRADING_POLICY_API_URL = 'http://127.0.0.1:18000/api/grades/v1/'
 COURSE_API_URL = 'http://127.0.0.1:18000/api/courses/v1/'
 
 LOGGING = get_logger_config(debug=DEBUG, dev_env=True, local_loglevel='DEBUG')


### PR DESCRIPTION
[EDUCATOR-3839](https://openedx.atlassian.net/browse/EDUCATOR-3839)

**Related PR**
https://github.com/edx/configuration/pull/4910

**Issue**
[graded_content API endpoint](https://github.com/edx/edx-analytics-dashboard/blob/master/analytics_dashboard/courses/urls.py#L70) is not working due to the change in _grading_policy_ URL in the [PR#19422](https://github.com/edx/edx-platform/pull/19422)

**Resolution**
I have updated the _grading_policy_ URL and grade version from v0 to v1.

**Reviewers**
- [x] @nasthagiri 
- [ ] @awaisdar001 