### PR TITLE
 BOM-897: fix user course permissions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ before_install:
 
     # Start up the relevant services
     - docker-compose -f .travis/docker-compose-travis.yml up -d
+    - docker exec analytics_api pip install --upgrade pip==9.0.3
     - docker exec analytics_api make -C /edx/app/analytics_api/analytics_api test.requirements
     - docker exec analytics_api make -C /edx/app/analytics_api/analytics_api travis
 

--- a/analytics_dashboard/courses/tests/test_views/__init__.py
+++ b/analytics_dashboard/courses/tests/test_views/__init__.py
@@ -142,7 +142,13 @@ class AuthTestMixin(MockApiTestMixin, PermissionsTestMixin, RedirectTestCaseMixi
 
     def _prepare_mock_client_to_return_empty_permissions(self, mock_client):
         """ Provided a mock of EdxRestApiClient, prepare it to return empty permissions """
-        mock_client.return_value.courses.return_value.get.return_value = []
+        mock_course_response = {
+            'pagination': {
+                'next': None
+            },
+            'results': []
+        }
+        mock_client.return_value.courses.return_value.get.return_value = mock_course_response
         hour_expiration_datetime = datetime.utcnow() + timedelta(hours=1)
         mock_client.get_oauth_access_token.return_value = ('test-access-token', hour_expiration_datetime)
 

--- a/analytics_dashboard/courses/views/course_summaries.py
+++ b/analytics_dashboard/courses/views/course_summaries.py
@@ -42,8 +42,9 @@ class CourseIndex(CourseAPIMixin, LoginRequiredMixin, TrackedViewMixin, LastUpda
 
     def get_context_data(self, **kwargs):
         context = super(CourseIndex, self).get_context_data(**kwargs)
-        courses = permissions.get_user_course_permissions(self.request.user)
-        if not courses:
+        user = self.request.user
+        courses = permissions.get_user_course_permissions(user)
+        if not courses and not (user.is_superuser or user.is_staff):
             # The user is probably not a course administrator and should not be using this application.
             raise PermissionDenied
 
@@ -93,8 +94,9 @@ class CourseIndexCSV(CourseAPIMixin, LoginRequiredMixin, DatetimeCSVResponseMixi
     }
 
     def get_data(self):
-        courses = permissions.get_user_course_permissions(self.request.user)
-        if not courses:
+        user = self.request.user
+        courses = permissions.get_user_course_permissions(user)
+        if not courses and not (user.is_superuser or user.is_staff):
             # The user is probably not a course administrator and should not be using this application.
             raise PermissionDenied
 


### PR DESCRIPTION
1. uses 'results' key in courses json response.
2. loops when pagination is required.
3. staff users now skip permissions check. assumes all courses.

BOM-897