### PR TITLE
[BD] Remove deprecated import from urlresolvers

### DIFF
--- a/analytics_dashboard/core/tests/test_views.py
+++ b/analytics_dashboard/core/tests/test_views.py
@@ -7,10 +7,10 @@ import mock
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
-from django.core.urlresolvers import reverse, reverse_lazy
 from django.db import DatabaseError
 from django.test import TestCase
 from django.test.utils import override_settings
+from django.urls import reverse, reverse_lazy
 from django.utils.http import urlquote
 from django_dynamic_fixture import G
 from testfixtures import LogCapture

--- a/analytics_dashboard/core/views.py
+++ b/analytics_dashboard/core/views.py
@@ -7,10 +7,10 @@ import uuid
 from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model, login
 from django.contrib.auth.views import LogoutView, logout_then_login
-from django.core.urlresolvers import reverse_lazy
 from django.db import DatabaseError, connection
 from django.http import Http404, HttpResponse
 from django.shortcuts import redirect
+from django.urls import reverse_lazy
 from django.views.generic import TemplateView, View
 
 from analytics_dashboard.courses import permissions

--- a/analytics_dashboard/courses/presenters/engagement.py
+++ b/analytics_dashboard/courses/presenters/engagement.py
@@ -7,7 +7,7 @@ import math
 import analyticsclient.constants.activity_types as AT
 from analyticsclient.client import Client
 from analyticsclient.exceptions import NotFoundError
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 from six.moves import range
 from waffle import switch_is_active

--- a/analytics_dashboard/courses/presenters/performance.py
+++ b/analytics_dashboard/courses/presenters/performance.py
@@ -7,7 +7,7 @@ import six
 from analyticsclient.exceptions import NotFoundError
 from django.conf import settings
 from django.core.cache import cache
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 from edx_rest_api_client.exceptions import HttpClientError
 from slugify import slugify

--- a/analytics_dashboard/courses/tests/test_presenters/test_presenters.py
+++ b/analytics_dashboard/courses/tests/test_presenters/test_presenters.py
@@ -9,8 +9,8 @@ from analyticsclient.constants import enrollment_modes
 from ddt import data, ddt, unpack
 from django.conf import settings
 from django.core.cache import cache
-from django.core.urlresolvers import reverse
 from django.test import TestCase, override_settings
+from django.urls import reverse
 from six.moves import zip
 from slugify import slugify
 from waffle.testutils import override_switch

--- a/analytics_dashboard/courses/tests/test_views/__init__.py
+++ b/analytics_dashboard/courses/tests/test_views/__init__.py
@@ -9,7 +9,7 @@ from ddt import data, ddt
 from django.conf import settings
 from django.contrib.humanize.templatetags.humanize import intcomma
 from django.core.cache import cache
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 from mock import Mock, patch
 from mock.mock import _is_started

--- a/analytics_dashboard/courses/tests/test_views/test_csv.py
+++ b/analytics_dashboard/courses/tests/test_views/test_csv.py
@@ -4,8 +4,8 @@ import mock
 import six
 from analyticsclient.exceptions import NotFoundError
 from ddt import data, ddt
-from django.core.urlresolvers import reverse
 from django.test import TestCase
+from django.urls import reverse
 from django.utils import timezone
 from waffle.testutils import override_switch
 

--- a/analytics_dashboard/courses/tests/test_views/test_engagement.py
+++ b/analytics_dashboard/courses/tests/test_views/test_engagement.py
@@ -3,8 +3,8 @@ from __future__ import absolute_import
 import analyticsclient.constants.activity_types as AT
 import httpretty
 from ddt import ddt
-from django.core.urlresolvers import reverse
 from django.test import TestCase
+from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 from mock import Mock, patch
 from waffle.testutils import override_switch

--- a/analytics_dashboard/courses/tests/test_views/test_performance.py
+++ b/analytics_dashboard/courses/tests/test_views/test_performance.py
@@ -7,8 +7,8 @@ import httpretty
 from analyticsclient.exceptions import ClientError, NotFoundError
 from ddt import ddt
 from django.conf import settings
-from django.core.urlresolvers import reverse
 from django.test import TestCase
+from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 from mock import Mock, patch
 from slugify import slugify

--- a/analytics_dashboard/courses/views/__init__.py
+++ b/analytics_dashboard/courses/views/__init__.py
@@ -13,8 +13,8 @@ from braces.views import LoginRequiredMixin
 from django.conf import settings
 from django.core.cache import cache
 from django.core.exceptions import PermissionDenied
-from django.core.urlresolvers import reverse
 from django.http import Http404
+from django.urls import reverse
 from django.utils import dateformat
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _

--- a/analytics_dashboard/courses/views/course_summaries.py
+++ b/analytics_dashboard/courses/views/course_summaries.py
@@ -4,8 +4,8 @@ import logging
 
 from braces.views import LoginRequiredMixin
 from django.core.exceptions import PermissionDenied
-from django.core.urlresolvers import reverse
 from django.http import Http404
+from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 from rest_framework_csv.renderers import CSVRenderer
 from waffle import switch_is_active

--- a/analytics_dashboard/courses/views/learners.py
+++ b/analytics_dashboard/courses/views/learners.py
@@ -4,7 +4,7 @@ import logging
 
 from six.moves.urllib.parse import urlencode
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from requests.exceptions import Timeout


### PR DESCRIPTION
## Description 
Import from django.urls instead of django.core.urlresolvers(deprecated)
Part of .https://openedx.atlassian.net/browse/BOM-1360

### Reviewers
- [x] @morenol 
- [x]  Is this ready for edX's review? 
- [ ] @jmbowman 
 
### Post-review
- [ ] Rebase and squash commits