### PR TITLE
[BD] Upload build-metrics only in python task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,3 +85,4 @@ deploy:
       acl: public_read
       on:
         branch: master
+        condition: "$TESTNAME = test-python"


### PR DESCRIPTION
## Description

Currently master builds are failing when travis attempt to upload the build-metrics to S3.

https://travis-ci.org/github/edx/edx-analytics-dashboard/builds/663629105?utm_source=github_status&utm_medium=notification

Since we only need that in the test-python worker, this change configures travis to run the deployment step only in the test-python worker

## Reviewers
- [x] @andrey-canon 
- [x] Ready for edX review
- [ ] @jmbowman 