### PR TITLE
[BD] Remove invalid comparation.

### DIFF
--- a/analytics_dashboard/courses/presenters/engagement.py
+++ b/analytics_dashboard/courses/presenters/engagement.py
@@ -220,7 +220,7 @@ class CourseEngagementVideoPresenter(CourseAPIPresenterMixin, CoursePresenter):
             })
 
         # including the URL enables navigation to child pages
-        if url_func > 0 and has_views:
+        if url_func and has_views:
             parent['url'] = url_func(parent)
 
     def build_section_url(self, section):


### PR DESCRIPTION
## Description 
Compare a function with an int is not allowed in python 3.
Part of .https://openedx.atlassian.net/browse/BOM-1360

### Reviewers
- [x] @morenol 
- [x]  Is this ready for edX's review? 
- [ ] @jmbowman 
 
### Post-review
- [ ] Rebase and squash commits