### PR TITLE
[BD] Constraint astroid

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -13,6 +13,9 @@
 # Django 2 drops Python 2.7 support
 Django<2.0.0
 
+# Major version to 2.0.0 does not work with pylint<2.0.0
+astroid<2.0.0
+
 # 3.0.0 drops Python 2.7 support
 edx-django-utils<3.0.0
 

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -6,7 +6,7 @@
 #
 -e git+https://github.com/edx/django-lang-pref-middleware.git@0.1.0#egg=django-lang-pref-middleware  # via -r requirements/test.txt
 argparse==1.4.0           # via -r requirements/test.txt, unittest2
-astroid==1.6.6 ; python_version <= "3.4"  # via -r requirements/test.txt, pylint
+astroid==1.6.6            # via -c requirements/constraints.txt, -r requirements/test.txt, pylint
 atomicwrites==1.3.0       # via -r requirements/test.txt, pytest
 attrs==19.3.0             # via -r requirements/test.txt, pytest
 awesome-slugify==1.6.5    # via -r requirements/test.txt

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -18,8 +18,7 @@ logilab-common==1.4.0
 selenium>=2.44.0,<3.0.0
 sure
 testfixtures==4.14.3
-astroid<2.0 ; python_version<="3.4"
-astroid>=2.0 ; python_version>="3.4"
+astroid
 pytest
 pytest-cov
 pytest-django

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,7 +6,7 @@
 #
 -e git+https://github.com/edx/django-lang-pref-middleware.git@0.1.0#egg=django-lang-pref-middleware  # via -r requirements/base.txt
 argparse==1.4.0           # via unittest2
-astroid==1.6.6 ; python_version <= "3.4"  # via -r requirements/test.in, pylint
+astroid==1.6.6            # via -c requirements/constraints.txt, -r requirements/test.in, pylint
 atomicwrites==1.3.0       # via pytest
 attrs==19.3.0             # via pytest
 awesome-slugify==1.6.5    # via -r requirements/base.txt


### PR DESCRIPTION
## Description 
Constraint astroid. This change is necessary in python 3 because if we don't constraint astroid in python3 and install pylint, this will install the last astroid and this incompatible with the pylint version pinned.
Part of .https://openedx.atlassian.net/browse/BOM-1360

### Reviewers
- [x] @morenol 
- [x]  Is this ready for edX's review? 
- [ ] @jmbowman 
 
### Post-review
- [ ] Rebase and squash commits