### PR TITLE
update insights settings for devstack

### DIFF
--- a/analytics_dashboard/settings/devstack.py
+++ b/analytics_dashboard/settings/devstack.py
@@ -6,10 +6,5 @@ from analytics_dashboard.settings.yaml_config import *
 DATA_API_URL = os.getenv('DATA_API_URL', DATA_API_URL)
 DATA_API_AUTH_TOKEN = os.getenv('DATA_API_AUTH_TOKEN', DATA_API_AUTH_TOKEN)
 
-SOCIAL_AUTH_EDX_OAUTH2_ISSUER = "http://localhost:18000"
-SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT = "http://edx.devstack.lms:18000"
-SOCIAL_AUTH_EDX_OAUTH2_PUBLIC_URL_ROOT = "http://localhost:18000"
-SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL = "http://localhost:18000/logout"
 
-BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL = "http://edx.devstack.lms:18000/oauth2"
 

--- a/analytics_dashboard/settings/devstack.yml
+++ b/analytics_dashboard/settings/devstack.yml
@@ -1,0 +1,24 @@
+---
+
+BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL: http://edx.devstack.lms:18000/oauth2
+COURSE_API_URL: http://edx.devstack.lms:18000/api/courses/v1/
+DATABASES:
+    default:
+        ATOMIC_REQUESTS: 'false'
+        CONN_MAX_AGE: 60
+        ENGINE: django.db.backends.mysql
+        HOST: edx.devstack.mysql
+        NAME: dashboard
+        OPTIONS:
+            connect_timeout: 10
+            init_command: SET sql_mode='STRICT_TRANS_TABLES'
+        PASSWORD: password
+        PORT: 3306
+        USER: dashboard001
+ENABLE_AUTO_AUTH: false
+GRADING_POLICY_API_URL: http://edx.devstack.lms:18000/api/grades/v1/
+SESSION_COOKIE_NAME: insights_sessionid
+SOCIAL_AUTH_EDX_OAUTH2_ISSUER: http://localhost:18000
+SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL: http://localhost:18000/logout
+SOCIAL_AUTH_EDX_OAUTH2_PUBLIC_URL_ROOT: http://localhost:18000
+SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT: http://edx.devstack.lms:18000

--- a/scripts/update_devstack.sh
+++ b/scripts/update_devstack.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -xe
+
+# Can be used to update a devstack container.  This is not the right permanent home for
+# this script, but it is a start.
+# Note: Copied and modified from .travis/run_tests.sh
+
+. /edx/app/insights/venvs/insights/bin/activate
+. /edx/app/insights/nodeenvs/insights/bin/activate
+
+cd /edx/app/insights/edx_analytics_dashboard
+export PATH=$PATH:$PWD/node_modules/.bin
+
+# Output node.js version
+node --version
+npm --version
+
+# HACK: remove package-lock.json because otherwise npm doesn't want to git clone (I WISH I KNEW WHY)
+# Note: Copied from .travis/run_tests.sh
+rm package-lock.json
+
+# Pin pip version
+make pin_pip
+
+make develop
+make migrate
+make static


### PR DESCRIPTION
**NOTE:** This seems to break the original tests.  Not sure, so just won't try to merge.

This is an imperfect setup, but it contains some minimal updates to push
this in the right direction.  For now, requires the following configs
to work:

DJANGO_SETTINGS_MODULE: "analytics_dashboard.settings.devstack"
ANALYTICS_DASHBOARD_CFG: "/edx/app/insights/edx_analytics_dashboard/analytics_dashboard/settings/devstack.yml"

The script update_devstack.sh can be run inside the container until a
more complete devstack provisioning is completed.