### PR TITLE
[BD] Use the latest version of data api in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,22 +7,12 @@ services:
   - docker
 
 env:
-  # Make sure to update this string on every Insights or Data API release
-  DATA_API_VERSION: "0.28.0"
-  DOCKER_COMPOSE_VERSION: "1.9.0"
+  DATA_API_VERSION: "latest"
 
 before_install:
     # Fix intermittent "resource temporarily unavailable" and "write" errors failing the Travis builds.
     # See: https://github.com/travis-ci/travis-ci/issues/8920
     - python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
-    # pin to 9.0.3 until tox-battery upgrades
-    - pip install --upgrade pip==9.0.3
-    # Install a newer version of docker-compose
-    # Remove once dockers default is this version: https://docs.travis-ci.com/user/docker/#Using-Docker-Compose
-    - sudo rm /usr/local/bin/docker-compose
-    - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
-    - chmod +x docker-compose
-    - sudo mv docker-compose /usr/local/bin
 
     # Start up the relevant services
     - docker-compose -f .travis/docker-compose-travis.yml up -d

--- a/.travis/docker-compose-travis.yml
+++ b/.travis/docker-compose-travis.yml
@@ -10,7 +10,7 @@ services:
       ELASTICSEARCH_LEARNERS_HOST: 'http://es:9200/'
       ELASTICSEARCH_LEARNERS_INDEX: 'learner'
       ELASTICSEARCH_LEARNERS_UPDATE_INDEX: 'index_update'
-    command: /edx/app/analytics_api/venvs/analytics_api/bin/python /edx/app/analytics_api/analytics_api/manage.py runserver 0.0.0.0:80
+    command: /edx/app/analytics_api/venvs/analytics_api/bin/python /edx/app/analytics_api/analytics_api/manage.py runserver 0.0.0.0:80 --settings analyticsdataserver.settings.local
   insights:
     image: edxops/insights:latest
     container_name: insights_testing


### PR DESCRIPTION
## Description https://openedx.atlassian.net/browse/BOM-1359

The analytics_api image used for insights tests is pretty old https://github.com/edx/edx-analytics-data-api/tree/0.28.0

## Reviewers
 - [ ] @andrey-canon
 - [x] Is this ready for edX's review?
- [ ] @jmbowman 