### PR TITLE
[BD] Add assertCountEqual.

### DIFF
--- a/analytics_dashboard/courses/tests/test_permissions.py
+++ b/analytics_dashboard/courses/tests/test_permissions.py
@@ -115,7 +115,7 @@ class PermissionsTests(TestCase):
         expected_calls = self._setup_mock_course_ids_responses_and_expects(mock_client, course_ids, page_size=page_size)
 
         # Check permissions
-        self.assertItemsEqual(permissions.get_user_course_permissions(self.user), course_ids)
+        assertCountEqual(self, permissions.get_user_course_permissions(self.user), course_ids)
         assertCountEqual(self, expected_calls, mock_client.mock_calls)
 
         # Check newly permitted course is not returned because the earlier permissions are cached

--- a/analytics_dashboard/courses/tests/test_presenters/test_course_summaries.py
+++ b/analytics_dashboard/courses/tests/test_presenters/test_course_summaries.py
@@ -1,11 +1,11 @@
 from __future__ import absolute_import
 
 import mock
+import six
 from ddt import data, ddt, unpack
 from django.conf import settings
 from django.core.cache import cache
 from django.test import TestCase
-from six.moves import zip
 
 from courses.presenters.course_summaries import CourseSummariesPresenter
 from courses.tests import utils
@@ -224,8 +224,8 @@ class CourseSummariesPresenterTests(TestCase):
         with mock.patch('analyticsclient.course_summaries.CourseSummaries.course_summaries',
                         mock.Mock(return_value=mock_api_response)):
             actual_summaries, last_updated = presenter.get_course_summaries(course_ids=input_course_ids)
-            for actual, expected in zip(actual_summaries, expected_summaries):
-                self.assertItemsEqual(actual, expected)
+            for actual, expected in six.moves.zip(actual_summaries, expected_summaries):
+                six.assertCountEqual(self, actual, expected)
             self.assertEqual(last_updated, utils.CREATED_DATETIME)
 
     def test_no_summaries(self):


### PR DESCRIPTION
## Description 
Run modernize does not update all the statements automatically, therefore some statements should be updated manually, in order to add the compatibility to python 3.
Part of https://openedx.atlassian.net/browse/BOM-1360

### Reviewers
- [x] @morenol 
- [x]  Is this ready for edX's review? 
- [ ] @jmbowman 
 
### Post-review
- [ ] Rebase and squash commits