### PR TITLE
[BD] Upgrade django-waffle 

### DIFF
--- a/analytics_dashboard/core/tests/test_views.py
+++ b/analytics_dashboard/core/tests/test_views.py
@@ -23,7 +23,7 @@ from courses.permissions import (get_user_course_permissions,
 User = get_user_model()
 
 
-class UserTestCaseMixin(TestCase):
+class UserTestCaseMixin(object):
     PASSWORD = 'password'
 
     def get_user(self):

--- a/analytics_dashboard/core/tests/test_views.py
+++ b/analytics_dashboard/core/tests/test_views.py
@@ -23,7 +23,7 @@ from courses.permissions import (get_user_course_permissions,
 User = get_user_model()
 
 
-class UserTestCaseMixin(object):
+class UserTestCaseMixin(TestCase):
     PASSWORD = 'password'
 
     def get_user(self):

--- a/analytics_dashboard/courses/tests/test_views/__init__.py
+++ b/analytics_dashboard/courses/tests/test_views/__init__.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 
 @override_switch('enable_course_api', active=True)
-class CourseAPIMixin(object):
+class CourseAPIMixin(TestCase):
     """
     Mixin with methods to help mock the course API.
     """

--- a/analytics_dashboard/courses/tests/test_views/__init__.py
+++ b/analytics_dashboard/courses/tests/test_views/__init__.py
@@ -29,8 +29,7 @@ from courses.tests.utils import (
 logger = logging.getLogger(__name__)
 
 
-@override_switch('enable_course_api', active=True)
-class CourseAPIMixin(TestCase):
+class CourseAPIMixin(object):
     """
     Mixin with methods to help mock the course API.
     """

--- a/analytics_dashboard/courses/tests/test_views/test_engagement.py
+++ b/analytics_dashboard/courses/tests/test_views/test_engagement.py
@@ -20,7 +20,6 @@ from courses.tests.test_views import (
 from courses.tests.utils import CourseSamples
 
 
-@override_switch('enable_engagement_videos_pages', active=True)
 class CourseEngagementViewTestMixin(PatchMixin, CourseAPIMixin):  # pylint: disable=abstract-method
     api_method = 'analyticsclient.course.Course.activity'
     active_secondary_nav_label = None
@@ -83,6 +82,7 @@ class CourseEngagementViewTestMixin(PatchMixin, CourseAPIMixin):  # pylint: disa
 
 
 @override_switch('enable_engagement_videos_pages', active=True)
+@override_switch('enable_course_api', active=True)
 @ddt
 class CourseEngagementContentViewTests(CourseViewTestMixin, CourseEngagementViewTestMixin, TestCase):
     viewname = 'courses:engagement:content'
@@ -147,7 +147,6 @@ class CourseEngagementContentViewTests(CourseViewTestMixin, CourseEngagementView
         self.assertIsNone(context['js_data']['course']['engagementTrends'])
 
 
-@override_switch('enable_engagement_videos_pages', active=True)
 @ddt
 class CourseEngagementVideoMixin(CourseEngagementViewTestMixin, CourseStructureViewMixin):
     active_secondary_nav_label = 'Video'
@@ -203,10 +202,14 @@ class CourseEngagementVideoMixin(CourseEngagementViewTestMixin, CourseStructureV
         self.assertEqual(response.status_code, 200)
 
 
+@override_switch('enable_engagement_videos_pages', active=True)
+@override_switch('enable_course_api', active=True)
 class EngagementVideoCourseTest(CourseEngagementVideoMixin, TestCase):
     viewname = 'courses:engagement:videos'
 
 
+@override_switch('enable_engagement_videos_pages', active=True)
+@override_switch('enable_course_api', active=True)
 class EngagementVideoCourseSectionTest(CourseEngagementVideoMixin, TestCase):
     viewname = 'courses:engagement:video_section'
 
@@ -233,6 +236,8 @@ class EngagementVideoCourseSectionTest(CourseEngagementVideoMixin, TestCase):
         self.assertEqual(response.status_code, 404)
 
 
+@override_switch('enable_engagement_videos_pages', active=True)
+@override_switch('enable_course_api', active=True)
 class EngagementVideoCourseSubsectionTest(CourseEngagementVideoMixin, TestCase):
     viewname = 'courses:engagement:video_subsection'
 
@@ -263,6 +268,8 @@ class EngagementVideoCourseSubsectionTest(CourseEngagementVideoMixin, TestCase):
         self.assertEqual(response.status_code, 404)
 
 
+@override_switch('enable_engagement_videos_pages', active=True)
+@override_switch('enable_course_api', active=True)
 class EngagementVideoCourseTimelineTest(CourseEngagementVideoMixin, TestCase):
     viewname = 'courses:engagement:video_timeline'
 

--- a/analytics_dashboard/courses/tests/test_views/test_performance.py
+++ b/analytics_dashboard/courses/tests/test_views/test_performance.py
@@ -496,7 +496,6 @@ class CoursePerformanceUngradedSubsectionViewTests(CoursePerformanceUngradedMixi
         self.assertEqual(response.status_code, 404)
 
 
-@override_switch('enable_course_api', active=True)
 class CoursePerformanceLearningOutcomesViewTestMixin(CoursePerformanceViewTestMixin):
 
     tags_factory = None
@@ -547,6 +546,7 @@ class CoursePerformanceLearningOutcomesViewTestMixin(CoursePerformanceViewTestMi
         pass
 
 
+@override_switch('enable_course_api', active=True)
 class CoursePerformanceLearningOutcomesContentViewTests(CoursePerformanceLearningOutcomesViewTestMixin, TestCase):
     viewname = 'courses:performance:learning_outcomes'
     tags_factory_init_data = [{"total_submissions": 21, "correct_submissions": 5,
@@ -570,6 +570,7 @@ class CoursePerformanceLearningOutcomesContentViewTests(CoursePerformanceLearnin
             super(CoursePerformanceLearningOutcomesContentViewTests, self).test_valid_course()
 
 
+@override_switch('enable_course_api', active=True)
 class CoursePerformanceLearningOutcomesSectionViewTests(CoursePerformanceLearningOutcomesViewTestMixin, TestCase):
     viewname = 'courses:performance:learning_outcomes_section'
     tags_factory_init_data = [{"total_submissions": 41, "correct_submissions": 10,
@@ -610,6 +611,7 @@ class CoursePerformanceLearningOutcomesSectionViewTests(CoursePerformanceLearnin
                 super(CoursePerformanceLearningOutcomesSectionViewTests, self).test_valid_course()
 
 
+@override_switch('enable_course_api', active=True)
 class CoursePerformanceLearningOutcomesAnswersDistributionViewTests(
         CoursePerformanceAnswerDistributionMixin,
         CoursePerformanceLearningOutcomesViewTestMixin,

--- a/analytics_dashboard/learner_analytics_api/v0/tests/test_views.py
+++ b/analytics_dashboard/learner_analytics_api/v0/tests/test_views.py
@@ -14,7 +14,6 @@ from core.tests.test_views import UserTestCaseMixin
 from courses.tests.test_views import PermissionsTestMixin
 
 
-@override_flag('display_learner_analytics', active=True)
 @ddt.ddt
 class LearnerAPITestMixin(UserTestCaseMixin, PermissionsTestMixin):
     """
@@ -80,6 +79,7 @@ class LearnerAPITestMixin(UserTestCaseMixin, PermissionsTestMixin):
         self.assert_response_equals(response, status_code, body)
 
 
+@override_flag('display_learner_analytics', active=True)
 class LearnerDetailViewTestCase(LearnerAPITestMixin, TestCase):
     endpoint = '/learners/username/'
     required_query_params = {'course_id': 'edX/DemoX/Demo_Course'}
@@ -94,6 +94,7 @@ class LearnerDetailViewTestCase(LearnerAPITestMixin, TestCase):
         })
 
 
+@override_flag('display_learner_analytics', active=True)
 class LearnerListViewTestCase(LearnerAPITestMixin, TestCase):
     endpoint = '/learners/'
     required_query_params = {'course_id': 'edX/DemoX/Demo_Course'}
@@ -130,6 +131,7 @@ class LearnerListCSVTestCase(LearnerListViewTestCase):
         self.assertEquals(response['Content-Disposition'], content_disposition)
 
 
+@override_flag('display_learner_analytics', active=True)
 class EngagementTimelinesViewTestCase(LearnerAPITestMixin, TestCase):
     endpoint = '/engagement_timelines/username/'
     required_query_params = {'course_id': 'edX/DemoX/Demo_Course'}
@@ -145,6 +147,7 @@ class EngagementTimelinesViewTestCase(LearnerAPITestMixin, TestCase):
         })
 
 
+@override_flag('display_learner_analytics', active=True)
 class CourseLearnerMetadataViewTestCase(LearnerAPITestMixin, TestCase):
     endpoint = '/course_learner_metadata/edX/DemoX/Demo_Course/'
     no_permissions_status_code = 403

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -14,7 +14,7 @@ django-lang-pref-middleware
 # Dependency of djangorestframework
 django-crispy-forms     				# MIT
 django-soapbox==1.3						# BSD
-django-waffle==0.12.0					# BSD
+django-waffle       					# BSD
 pinax-announcements==2.0.4				# MIT
 edx-auth-backends
 edx-ccx-keys

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ django-countries==5.5     # via -c requirements/constraints.txt, -r requirements
 django-crispy-forms==1.8.1  # via -c requirements/constraints.txt, -r requirements/base.in
 django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/base.in
 django-soapbox==1.3       # via -r requirements/base.in
-django-waffle==0.17.0     # via -c requirements/constraints.txt, -r requirements/base.in, edx-django-utils, edx-drf-extensions
+django-waffle==0.18.0     # via -c requirements/constraints.txt, -r requirements/base.in, edx-django-utils, edx-drf-extensions
 django-webpack-loader==0.4.1  # via -r requirements/base.in
 django==1.11.29           # via -c requirements/constraints.txt, -r requirements/base.in, django-appconf, django-braces, django-model-utils, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, rest-condition
 djangorestframework-csv==2.0.0  # via -r requirements/base.in

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ django-countries==5.5     # via -c requirements/constraints.txt, -r requirements
 django-crispy-forms==1.8.1  # via -c requirements/constraints.txt, -r requirements/base.in
 django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/base.in
 django-soapbox==1.3       # via -r requirements/base.in
-django-waffle==0.12.0     # via -r requirements/base.in, edx-django-utils, edx-drf-extensions
+django-waffle==0.17.0     # via -c requirements/constraints.txt, -r requirements/base.in, edx-django-utils, edx-drf-extensions
 django-webpack-loader==0.4.1  # via -r requirements/base.in
 django==1.11.29           # via -c requirements/constraints.txt, -r requirements/base.in, django-appconf, django-braces, django-model-utils, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, rest-condition
 djangorestframework-csv==2.0.0  # via -r requirements/base.in

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -34,8 +34,8 @@ django-crispy-forms<1.9.0
 # 4.0.0 drops Python 2.7 support
 django-model-utils<4.0.0
 
-# 0.18.0 drops Python 2.7 support
-django-waffle<0.18.0
+# Dropped support for Django 2.
+django-waffle<0.19.0
 
 # 3.0.0 drops Python 2.7 support
 edx-django-utils<3.0.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -34,6 +34,9 @@ django-crispy-forms<1.9.0
 # 4.0.0 drops Python 2.7 support
 django-model-utils<4.0.0
 
+# 0.18.0 drops Python 2.7 support
+django-waffle<0.18.0
+
 # 3.0.0 drops Python 2.7 support
 edx-django-utils<3.0.0
 

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -22,7 +22,7 @@ django-countries==5.5     # via -c requirements/constraints.txt, -r requirements
 django-crispy-forms==1.8.1  # via -c requirements/constraints.txt, -r requirements/base.txt
 django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/base.txt
 django-soapbox==1.3       # via -r requirements/base.txt
-django-waffle==0.12.0     # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
+django-waffle==0.17.0     # via -c requirements/constraints.txt, -r requirements/base.txt, edx-django-utils, edx-drf-extensions
 django-webpack-loader==0.4.1  # via -r requirements/base.txt
 django==1.11.29           # via -c requirements/constraints.txt, -r requirements/base.txt, django-appconf, django-braces, django-model-utils, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, rest-condition
 djangorestframework-csv==2.0.0  # via -r requirements/base.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -22,7 +22,7 @@ django-countries==5.5     # via -c requirements/constraints.txt, -r requirements
 django-crispy-forms==1.8.1  # via -c requirements/constraints.txt, -r requirements/base.txt
 django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/base.txt
 django-soapbox==1.3       # via -r requirements/base.txt
-django-waffle==0.17.0     # via -c requirements/constraints.txt, -r requirements/base.txt, edx-django-utils, edx-drf-extensions
+django-waffle==0.18.0     # via -c requirements/constraints.txt, -r requirements/base.txt, edx-django-utils, edx-drf-extensions
 django-webpack-loader==0.4.1  # via -r requirements/base.txt
 django==1.11.29           # via -c requirements/constraints.txt, -r requirements/base.txt, django-appconf, django-braces, django-model-utils, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, rest-condition
 djangorestframework-csv==2.0.0  # via -r requirements/base.txt

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -31,7 +31,7 @@ django-debug-toolbar==1.8  # via -r requirements/local.in
 django-dynamic-fixture==3.0.3  # via -r requirements/test.txt
 django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/test.txt
 django-soapbox==1.3       # via -r requirements/test.txt
-django-waffle==0.17.0     # via -c requirements/constraints.txt, -r requirements/test.txt, edx-django-utils, edx-drf-extensions
+django-waffle==0.18.0     # via -c requirements/constraints.txt, -r requirements/test.txt, edx-django-utils, edx-drf-extensions
 django-webpack-loader==0.4.1  # via -r requirements/test.txt
 django==1.11.29           # via -c requirements/constraints.txt, -r requirements/test.txt, django-appconf, django-braces, django-debug-toolbar, django-model-utils, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, rest-condition
 djangorestframework-csv==2.0.0  # via -r requirements/test.txt

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -31,7 +31,7 @@ django-debug-toolbar==1.8  # via -r requirements/local.in
 django-dynamic-fixture==3.0.3  # via -r requirements/test.txt
 django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/test.txt
 django-soapbox==1.3       # via -r requirements/test.txt
-django-waffle==0.12.0     # via -r requirements/test.txt, edx-django-utils, edx-drf-extensions
+django-waffle==0.17.0     # via -c requirements/constraints.txt, -r requirements/test.txt, edx-django-utils, edx-drf-extensions
 django-webpack-loader==0.4.1  # via -r requirements/test.txt
 django==1.11.29           # via -c requirements/constraints.txt, -r requirements/test.txt, django-appconf, django-braces, django-debug-toolbar, django-model-utils, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, rest-condition
 djangorestframework-csv==2.0.0  # via -r requirements/test.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -20,7 +20,7 @@ django-countries==5.5     # via -c requirements/constraints.txt, -r requirements
 django-crispy-forms==1.8.1  # via -c requirements/constraints.txt, -r requirements/base.txt
 django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/base.txt
 django-soapbox==1.3       # via -r requirements/base.txt
-django-waffle==0.12.0     # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
+django-waffle==0.17.0     # via -c requirements/constraints.txt, -r requirements/base.txt, edx-django-utils, edx-drf-extensions
 django-webpack-loader==0.4.1  # via -r requirements/base.txt
 django==1.11.29           # via -c requirements/constraints.txt, -r requirements/base.txt, django-appconf, django-braces, django-model-utils, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, rest-condition
 djangorestframework-csv==2.0.0  # via -r requirements/base.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -20,7 +20,7 @@ django-countries==5.5     # via -c requirements/constraints.txt, -r requirements
 django-crispy-forms==1.8.1  # via -c requirements/constraints.txt, -r requirements/base.txt
 django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/base.txt
 django-soapbox==1.3       # via -r requirements/base.txt
-django-waffle==0.17.0     # via -c requirements/constraints.txt, -r requirements/base.txt, edx-django-utils, edx-drf-extensions
+django-waffle==0.18.0     # via -c requirements/constraints.txt, -r requirements/base.txt, edx-django-utils, edx-drf-extensions
 django-webpack-loader==0.4.1  # via -r requirements/base.txt
 django==1.11.29           # via -c requirements/constraints.txt, -r requirements/base.txt, django-appconf, django-braces, django-model-utils, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, rest-condition
 djangorestframework-csv==2.0.0  # via -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -29,7 +29,7 @@ django-crispy-forms==1.8.1  # via -c requirements/constraints.txt, -r requiremen
 django-dynamic-fixture==3.0.3  # via -r requirements/test.in
 django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/base.txt
 django-soapbox==1.3       # via -r requirements/base.txt
-django-waffle==0.12.0     # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
+django-waffle==0.17.0     # via -c requirements/constraints.txt, -r requirements/base.txt, edx-django-utils, edx-drf-extensions
 django-webpack-loader==0.4.1  # via -r requirements/base.txt
 django==1.11.29           # via -c requirements/constraints.txt, -r requirements/base.txt, django-appconf, django-braces, django-model-utils, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, rest-condition
 djangorestframework-csv==2.0.0  # via -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -29,7 +29,7 @@ django-crispy-forms==1.8.1  # via -c requirements/constraints.txt, -r requiremen
 django-dynamic-fixture==3.0.3  # via -r requirements/test.in
 django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/base.txt
 django-soapbox==1.3       # via -r requirements/base.txt
-django-waffle==0.17.0     # via -c requirements/constraints.txt, -r requirements/base.txt, edx-django-utils, edx-drf-extensions
+django-waffle==0.18.0     # via -c requirements/constraints.txt, -r requirements/base.txt, edx-django-utils, edx-drf-extensions
 django-webpack-loader==0.4.1  # via -r requirements/base.txt
 django==1.11.29           # via -c requirements/constraints.txt, -r requirements/base.txt, django-appconf, django-braces, django-model-utils, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, rest-condition
 djangorestframework-csv==2.0.0  # via -r requirements/base.txt


### PR DESCRIPTION
## Description 
This is a simple upgrade to 0.17.0, however in django-waffle changed the way how the override decorator were defined, They now are inheriting from `TestContextDecorator`(https://github.com/django-waffle/django-waffle/blob/master/waffle/testutils.py#L12), this raises the following error when we execute the tests.
`raise TypeError('Can only decorate subclasses of unittest.TestCase')`

that is way all the statements like `@override_switch...`, were relocated to the test class 

part of https://openedx.atlassian.net/browse/BOM-1360

### Reviewers
- [x] @morenol 
- [x]  Is this ready for edX's review? 
- [ ] @jmbowman 
 
### Post-review
- [ ] Rebase and squash commits