### PR TITLE
BOM-1152: switch to OAuthAPIClient for permissions

### DIFF
--- a/analytics_dashboard/courses/exceptions.py
+++ b/analytics_dashboard/courses/exceptions.py
@@ -18,13 +18,8 @@ class UserNotAssociatedWithBackendError(PermissionsError):
 class InvalidAccessTokenError(PermissionsError):
     """
     Raise if user has an empty or otherwise invalid access token.
-    """
-    pass
 
-
-class AccessTokenRetrievalFailedError(PermissionsError):
-    """
-    Raise if access token retrieval fails (e.g. the backend is unreachable).
+    Deprecated: This should removed when OIDC code is removed.
     """
     pass
 

--- a/analytics_dashboard/courses/tests/test_views/__init__.py
+++ b/analytics_dashboard/courses/tests/test_views/__init__.py
@@ -35,7 +35,7 @@ class CourseAPIMixin(object):
     """
     COURSE_BLOCKS_API_TEMPLATE = \
         settings.COURSE_API_URL + \
-        '/blocks/?course_id={course_id}&requested_fields=children,graded&depth=all&all_blocks=true'
+        'blocks/?course_id={course_id}&requested_fields=children,graded&depth=all&all_blocks=true'
     GRADING_POLICY_API_TEMPLATE = settings.GRADING_POLICY_API_URL + '/policy/courses/{course_id}/'
 
     def mock_course_api(self, url, body=None, **kwargs):
@@ -65,7 +65,7 @@ class CourseAPIMixin(object):
         logger.debug('Mocking Course API URL: %s', url)
 
     def mock_course_detail(self, course_id, extra=None):
-        path = '{api}/courses/{course_id}/'.format(api=settings.COURSE_API_URL, course_id=course_id)
+        path = '{api}courses/{course_id}/'.format(api=settings.COURSE_API_URL, course_id=course_id)
         body = {'id': course_id, 'name': mock_course_name(course_id)}
         if extra:
             body.update(extra)
@@ -121,7 +121,7 @@ class AuthTestMixin(MockApiTestMixin, PermissionsTestMixin, RedirectTestCaseMixi
                 self.assertRedirectsNoFollow(response, settings.LOGIN_URL, next=self.path(course_id=course_id))
 
     @data(CourseSamples.DEMO_COURSE_ID, CourseSamples.DEPRECATED_DEMO_COURSE_ID)
-    @mock.patch('courses.permissions.EdxRestApiClient')
+    @mock.patch('courses.permissions.OAuthAPIClient')
     def test_authorization(self, course_id, mock_client):
         """
         Users must be authorized to view a course in order to view the course pages.
@@ -141,16 +141,13 @@ class AuthTestMixin(MockApiTestMixin, PermissionsTestMixin, RedirectTestCaseMixi
                 self.assertEqual(response.status_code, 403)
 
     def _prepare_mock_client_to_return_empty_permissions(self, mock_client):
-        """ Provided a mock of EdxRestApiClient, prepare it to return empty permissions """
-        mock_course_response = {
+        """ Provided a mock of OAuthAPIClient, prepare it to return empty permissions """
+        mock_client.get.return_value = {
             'pagination': {
                 'next': None
             },
             'results': []
         }
-        mock_client.return_value.course_ids.return_value.get.return_value = mock_course_response
-        hour_expiration_datetime = datetime.utcnow() + timedelta(hours=1)
-        mock_client.get_and_cache_jwt_oauth_access_token.return_value = ('test-access-token', hour_expiration_datetime)
 
 
 # pylint: disable=abstract-method

--- a/analytics_dashboard/settings/test.py
+++ b/analytics_dashboard/settings/test.py
@@ -30,7 +30,7 @@ GRADING_POLICY_API_URL = 'http://grading-policy-api-host'
 BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL='http://provider-host/oauth2'
 BACKEND_SERVICE_EDX_OAUTH2_KEY='test_backend_oauth2_key'
 BACKEND_SERVICE_EDX_OAUTH2_SECRET='test_backend_oauth2_secret'
-COURSE_API_URL = 'http://course-api-host/course_ids'
+COURSE_API_URL = 'http://course-api-host/api/courses/v1/'
 COURSE_API_KEY = 'test_course_api_key'
 
 DATA_API_URL = 'http://data-api-host/api/v0'


### PR DESCRIPTION
This updates from the deprecated EdxRestApiClient to the newer
OAuthAPIClient, **only** in the newly added code for permissions.

The deprecated EdxRestApiClient is still in use in other parts of
Insights.

BOM-1152