### PR TITLE
[BD]Constrain python-openid and wrapt

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -55,7 +55,7 @@ pyjwkest==1.3.2           # via edx-drf-extensions
 pyjwt==1.7.1              # via djangorestframework-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pymongo==3.10.1           # via edx-opaque-keys
 python-dateutil==2.8.1    # via edx-drf-extensions
-python-openid==2.2.5      # via social-auth-core
+python-openid==2.2.5 ; python_version == "2.7"  # via -c requirements/constraints.txt, social-auth-core
 pytz==2019.3              # via django
 pyyaml==5.3               # via edx-django-release-util, edx-i18n-tools
 regex==2020.2.20          # via awesome-slugify

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -27,3 +27,9 @@ django-countries<6.0.0
 
 # django-crispy-forms version 1.9.0 dropped support to Python 2.7
 django-crispy-forms<1.9.0
+
+# This only works on python 2.7.
+python-openid; python_version == "2.7"
+
+# Running in python3 astroid 2.3.3 has requirement wrapt==1.11.*
+wrapt>=1.12.0 ; python_version<"3"

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -31,5 +31,5 @@ django-crispy-forms<1.9.0
 # This only works on python 2.7.
 python-openid; python_version == "2.7"
 
-# Running in python3 astroid 2.3.3 has requirement wrapt==1.11.*
-wrapt>=1.12.0 ; python_version<"3"
+# Constraint from astroid 2.3.3
+wrapt==1.11.*

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -61,7 +61,7 @@ pyjwkest==1.3.2           # via -r requirements/base.txt, edx-drf-extensions
 pyjwt==1.7.1              # via -r requirements/base.txt, djangorestframework-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pymongo==3.10.1           # via -r requirements/base.txt, edx-opaque-keys
 python-dateutil==2.8.1    # via -r requirements/base.txt, edx-drf-extensions
-python-openid==2.2.5      # via -r requirements/base.txt, social-auth-core
+python-openid==2.2.5 ; python_version == "2.7"  # via -c requirements/constraints.txt, -r requirements/base.txt, social-auth-core
 pytz==2019.3              # via -r requirements/base.txt, babel, django
 pyyaml==5.3               # via -r requirements/base.txt, edx-django-release-util, edx-i18n-tools
 regex==2020.2.20          # via -r requirements/base.txt, awesome-slugify

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -93,7 +93,7 @@ pytest-cov==2.8.1         # via -r requirements/test.txt
 pytest-django==3.8.0      # via -r requirements/test.txt
 pytest==4.6.9             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/test.txt, edx-drf-extensions
-python-openid==2.2.5      # via -r requirements/test.txt, social-auth-core
+python-openid==2.2.5 ; python_version == "2.7"  # via -c requirements/constraints.txt, -r requirements/test.txt, social-auth-core
 pytz==2019.3              # via -r requirements/test.txt, django
 pyyaml==5.3               # via -r requirements/test.txt, edx-django-release-util, edx-i18n-tools
 regex==2020.2.20          # via -r requirements/test.txt, awesome-slugify
@@ -120,7 +120,7 @@ unidecode==0.4.21         # via -r requirements/test.txt, awesome-slugify
 unittest2==1.1.0          # via -r requirements/test.txt
 urllib3==1.25.8           # via -r requirements/test.txt, elasticsearch, requests, transifex-client
 wcwidth==0.1.8            # via -r requirements/test.txt, curtsies, pytest
-wrapt==1.12.0             # via -r requirements/test.txt, astroid
+wrapt==1.12.0 ; python_version < "3"  # via -c requirements/constraints.txt, -r requirements/test.txt, astroid
 zipp==1.2.0               # via -r requirements/test.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -120,7 +120,7 @@ unidecode==0.4.21         # via -r requirements/test.txt, awesome-slugify
 unittest2==1.1.0          # via -r requirements/test.txt
 urllib3==1.25.8           # via -r requirements/test.txt, elasticsearch, requests, transifex-client
 wcwidth==0.1.8            # via -r requirements/test.txt, curtsies, pytest
-wrapt==1.12.0 ; python_version < "3"  # via -c requirements/constraints.txt, -r requirements/test.txt, astroid
+wrapt==1.11.2             # via -c requirements/constraints.txt, -r requirements/test.txt, astroid
 zipp==1.2.0               # via -r requirements/test.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -59,7 +59,7 @@ pyjwt==1.7.1              # via -r requirements/base.txt, djangorestframework-jw
 pymongo==3.10.1           # via -r requirements/base.txt, edx-opaque-keys
 python-dateutil==2.8.1    # via -r requirements/base.txt, edx-drf-extensions
 python-memcached==1.58    # via -r requirements/production.in
-python-openid==2.2.5      # via -r requirements/base.txt, social-auth-core
+python-openid==2.2.5 ; python_version == "2.7"  # via -c requirements/constraints.txt, -r requirements/base.txt, social-auth-core
 pytz==2019.3              # via -r requirements/base.txt, django
 pyyaml==5.3               # via -r requirements/base.txt, -r requirements/production.in, edx-django-release-util, edx-i18n-tools
 regex==2020.2.20          # via -r requirements/base.txt, awesome-slugify

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -115,7 +115,7 @@ unidecode==0.4.21         # via -r requirements/base.txt, awesome-slugify
 unittest2==1.1.0          # via -r requirements/test.in
 urllib3==1.25.8           # via -r requirements/base.txt, elasticsearch, requests
 wcwidth==0.1.8            # via -r requirements/base.txt, curtsies, pytest
-wrapt==1.12.0 ; python_version < "3"  # via -c requirements/constraints.txt, astroid
+wrapt==1.11.2             # via -c requirements/constraints.txt, astroid
 zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -90,7 +90,7 @@ pytest-cov==2.8.1         # via -r requirements/test.in
 pytest-django==3.8.0      # via -r requirements/test.in
 pytest==4.6.9             # via -r requirements/test.in, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/base.txt, edx-drf-extensions
-python-openid==2.2.5      # via -r requirements/base.txt, social-auth-core
+python-openid==2.2.5 ; python_version == "2.7"  # via -c requirements/constraints.txt, -r requirements/base.txt, social-auth-core
 pytz==2019.3              # via -r requirements/base.txt, django
 pyyaml==5.3               # via -r requirements/base.txt, edx-django-release-util, edx-i18n-tools
 regex==2020.2.20          # via -r requirements/base.txt, awesome-slugify
@@ -115,7 +115,7 @@ unidecode==0.4.21         # via -r requirements/base.txt, awesome-slugify
 unittest2==1.1.0          # via -r requirements/test.in
 urllib3==1.25.8           # via -r requirements/base.txt, elasticsearch, requests
 wcwidth==0.1.8            # via -r requirements/base.txt, curtsies, pytest
-wrapt==1.12.0             # via astroid
+wrapt==1.12.0 ; python_version < "3"  # via -c requirements/constraints.txt, astroid
 zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
## Description 
Constrain python-openid, this should be replace by python3-openid. 
Constrain wrapt, astroid 2.3.3 has requirement wrapt==1.11.*, https://openedx.atlassian.net/browse/BOM-1360

### Reviewers
- [x] @morenol 
- [x]  Is this ready for edX's review? 
- [ ] @jmbowman 
 
### Post-review
- [ ] Rebase and squash commits