### PR TITLE
[BD]Decode the response content.

### DIFF
--- a/analytics_dashboard/core/tests/test_views.py
+++ b/analytics_dashboard/core/tests/test_views.py
@@ -74,7 +74,7 @@ class ViewTests(TestCase):
                 u'database_connection': database_connection,
             }
         }
-        self.assertDictEqual(json.loads(response.content), expected)
+        self.assertDictEqual(json.loads(response.content.decode()), expected)
 
     def test_status(self):
         response = self.client.get(reverse('status'))

--- a/analytics_dashboard/courses/tests/test_views/test_csv.py
+++ b/analytics_dashboard/courses/tests/test_views/test_csv.py
@@ -44,7 +44,7 @@ class CourseCSVTestMixin(ViewTestMixin):
         self.assertResponseFilename(response, filename)
 
         # Check data
-        self.assertEqual(response.content, csv_data)
+        self.assertEqual(response.content.decode(), csv_data)
 
     def assertResponseContentType(self, response, content_type):
         self.assertEqual(response['Content-Type'], content_type)
@@ -238,7 +238,7 @@ class CourseIndexCSVTests(ViewTestMixin, TestCase):
         self.assertResponseFilename(response, filename)
 
         # Check data
-        self.assertEqual(response.content, csv_data)
+        self.assertEqual(response.content.decode(), csv_data)
 
     def assertResponseContentType(self, response, content_type):
         self.assertEqual(response['Content-Type'], content_type)

--- a/analytics_dashboard/learner_analytics_api/v0/tests/test_views.py
+++ b/analytics_dashboard/learner_analytics_api/v0/tests/test_views.py
@@ -46,7 +46,7 @@ class LearnerAPITestMixin(UserTestCaseMixin, PermissionsTestMixin):
     def assert_response_equals(self, response, expected_status_code, expected_body=None):
         self.assertEqual(response.status_code, expected_status_code)
         if expected_body is not None:
-            self.assertEqual(json.loads(response.content), expected_body)
+            self.assertEqual(json.loads(response.content.decode()), expected_body)
 
     def test_not_authenticated(self):
         response = self.client.get('/api/learner_analytics/v0' + self.endpoint, self.required_query_params)


### PR DESCRIPTION
## Description 
response.content returns a bytes like object in Python 3.x instead of str, therefore the dictionary elements will never be equals, these changes decodes it to string.
part of https://openedx.atlassian.net/browse/BOM-1360

### Reviewers
- [x] @morenol 
- [x]  Is this ready for edX's review? 
- [ ] @jmbowman 
 
### Post-review
- [ ] Rebase and squash commits