### PR TITLE
BOM-897: switch from courses to course_ids

### DIFF
--- a/analytics_dashboard/courses/permissions.py
+++ b/analytics_dashboard/courses/permissions.py
@@ -209,27 +209,27 @@ def _refresh_user_course_permissions(user):
             jwt=access_token,
         )
 
-        courses = []
+        course_ids = []
         page = 1
 
         while page:
             logger.debug('Retrieving page %d of courses...', page)
-            response = client.courses().get(
+            response = client.course_ids().get(
                 username=user.username,
                 role=ROLE_FOR_ALLOWED_COURSES,
                 page=page,
                 page_size=100,
             )
 
-            courses += response['results']
+            course_ids += response['results']
 
             if response['pagination']['next']:
                 page += 1
             else:
                 page = None
-                logger.debug('Completed retrieval of courses. Retrieved info for %d courses.', len(courses))
+                logger.debug('Completed retrieval of courses. Retrieved info for %d courses.', len(course_ids))
 
-        allowed_courses = list(set(course['id'] for course in courses))
+        allowed_courses = list(set(course_ids))
 
     except Exception as e:
         logger.error("Unable to retrieve course permissions: %s", e)

--- a/analytics_dashboard/courses/tests/test_views/__init__.py
+++ b/analytics_dashboard/courses/tests/test_views/__init__.py
@@ -148,7 +148,7 @@ class AuthTestMixin(MockApiTestMixin, PermissionsTestMixin, RedirectTestCaseMixi
             },
             'results': []
         }
-        mock_client.return_value.courses.return_value.get.return_value = mock_course_response
+        mock_client.return_value.course_ids.return_value.get.return_value = mock_course_response
         hour_expiration_datetime = datetime.utcnow() + timedelta(hours=1)
         mock_client.get_and_cache_jwt_oauth_access_token.return_value = ('test-access-token', hour_expiration_datetime)
 

--- a/analytics_dashboard/settings/test.py
+++ b/analytics_dashboard/settings/test.py
@@ -30,7 +30,7 @@ GRADING_POLICY_API_URL = 'http://grading-policy-api-host'
 BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL='http://provider-host/oauth2'
 BACKEND_SERVICE_EDX_OAUTH2_KEY='test_backend_oauth2_key'
 BACKEND_SERVICE_EDX_OAUTH2_SECRET='test_backend_oauth2_secret'
-COURSE_API_URL = 'http://course-api-host/courses'
+COURSE_API_URL = 'http://course-api-host/course_ids'
 COURSE_API_KEY = 'test_course_api_key'
 
 DATA_API_URL = 'http://data-api-host/api/v0'


### PR DESCRIPTION
Switches the permission check endpoint from /courses to /course_ids to
get the list of course_ids for which the user has staff permissions.

The /courses endpoint was not performant enough.

BOM-897