### PR TITLE
[FIX] Fixing Invalid date range text message for Analytics Learners page

### DIFF
--- a/analytics_dashboard/static/apps/learners/roster/views/activity-date-range.js
+++ b/analytics_dashboard/static/apps/learners/roster/views/activity-date-range.js
@@ -16,8 +16,8 @@ define(function(require) {
                 naText = gettext('n/a');
 
             return {
-                startDate: _(dateRange).has('start') ? Utils.formatDate(dateRange.start) : naText,
-                endDate: _(dateRange).has('end') ? Utils.formatDate(dateRange.end) : naText
+                startDate: _(dateRange).has('start') && ! _.isNull(dateRange.start) ? Utils.formatDate(dateRange.start) : naText,
+                endDate: _(dateRange).has('end') && ! _.isNull(dateRange.end) ? Utils.formatDate(dateRange.end) : naText
             };
         }
     });


### PR DESCRIPTION
Whenever I open a Learners Engagement page for any particular course in Insights(**hawthorn.master**), it internally calls analytics-data-api endpoint at **/api/v0/course_learner_metadata/{course_id}** and endpoint returns JSON response containing a “date_range” under a “engagement_ranges”. (Note: I checked edx-analytics-api documentation (https://edx.readthedocs.io/projects/edx-data-analytics-api/en/latest/) but, I didn’t found API reference for same.)

So, If any learner engagement found during a week for a particular course, it gives date_range object with a valid date as follows:
```
“engagement_ranges”: {
  "date_range”: {
    “start”: “2019-07-24”,
    “end”: “2019-07-31”
  },
  …
}
```

But if there is no learners activity/engagement found during a week for any particular course, it gives date_range objects with start_date and end_date as a null value.
```
“engagement_ranges”: {
  “date_range”: {
    “start”: null,
    “end”: null
  },
  …
}
```

Above response is parsed by backbone js located at **edx-analytics-dashboard/analytics_dashboard/static/apps/learners/roster/views/activity-date-range.js** and if date_range has a **start** and **end** in response then data is parsed using **Utils.formatDate()** so if the date is null it gives invalid date as a response and final string is “**Activity between Invalid date - Invalid date**”.

There should be a condition like, if “start” and “end” is available in “date_range” dict and they have a valid date, then it should proceed to parse, else it executes else condition from ternary expression and returns “n/a” so final string should be “**Activity between n/a - n/a**” as per backbone test cases.