### PR TITLE
[BD] Use settings.MIDDLEWARE instead of settings.MIDDLEWARE_CLASSES.

### DIFF
--- a/analytics_dashboard/core/middleware.py
+++ b/analytics_dashboard/core/middleware.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import
 import logging
 
 from django.template.response import TemplateResponse
+from django.utils.deprecation import MiddlewareMixin
 from lang_pref_middleware import middleware
 
 from core.exceptions import ServiceUnavailableError
@@ -14,7 +15,7 @@ from core.exceptions import ServiceUnavailableError
 logger = logging.getLogger(__name__)
 
 
-class LanguagePreferenceMiddleware(middleware.LanguagePreferenceMiddleware):
+class LanguagePreferenceMiddleware(middleware.LanguagePreferenceMiddleware, MiddlewareMixin):
     def get_user_language_preference(self, user):
         """
         Retrieve the given user's language preference.
@@ -24,7 +25,7 @@ class LanguagePreferenceMiddleware(middleware.LanguagePreferenceMiddleware):
         return user.language
 
 
-class ServiceUnavailableExceptionMiddleware(object):
+class ServiceUnavailableExceptionMiddleware(MiddlewareMixin):
     """
     Display an error template for 502 errors.
     """

--- a/analytics_dashboard/courses/middleware.py
+++ b/analytics_dashboard/courses/middleware.py
@@ -9,6 +9,7 @@ import logging
 import six
 from django.http import Http404
 from django.template.response import TemplateResponse
+from django.utils.deprecation import MiddlewareMixin
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 
@@ -17,7 +18,7 @@ from courses.exceptions import PermissionsRetrievalFailedError
 logger = logging.getLogger(__name__)
 
 
-class CourseMiddleware(object):
+class CourseMiddleware(MiddlewareMixin):
     """
     Adds course info to the request object.
     """
@@ -40,7 +41,7 @@ class CourseMiddleware(object):
         return None
 
 
-class CoursePermissionsExceptionMiddleware(object):
+class CoursePermissionsExceptionMiddleware(MiddlewareMixin):
     """
     Display an error template for PermissionsNotFoundError exceptions.
     """

--- a/analytics_dashboard/help/middleware.py
+++ b/analytics_dashboard/help/middleware.py
@@ -1,12 +1,13 @@
 from __future__ import absolute_import
 
+from django.utils.deprecation import MiddlewareMixin
 from rest_framework.response import Response
 
 from help import HELP_CONTEXT_TOKEN_NAME
 from help.utils import get_doc_url
 
 
-class HelpURLMiddleware(object):
+class HelpURLMiddleware(MiddlewareMixin):
     """
     Adds a "help_url" entry to the response context.
     """

--- a/analytics_dashboard/settings/base.py
+++ b/analytics_dashboard/settings/base.py
@@ -170,8 +170,8 @@ TEMPLATES = [
 
 
 ########## MIDDLEWARE CONFIGURATION
-# See: https://docs.djangoproject.com/en/dev/ref/settings/#middleware-classes
-MIDDLEWARE = (
+# See: https://docs.djangoproject.com/en/1.11/ref/settings/#middleware-classes
+MIDDLEWARE = [
     'edx_django_utils.cache.middleware.RequestCacheMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
@@ -190,7 +190,7 @@ MIDDLEWARE = (
     'edx_django_utils.cache.middleware.TieredCacheMiddleware',
     'edx_rest_framework_extensions.middleware.RequestMetricsMiddleware',
     'edx_rest_framework_extensions.auth.jwt.middleware.EnsureJWTAuthSettingsMiddleware',
-)
+]
 ########## END MIDDLEWARE CONFIGURATION
 
 

--- a/analytics_dashboard/settings/base.py
+++ b/analytics_dashboard/settings/base.py
@@ -171,7 +171,7 @@ TEMPLATES = [
 
 ########## MIDDLEWARE CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#middleware-classes
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'edx_django_utils.cache.middleware.RequestCacheMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',

--- a/analytics_dashboard/settings/dev.py
+++ b/analytics_dashboard/settings/dev.py
@@ -35,7 +35,7 @@ if os.environ.get('ENABLE_DJANGO_TOOLBAR', '').lower() in ('true', 't', '1'):
         'debug_toolbar',
     )
 
-    MIDDLEWARE_CLASSES += (
+    MIDDLEWARE += (
         'debug_toolbar.middleware.DebugToolbarMiddleware',
     )
 

--- a/analytics_dashboard/settings/dev.py
+++ b/analytics_dashboard/settings/dev.py
@@ -35,9 +35,9 @@ if os.environ.get('ENABLE_DJANGO_TOOLBAR', '').lower() in ('true', 't', '1'):
         'debug_toolbar',
     )
 
-    MIDDLEWARE += (
+    MIDDLEWARE += [
         'debug_toolbar.middleware.DebugToolbarMiddleware',
-    )
+    ]
 
     DEBUG_TOOLBAR_PATCH_SETTINGS = False
 


### PR DESCRIPTION
## Description 
Use settings.MIDDLEWARE instead of settings.MIDDLEWARE_CLASSES.
Part of .https://openedx.atlassian.net/browse/BOM-1360

### Reviewers
- [x] @morenol 
- [x]  Is this ready for edX's review? 
- [ ] @jmbowman 
 
### Post-review
- [ ] Rebase and squash commits