### PR TITLE
BOM-897: DOP to DOT for Insights

### DIFF
--- a/acceptance_tests/mixins.py
+++ b/acceptance_tests/mixins.py
@@ -258,7 +258,7 @@ class LoginMixin(object):
 
 class LogoutMixin(object):
     def logout(self):
-        url = '{}/accounts/logout/'.format(DASHBOARD_SERVER_URL)
+        url = '{}/logout/'.format(DASHBOARD_SERVER_URL)
         self.browser.get(url)
 
 

--- a/acceptance_tests/pages.py
+++ b/acceptance_tests/pages.py
@@ -94,7 +94,7 @@ class LMSLoginPage(PageObject):
 
 
 class LoginPage(DashboardPage):
-    path = 'accounts/login'
+    path = 'login'
 
     def is_browser_on_page(self):
         return True

--- a/analytics_dashboard/core/models.py
+++ b/analytics_dashboard/core/models.py
@@ -12,8 +12,17 @@ class User(AbstractUser):
 
     @property
     def access_token(self):
+        """
+        Returns the access token from the extra data in the user's social auth.
+
+        Note that a single user_id can be associated with multiple provider/uid combinations. For example:
+            provider    uid             user_id
+            edx-oidc    person          123
+            edx-oauth2  person          123
+            edx-oauth2  person@edx.org  123
+        """
         try:
-            return self.social_auth.first().extra_data[u'access_token']  # pylint: disable=no-member
+            return self.social_auth.order_by('-id').first().extra_data[u'access_token']  # pylint: disable=no-member
         except Exception:  # pylint: disable=broad-except
             return None
 

--- a/analytics_dashboard/core/tests/test_models.py
+++ b/analytics_dashboard/core/tests/test_models.py
@@ -17,3 +17,22 @@ class UserTests(TestCase):
         social_auth.extra_data[u'access_token'] = access_token
         social_auth.save()
         self.assertEqual(user.access_token, access_token)
+
+    def test_multiple_access_tokens(self):
+        """ Ensures the correct access token is pulled from the insights user when multiple social auth entries
+        exist for that user. """
+        user = G(User)
+        self.assertIsNone(user.access_token)
+
+        lms_user_id = 6181
+        expected_access_token = 'access_token_3'
+        UserSocialAuth.objects.create(user=user, provider='edx-oidc', uid='older_6181',
+                                      extra_data={'user_id': lms_user_id, 'access_token': 'access_token_1'})
+        UserSocialAuth.objects.create(user=user, provider='edx-oauth2', uid='older_6181',
+                                      extra_data={'user_id': lms_user_id, 'access_token': 'access_token_2'})
+        UserSocialAuth.objects.create(user=user, provider='edx-oauth2',
+                                      extra_data={'user_id': lms_user_id, 'access_token': expected_access_token})
+
+        same_user = User.objects.get(id=user.id)
+        self.assertEqual(same_user.social_auth.count(), 3)
+        self.assertEqual(same_user.access_token, expected_access_token)

--- a/analytics_dashboard/core/tests/test_views.py
+++ b/analytics_dashboard/core/tests/test_views.py
@@ -103,7 +103,7 @@ class LoginViewTests(RedirectTestCaseMixin, TestCase):
         The login page should redirect users to the OAuth2 provider's login page.
         """
         response = self.client.get(settings.LOGIN_URL)
-        path = reverse('social:begin', args=['edx-oidc'])
+        path = reverse('social:begin', args=['edx-oauth2'])
         self.assertRedirectsNoFollow(response, path, status_code=302)
 
 

--- a/analytics_dashboard/courses/exceptions.py
+++ b/analytics_dashboard/courses/exceptions.py
@@ -22,6 +22,13 @@ class InvalidAccessTokenError(PermissionsError):
     pass
 
 
+class AccessTokenRetrievalFailedError(PermissionsError):
+    """
+    Raise if access token retrieval fails (e.g. the backend is unreachable).
+    """
+    pass
+
+
 class PermissionsRetrievalFailedError(PermissionsError):
     """
     Raise if permissions retrieval fails (e.g. the backend is unreachable).

--- a/analytics_dashboard/learner_analytics_api/v0/tests/test_views.py
+++ b/analytics_dashboard/learner_analytics_api/v0/tests/test_views.py
@@ -54,6 +54,7 @@ class LearnerAPITestMixin(UserTestCaseMixin, PermissionsTestMixin):
 
     def test_no_course_permissions(self):
         self.login()
+        self.grant_permission(self.user, [])
         response = self.client.get('/api/learner_analytics/v0' + self.endpoint, self.required_query_params)
         self.assert_response_equals(response, self.no_permissions_status_code)
 

--- a/analytics_dashboard/settings/base.py
+++ b/analytics_dashboard/settings/base.py
@@ -51,9 +51,9 @@ DATABASES = {
         'HOST': '127.0.0.1',
         'PORT': '3306',
         'OPTIONS': {
-	    'connect_timeout': 10,
-	    'init_command': "SET sql_mode='STRICT_TRANS_TABLES'",
-        }, 
+            'connect_timeout': 10,
+            'init_command': "SET sql_mode='STRICT_TRANS_TABLES'",
+        },
     }
 }
 ########## END DATABASE CONFIGURATION
@@ -333,10 +333,11 @@ TIME_FORMAT = 'g:i A'
 ########## AUTHENTICATION
 AUTH_USER_MODEL = 'core.User'
 
-# Allow authentication via edX OAuth2/OpenID Connect
+# Allow authentication via edX OAuth2 and edX OAuth2/OpenID Connect
 AUTHENTICATION_BACKENDS = (
-    'auth_backends.backends.EdXOpenIdConnect',
+    'auth_backends.backends.EdXOAuth2',
     'django.contrib.auth.backends.ModelBackend',
+    'auth_backends.backends.EdXOpenIdConnect',
 )
 
 # Set to true if using SSL and running behind a proxy
@@ -346,6 +347,7 @@ SOCIAL_AUTH_ADMIN_USER_SEARCH_FIELDS = ['username', 'email']
 
 SOCIAL_AUTH_STRATEGY = 'auth_backends.strategies.EdxDjangoStrategy'
 
+# These OIDC variables are DEPRECATED.
 # Set these to the correct values for your OAuth2/OpenID Connect provider
 SOCIAL_AUTH_EDX_OIDC_KEY = 'YOUR_OAUTH2_KEY'
 SOCIAL_AUTH_EDX_OIDC_SECRET = 'secret'
@@ -355,6 +357,17 @@ SOCIAL_AUTH_EDX_OIDC_LOGOUT_URL = 'http://127.0.0.1:8000/logout'
 
 # This value should be the same as SOCIAL_AUTH_EDX_OIDC_SECRET
 SOCIAL_AUTH_EDX_OIDC_ID_TOKEN_DECRYPTION_KEY = 'secret'
+
+# Set these to the correct values for your OAuth2 provider (e.g., devstack)
+SOCIAL_AUTH_EDX_OAUTH2_KEY = "insights-sso-key"
+SOCIAL_AUTH_EDX_OAUTH2_SECRET = "insights-sso-secret"
+SOCIAL_AUTH_EDX_OAUTH2_ISSUER = "http://127.0.0.1:8000"
+SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT = "http://127.0.0.1:8000"
+SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL = "http://127.0.0.1:8000/logout"
+
+BACKEND_SERVICE_EDX_OAUTH2_KEY = "insights-backend-service-key"
+BACKEND_SERVICE_EDX_OAUTH2_SECRET = "insights-backend-service-secret"
+BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL = "http://127.0.0.1:8000/oauth2"
 
 # Enables a special view that, when accessed, creates and logs in a new user.
 # This should NOT be enabled for production deployments!
@@ -367,6 +380,7 @@ AUTO_AUTH_USERNAME_PREFIX = 'AUTO_AUTH_'
 # Maximum time (in seconds) before course permissions expire and need to be refreshed
 COURSE_PERMISSIONS_TIMEOUT = 900
 
+LOGIN_URL = '/login/'
 LOGIN_REDIRECT_URL = '/courses/'
 LOGOUT_REDIRECT_URL = '/'
 

--- a/analytics_dashboard/settings/devstack.py
+++ b/analytics_dashboard/settings/devstack.py
@@ -5,3 +5,11 @@ from analytics_dashboard.settings.yaml_config import *
 
 DATA_API_URL = os.getenv('DATA_API_URL', DATA_API_URL)
 DATA_API_AUTH_TOKEN = os.getenv('DATA_API_AUTH_TOKEN', DATA_API_AUTH_TOKEN)
+
+SOCIAL_AUTH_EDX_OAUTH2_ISSUER = "http://localhost:18000"
+SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT = "http://edx.devstack.lms:18000"
+SOCIAL_AUTH_EDX_OAUTH2_PUBLIC_URL_ROOT = "http://localhost:18000"
+SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL = "http://localhost:18000/logout"
+
+BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL = "http://edx.devstack.lms:18000/oauth2"
+

--- a/analytics_dashboard/settings/test.py
+++ b/analytics_dashboard/settings/test.py
@@ -27,7 +27,10 @@ USER_TRACKING_CLAIM = None
 LMS_COURSE_SHORTCUT_BASE_URL = 'http://lms-host'
 CMS_COURSE_SHORTCUT_BASE_URL = 'http://cms-host'
 GRADING_POLICY_API_URL = 'http://grading-policy-api-host'
-COURSE_API_URL = 'http://course-api-host'
+BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL='http://provider-host/oauth2'
+BACKEND_SERVICE_EDX_OAUTH2_KEY='test_backend_oauth2_key'
+BACKEND_SERVICE_EDX_OAUTH2_SECRET='test_backend_oauth2_secret'
+COURSE_API_URL = 'http://course-api-host/courses'
 COURSE_API_KEY = 'test_course_api_key'
 
 DATA_API_URL = 'http://data-api-host/api/v0'

--- a/analytics_dashboard/urls.py
+++ b/analytics_dashboard/urls.py
@@ -1,12 +1,11 @@
 # pylint: disable=line-too-long,no-value-for-parameter
 import os
 
+from auth_backends.urls import oauth2_urlpatterns
 from django.conf.urls import include, url
 from django.conf import settings
 from django.contrib import admin
-from django.core.urlresolvers import reverse_lazy
 from django.views import defaults
-from django.views.generic import RedirectView
 from django.views.i18n import JavaScriptCatalog
 from django.contrib.staticfiles import views as static_views
 
@@ -17,22 +16,21 @@ from core import views
 
 admin.autodiscover()
 
-urlpatterns = [
+# NOTE 1: Add our logout override first to ensure it is registered by Django as the actual logout view.
+# NOTE 2: These same patterns are used for rest_framework's browseable API authentication links.
+AUTH_URLS = [
+    url(r'^logout/$', views.InsightsLogoutView.as_view(), name='logout'),
+    url(r'^logout_then_login/$', views.insights_logout_then_login, name='logout_then_login'),
+] + oauth2_urlpatterns
+
+urlpatterns = AUTH_URLS + [
     url(r'^$', views.LandingView.as_view(), name='landing'),
-    url(r'^api-auth/', include('rest_framework.urls')),
     url(r'^jsi18n/$', JavaScriptCatalog.as_view(packages=['core', 'courses']), name='javascript-catalog'),
     url(r'^status/$', views.status, name='status'),
     url(r'^health/$', views.health, name='health'),
     url(r'^courses/', include('courses.urls')),
     url(r'^admin/', admin.site.urls),
-    # TODO: the namespace arg is deprecated, but python-social-auth urls.py doesn't specify app_name so we are stuck
-    # using namespace. Once python-social-auth is updated to fix that, remove the namespace arg.
-    url('', include('social_django.urls', namespace='social')),
-    url(r'^accounts/login/$',
-        RedirectView.as_view(url=reverse_lazy('social:begin', args=['edx-oidc']), permanent=False, query_string=True),
-        name='login'),
-    url(r'^accounts/logout/$', views.InsightsLogoutView.as_view(), name='logout'),
-    url(r'^accounts/logout_then_login/$', views.insights_logout_then_login, name='logout_then_login'),
+    url(r'^api-auth/', include(AUTH_URLS, namespace='rest_framework')),
     url(r'^test/auto_auth/$', views.AutoAuth.as_view(), name='auto_auth'),
     url(r'^announcements/', include('pinax.announcements.urls', namespace='pinax_announcements')),
 ]

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -14,7 +14,7 @@ django-crispy-forms==1.6.1				# MIT
 django-soapbox==1.3						# BSD
 django-waffle==0.12.0					# BSD
 pinax-announcements==2.0.4				# MIT
-edx-auth-backends==1.1.3
+edx-auth-backends
 edx-ccx-keys==0.2.1
 edx-opaque-keys
 edx-django-release-util==0.3.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -27,7 +27,7 @@ djangorestframework-csv==2.0.0
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 djangorestframework==3.6.3
 edx-analytics-data-api-client==0.15.3
-edx-auth-backends==1.1.3
+edx-auth-backends==2.0.2
 edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==0.4.1
@@ -52,13 +52,13 @@ psutil==1.2.1             # via edx-drf-extensions
 pycryptodomex==3.9.4      # via pyjwkest
 pygments==2.5.2           # via bpython
 pyjwkest==1.3.2           # via edx-drf-extensions, social-auth-core
-pyjwt==1.7.1              # via djangorestframework-jwt, edx-rest-api-client, social-auth-core
+pyjwt==1.7.1              # via djangorestframework-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pymongo==3.10.0           # via edx-opaque-keys
 python-dateutil==2.8.1    # via edx-drf-extensions
 python-openid==2.2.5      # via social-auth-core
 pytz==2019.3              # via django
 pyyaml==5.3               # via edx-django-release-util, edx-i18n-tools
-regex==2019.12.20         # via awesome-slugify
+regex==2020.1.7           # via awesome-slugify
 requests-oauthlib==1.3.0  # via social-auth-core
 requests==2.22.0
 rest-condition==1.0.3     # via edx-drf-extensions

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -30,7 +30,7 @@ djangorestframework-jwt==1.11.0
 djangorestframework==3.6.3
 docutils==0.15.2          # via sphinx
 edx-analytics-data-api-client==0.15.3
-edx-auth-backends==1.1.3
+edx-auth-backends==2.0.2
 edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==0.4.1
@@ -64,7 +64,7 @@ python-dateutil==2.8.1
 python-openid==2.2.5
 pytz==2019.3
 pyyaml==5.3
-regex==2019.12.20
+regex==2020.1.7
 requests-oauthlib==1.3.0
 requests==2.22.0
 rest-condition==1.0.3

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -37,7 +37,7 @@ djangorestframework-csv==2.0.0
 djangorestframework-jwt==1.11.0
 djangorestframework==3.6.3
 edx-analytics-data-api-client==0.15.3
-edx-auth-backends==1.1.3
+edx-auth-backends==2.0.2
 edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==0.4.1
@@ -89,7 +89,7 @@ python-dateutil==2.8.1
 python-openid==2.2.5
 pytz==2019.3
 pyyaml==5.3
-regex==2019.12.20
+regex==2020.1.7
 requests-oauthlib==1.3.0
 requests==2.22.0
 rest-condition==1.0.3

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -27,7 +27,7 @@ djangorestframework-csv==2.0.0
 djangorestframework-jwt==1.11.0
 djangorestframework==3.6.3
 edx-analytics-data-api-client==0.15.3
-edx-auth-backends==1.1.3
+edx-auth-backends==2.0.2
 edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==0.4.1
@@ -62,7 +62,7 @@ python-memcached==1.58
 python-openid==2.2.5
 pytz==2019.3
 pyyaml==5.3
-regex==2019.12.20
+regex==2020.1.7
 requests-oauthlib==1.3.0
 requests==2.22.0
 rest-condition==1.0.3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -35,7 +35,7 @@ djangorestframework-csv==2.0.0
 djangorestframework-jwt==1.11.0
 djangorestframework==3.6.3
 edx-analytics-data-api-client==0.15.3
-edx-auth-backends==1.1.3
+edx-auth-backends==2.0.2
 edx-ccx-keys==0.2.1
 edx-django-release-util==0.3.1
 edx-django-utils==0.4.1
@@ -86,7 +86,7 @@ python-dateutil==2.8.1
 python-openid==2.2.5
 pytz==2019.3
 pyyaml==5.3
-regex==2019.12.20
+regex==2020.1.7
 requests-oauthlib==1.3.0
 requests==2.22.0
 rest-condition==1.0.3


### PR DESCRIPTION
Two updates required:
1. The user tracking id needs to be fetched from a different place.
2. The permissions need to be requested from the LMS.  This is done (and cached) on demand.

NOTE: This PR uses the deprecated  `EdxRestApiClient` until a future pass when the new api client has caching added.

BOM-897