### PR TITLE
[BD] Upgrade to django 2.2 and drop python 2 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,9 @@ before_install:
 
     # Start up the relevant services
     - docker-compose -f .travis/docker-compose-travis.yml up -d
-    - docker exec analytics_api pip install --upgrade pip==9.0.3
-    - docker exec analytics_api make -C /edx/app/analytics_api/analytics_api travis
+    - docker exec analytics_api bash -c "
+      source /edx/app/analytics_api/venvs/analytics_api/bin/activate &&
+      make -C /edx/app/analytics_api/analytics_api travis"
     # HACK: https://github.com/nodejs/docker-node/issues/1199
     - rm package-lock.json
 

--- a/acceptance_tests/mixins.py
+++ b/acceptance_tests/mixins.py
@@ -326,7 +326,7 @@ class AnalyticsDashboardWebAppTestMixin(FooterMixin, PrimaryNavMixin, ContextSen
         """
         # Account for Django truncation
         if len(value) > MAX_SUMMARY_POINT_VALUE_LENGTH:
-            value = value[:(MAX_SUMMARY_POINT_VALUE_LENGTH - 3)] + '...'
+            value = value[:(MAX_SUMMARY_POINT_VALUE_LENGTH - 1)] + '…'
 
         element = self.page.q(css="div[{0}] .summary-point-number".format(data_selector))
         self.assertTrue(element.present)

--- a/analytics_dashboard/core/tests/test_views.py
+++ b/analytics_dashboard/core/tests/test_views.py
@@ -97,7 +97,8 @@ class ViewTests(TestCase):
                 expected_status_code=503, overall_status=UNAVAILABLE, database_connection=UNAVAILABLE
             )
             log_capture.check(
-                ('analytics_dashboard.core.views', 'ERROR', 'Insights database is not reachable: example error')
+                ('analytics_dashboard.core.views', 'ERROR', 'Insights database is not reachable: example error'),
+                ('django.request', 'ERROR', 'Service Unavailable: /health/'),
             )
 
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -13,6 +13,7 @@ djangorestframework-csv     			# BSD
 django-lang-pref-middleware
 # Dependency of djangorestframework
 django-crispy-forms     				# MIT
+django-lang-pref-middleware
 django-waffle       					# BSD
 django-soapbox							# BSD
 pinax-announcements     				# MIT
@@ -30,5 +31,3 @@ logutils        						# BSD
 requests								# Apache 2.0
 stevedore>=0.14.1,<2.0.0
 path.py<12.0                            # >=12.0 is python3 only
-
--e git+https://github.com/edx/django-lang-pref-middleware.git@0.1.0#egg=django-lang-pref-middleware

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -31,3 +31,6 @@ logutils        						# BSD
 requests								# Apache 2.0
 stevedore>=0.14.1,<2.0.0
 path.py<12.0                            # >=12.0 is python3 only
+
+# This can be removed once an official social-auth-app-django Pypi release with Django 2.2 support is available in the future.
+-e git+https://github.com/python-social-auth/social-app-django.git@ffa0fb99a80d11479bea2c4eae9a01ee835d52b9#egg=social-auth-app-django

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,6 +4,7 @@
 #
 #    make upgrade
 #
+-e git+https://github.com/python-social-auth/social-app-django.git@ffa0fb99a80d11479bea2c4eae9a01ee835d52b9#egg=social-auth-app-django  # via -r requirements/base.in
 awesome-slugify==1.6.5    # via -r requirements/base.in
 blessings==1.7            # via curtsies
 bpython==0.19             # via -r requirements/base.in
@@ -62,7 +63,6 @@ rest-condition==1.0.3     # via edx-drf-extensions
 semantic-version==2.8.4   # via edx-drf-extensions
 six==1.14.0               # via blessings, bpython, django-braces, django-countries, djangorestframework-csv, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-opaque-keys, libsass, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via edx-rest-api-client
-social-auth-app-django==3.1.0  # via edx-auth-backends
 social-auth-core==3.2.0   # via -c requirements/constraints.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via -r requirements/base.in, edx-opaque-keys

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,74 +4,70 @@
 #
 #    make upgrade
 #
--e git+https://github.com/edx/django-lang-pref-middleware.git@0.1.0#egg=django-lang-pref-middleware  # via -r requirements/base.in
 awesome-slugify==1.6.5    # via -r requirements/base.in
-backports.os==0.1.1       # via path.py
 blessings==1.7            # via curtsies
-bpython==0.18             # via -r requirements/base.in
+bpython==0.19             # via -r requirements/base.in
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
-configparser==4.0.2       # via importlib-metadata
-contextlib2==0.6.0.post1  # via importlib-metadata, zipp
 curtsies==0.3.1           # via bpython
-django-appconf==1.0.3     # via -r requirements/base.in
+defusedxml==0.6.0         # via python3-openid, social-auth-core
+django-appconf==1.0.4     # via -r requirements/base.in
 django-braces==1.14.0     # via -r requirements/base.in
 django-countries==5.5     # via -c requirements/constraints.txt, -r requirements/base.in
 django-crispy-forms==1.8.1  # via -c requirements/constraints.txt, -r requirements/base.in
+django-lang-pref-middleware==0.2.0  # via -r requirements/base.in
 django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/base.in
-django-soapbox==1.5       # via -r requirements/base.in
+django-soapbox==1.6       # via -r requirements/base.in
 django-waffle==0.18.0     # via -c requirements/constraints.txt, -r requirements/base.in, edx-django-utils, edx-drf-extensions
 django-webpack-loader==0.7.0  # via -r requirements/base.in
-django==1.11.29           # via -c requirements/constraints.txt, -r requirements/base.in, django-appconf, django-braces, django-model-utils, django-soapbox, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, pinax-announcements, rest-condition
+django==2.2.12            # via -c requirements/constraints.txt, -r requirements/base.in, django-appconf, django-braces, django-lang-pref-middleware, django-model-utils, django-soapbox, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, pinax-announcements, rest-condition
 djangorestframework-csv==2.1.0  # via -r requirements/base.in
 djangorestframework==3.9.4  # via -c requirements/constraints.txt, -r requirements/base.in, djangorestframework-csv, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -c requirements/constraints.txt, edx-drf-extensions
 edx-analytics-data-api-client==0.15.5  # via -r requirements/base.in
 edx-auth-backends==3.0.2  # via -r requirements/base.in
-edx-ccx-keys==1.0.0       # via -r requirements/base.in
-edx-django-release-util==0.3.6  # via -r requirements/base.in
+edx-ccx-keys==1.0.1       # via -r requirements/base.in
+edx-django-release-util==0.4.2  # via -r requirements/base.in
 edx-django-utils==2.0.4   # via -c requirements/constraints.txt, -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==5.0.0  # via -r requirements/base.in
+edx-drf-extensions==5.0.2  # via -r requirements/base.in
 edx-i18n-tools==0.5.0     # via -r requirements/base.in
-edx-opaque-keys==2.0.1    # via -r requirements/base.in, edx-ccx-keys, edx-drf-extensions
+edx-opaque-keys==2.0.2    # via -r requirements/base.in, edx-ccx-keys, edx-drf-extensions
 edx-rest-api-client==3.0.2  # via -c requirements/constraints.txt, -r requirements/base.in
-future==0.18.2            # via backports.os, pyjwkest
+future==0.18.2            # via pyjwkest
 greenlet==0.4.15          # via bpython
 idna==2.9                 # via requests
-importlib-metadata==1.5.0  # via path.py
+importlib-metadata==1.6.0  # via path.py
 libsass==0.11.1           # via -r requirements/base.in
 logutils==0.3.5           # via -r requirements/base.in
 newrelic==5.10.0.138      # via edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 path.py==11.5.2           # via -r requirements/base.in, edx-i18n-tools
-pathlib2==2.3.5           # via importlib-metadata
 pbr==5.4.4                # via stevedore
 pinax-announcements==3.0.2  # via -r requirements/base.in
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1             # via edx-django-utils
 pycryptodomex==3.9.7      # via pyjwkest
-pygments==2.5.2           # via bpython
+pygments==2.6.1           # via bpython
 pyjwkest==1.4.2           # via edx-drf-extensions
 pyjwt==1.7.1              # via drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pymongo==3.10.1           # via edx-opaque-keys
 python-dateutil==2.8.1    # via edx-drf-extensions
-python-openid==2.2.5 ; python_version == "2.7"  # via -c requirements/constraints.txt, social-auth-core
+python3-openid==3.1.0     # via social-auth-core
 pytz==2019.3              # via django
-pyyaml==5.3               # via edx-django-release-util, edx-i18n-tools
+pyyaml==5.3.1             # via edx-django-release-util, edx-i18n-tools
 regex==2020.2.20          # via awesome-slugify
 requests-oauthlib==1.3.0  # via social-auth-core
 requests==2.23.0          # via -r requirements/base.in, bpython, edx-analytics-data-api-client, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via edx-drf-extensions
-scandir==1.10.0           # via pathlib2
 semantic-version==2.8.4   # via edx-drf-extensions
-six==1.14.0               # via blessings, bpython, django-appconf, django-braces, django-countries, djangorestframework-csv, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-opaque-keys, libsass, pathlib2, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
+six==1.14.0               # via blessings, bpython, django-braces, django-countries, djangorestframework-csv, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-opaque-keys, libsass, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 social-auth-app-django==3.1.0  # via edx-auth-backends
-social-auth-core==3.2.0   # via edx-auth-backends, social-auth-app-django
+social-auth-core==3.2.0   # via -c requirements/constraints.txt, edx-auth-backends, social-auth-app-django
+sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via -r requirements/base.in, edx-opaque-keys
-typing==3.7.4.1           # via curtsies
 unicodecsv==0.14.1        # via djangorestframework-csv
 unidecode==0.4.21         # via awesome-slugify
 urllib3==1.25.8           # via requests
-wcwidth==0.1.8            # via curtsies
+wcwidth==0.1.9            # via curtsies
 zipp==1.2.0               # via importlib-metadata

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,8 +10,8 @@
 
 # TODO: Many pinned dependencies should be unpinned and/or moved to this constraints file.
 
-# Django 2 drops Python 2.7 support
-Django<2.0.0
+# Code support django 2.2
+Django<3.0.0
 
 # Major version to 2.0.0 does not work with pylint<2.0.0
 astroid<2.0.0
@@ -55,8 +55,8 @@ gunicorn<20.0.0
 # 2.0.0 drops Python 2.7 support.
 mysqlclient<2.0.0
 
-# This only works on python 2.7.
-python-openid; python_version == "2.7"
+# 3.3.0 Generate incompatibilities with awesome-slugify.
+social-auth-core==3.2.0
 
 # Constraint from astroid 2.3.3
 wrapt==1.11.*

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -22,9 +22,6 @@ edx-django-utils<3.0.0
 # 4.0.0 drops Python 2.7 support
 edx-rest-api-client<4.0.0
 
-# Already in python3 standard library
-futures; python_version == "2.7"
-
 # 3.10.0 drops Python 2.7 support
 djangorestframework<3.10.0
 

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,45 +4,43 @@
 #
 #    make upgrade
 #
--e git+https://github.com/edx/django-lang-pref-middleware.git@0.1.0#egg=django-lang-pref-middleware  # via -r requirements/base.txt
 alabaster==0.7.12         # via sphinx
 awesome-slugify==1.6.5    # via -r requirements/base.txt
 babel==2.8.0              # via sphinx
-backports.os==0.1.1       # via -r requirements/base.txt, path.py
 blessings==1.7            # via -r requirements/base.txt, curtsies
-bpython==0.18             # via -r requirements/base.txt
+bpython==0.19             # via -r requirements/base.txt
 certifi==2019.11.28       # via -r requirements/base.txt, requests
 chardet==3.0.4            # via -r requirements/base.txt, requests
-configparser==4.0.2       # via -r requirements/base.txt, importlib-metadata
-contextlib2==0.6.0.post1  # via -r requirements/base.txt, importlib-metadata, zipp
 curtsies==0.3.1           # via -r requirements/base.txt, bpython
-django-appconf==1.0.3     # via -r requirements/base.txt
+defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social-auth-core
+django-appconf==1.0.4     # via -r requirements/base.txt
 django-braces==1.14.0     # via -r requirements/base.txt
 django-countries==5.5     # via -c requirements/constraints.txt, -r requirements/base.txt
 django-crispy-forms==1.8.1  # via -c requirements/constraints.txt, -r requirements/base.txt
+django-lang-pref-middleware==0.2.0  # via -r requirements/base.txt
 django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/base.txt
-django-soapbox==1.5       # via -r requirements/base.txt
+django-soapbox==1.6       # via -r requirements/base.txt
 django-waffle==0.18.0     # via -c requirements/constraints.txt, -r requirements/base.txt, edx-django-utils, edx-drf-extensions
 django-webpack-loader==0.7.0  # via -r requirements/base.txt
-django==1.11.29           # via -c requirements/constraints.txt, -r requirements/base.txt, django-appconf, django-braces, django-model-utils, django-soapbox, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, pinax-announcements, rest-condition
+django==2.2.12            # via -c requirements/constraints.txt, -r requirements/base.txt, django-appconf, django-braces, django-lang-pref-middleware, django-model-utils, django-soapbox, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, pinax-announcements, rest-condition
 djangorestframework-csv==2.1.0  # via -r requirements/base.txt
 djangorestframework==3.9.4  # via -c requirements/constraints.txt, -r requirements/base.txt, djangorestframework-csv, drf-jwt, edx-drf-extensions, rest-condition
 docutils==0.16            # via sphinx
 drf-jwt==1.14.0           # via -c requirements/constraints.txt, -r requirements/base.txt, edx-drf-extensions
 edx-analytics-data-api-client==0.15.5  # via -r requirements/base.txt
 edx-auth-backends==3.0.2  # via -r requirements/base.txt
-edx-ccx-keys==1.0.0       # via -r requirements/base.txt
-edx-django-release-util==0.3.6  # via -r requirements/base.txt
+edx-ccx-keys==1.0.1       # via -r requirements/base.txt
+edx-django-release-util==0.4.2  # via -r requirements/base.txt
 edx-django-utils==2.0.4   # via -c requirements/constraints.txt, -r requirements/base.txt, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==5.0.0  # via -r requirements/base.txt
+edx-drf-extensions==5.0.2  # via -r requirements/base.txt
 edx-i18n-tools==0.5.0     # via -r requirements/base.txt
-edx-opaque-keys==2.0.1    # via -r requirements/base.txt, edx-ccx-keys, edx-drf-extensions
+edx-opaque-keys==2.0.2    # via -r requirements/base.txt, edx-ccx-keys, edx-drf-extensions
 edx-rest-api-client==3.0.2  # via -c requirements/constraints.txt, -r requirements/base.txt
-future==0.18.2            # via -r requirements/base.txt, backports.os, pyjwkest
+future==0.18.2            # via -r requirements/base.txt, pyjwkest
 greenlet==0.4.15          # via -r requirements/base.txt, bpython
 idna==2.9                 # via -r requirements/base.txt, requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.5.0  # via -r requirements/base.txt, path.py
+importlib-metadata==1.6.0  # via -r requirements/base.txt, path.py
 jinja2==2.11.1            # via sphinx
 libsass==0.11.1           # via -r requirements/base.txt
 logutils==0.3.5           # via -r requirements/base.txt
@@ -50,37 +48,35 @@ markupsafe==1.1.1         # via jinja2
 newrelic==5.10.0.138      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 path.py==11.5.2           # via -r requirements/base.txt, edx-i18n-tools
-pathlib2==2.3.5           # via -r requirements/base.txt, importlib-metadata
 pbr==5.4.4                # via -r requirements/base.txt, stevedore
 pinax-announcements==3.0.2  # via -r requirements/base.txt
 polib==1.1.0              # via -r requirements/base.txt, edx-i18n-tools
 psutil==1.2.1             # via -r requirements/base.txt, edx-django-utils
 pycryptodomex==3.9.7      # via -r requirements/base.txt, pyjwkest
-pygments==2.5.2           # via -r requirements/base.txt, bpython, sphinx
+pygments==2.6.1           # via -r requirements/base.txt, bpython, sphinx
 pyjwkest==1.4.2           # via -r requirements/base.txt, edx-drf-extensions
 pyjwt==1.7.1              # via -r requirements/base.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pymongo==3.10.1           # via -r requirements/base.txt, edx-opaque-keys
 python-dateutil==2.8.1    # via -r requirements/base.txt, edx-drf-extensions
-python-openid==2.2.5 ; python_version == "2.7"  # via -c requirements/constraints.txt, -r requirements/base.txt, social-auth-core
+python3-openid==3.1.0     # via -r requirements/base.txt, social-auth-core
 pytz==2019.3              # via -r requirements/base.txt, babel, django
-pyyaml==5.3               # via -r requirements/base.txt, edx-django-release-util, edx-i18n-tools
+pyyaml==5.3.1             # via -r requirements/base.txt, edx-django-release-util, edx-i18n-tools
 regex==2020.2.20          # via -r requirements/base.txt, awesome-slugify
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
 requests==2.23.0          # via -r requirements/base.txt, bpython, edx-analytics-data-api-client, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
-scandir==1.10.0           # via -r requirements/base.txt, pathlib2
 semantic-version==2.8.4   # via -r requirements/base.txt, edx-drf-extensions
-six==1.14.0               # via -r requirements/base.txt, blessings, bpython, django-appconf, django-braces, django-countries, djangorestframework-csv, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-opaque-keys, libsass, pathlib2, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, sphinx, stevedore
+six==1.14.0               # via -r requirements/base.txt, blessings, bpython, django-braces, django-countries, djangorestframework-csv, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-opaque-keys, libsass, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, sphinx, stevedore
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via sphinx
 social-auth-app-django==3.1.0  # via -r requirements/base.txt, edx-auth-backends
-social-auth-core==3.2.0   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
+social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/base.txt, edx-auth-backends, social-auth-app-django
 sphinx==1.4.5             # via -r requirements/doc.in, sphinx-rtd-theme
 sphinx_rtd_theme==0.1.9   # via -r requirements/doc.in
+sqlparse==0.3.1           # via -r requirements/base.txt, django
 stevedore==1.32.0         # via -r requirements/base.txt, edx-opaque-keys
-typing==3.7.4.1           # via -r requirements/base.txt, curtsies
 unicodecsv==0.14.1        # via -r requirements/base.txt, djangorestframework-csv
 unidecode==0.4.21         # via -r requirements/base.txt, awesome-slugify
 urllib3==1.25.8           # via -r requirements/base.txt, requests
-wcwidth==0.1.8            # via -r requirements/base.txt, curtsies
+wcwidth==0.1.9            # via -r requirements/base.txt, curtsies
 zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,6 +4,7 @@
 #
 #    make upgrade
 #
+-e git+https://github.com/python-social-auth/social-app-django.git@ffa0fb99a80d11479bea2c4eae9a01ee835d52b9#egg=social-auth-app-django  # via -r requirements/base.txt
 alabaster==0.7.12         # via sphinx
 awesome-slugify==1.6.5    # via -r requirements/base.txt
 babel==2.8.0              # via sphinx
@@ -69,7 +70,6 @@ semantic-version==2.8.4   # via -r requirements/base.txt, edx-drf-extensions
 six==1.14.0               # via -r requirements/base.txt, blessings, bpython, django-braces, django-countries, djangorestframework-csv, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-opaque-keys, libsass, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, sphinx, stevedore
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via sphinx
-social-auth-app-django==3.1.0  # via -r requirements/base.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/base.txt, edx-auth-backends, social-auth-app-django
 sphinx==1.4.5             # via -r requirements/doc.in, sphinx-rtd-theme
 sphinx_rtd_theme==0.1.9   # via -r requirements/doc.in

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -4,6 +4,7 @@
 #
 #    make upgrade
 #
+-e git+https://github.com/python-social-auth/social-app-django.git@ffa0fb99a80d11479bea2c4eae9a01ee835d52b9#egg=social-auth-app-django  # via -r requirements/test.txt
 argparse==1.4.0           # via -r requirements/test.txt, unittest2
 astroid==1.6.6            # via -c requirements/constraints.txt, -r requirements/test.txt, pylint
 attrs==19.3.0             # via -r requirements/test.txt, pytest
@@ -97,7 +98,6 @@ selenium==2.53.6          # via -r requirements/test.txt, bok-choy, needle
 semantic-version==2.8.4   # via -r requirements/test.txt, edx-drf-extensions
 six==1.14.0               # via -r requirements/pip_tools.txt, -r requirements/test.txt, astroid, blessings, bok-choy, bpython, django-braces, django-countries, django-dynamic-fixture, djangorestframework-csv, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-opaque-keys, libsass, logilab-common, mock, packaging, pathlib2, pip-tools, pyjwkest, pylint, python-dateutil, social-auth-app-django, social-auth-core, stevedore, sure, transifex-client, unittest2
 slumber==0.7.1            # via -r requirements/test.txt, edx-rest-api-client
-social-auth-app-django==3.1.0  # via -r requirements/test.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/test.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.3.1           # via -r requirements/test.txt, django, django-debug-toolbar
 stevedore==1.32.0         # via -r requirements/test.txt, edx-opaque-keys

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -4,57 +4,50 @@
 #
 #    make upgrade
 #
--e git+https://github.com/edx/django-lang-pref-middleware.git@0.1.0#egg=django-lang-pref-middleware  # via -r requirements/test.txt
 argparse==1.4.0           # via -r requirements/test.txt, unittest2
 astroid==1.6.6            # via -c requirements/constraints.txt, -r requirements/test.txt, pylint
-atomicwrites==1.3.0       # via -r requirements/test.txt, pytest
 attrs==19.3.0             # via -r requirements/test.txt, pytest
 awesome-slugify==1.6.5    # via -r requirements/test.txt
-backports.functools-lru-cache==1.6.1  # via -r requirements/test.txt, astroid, isort, pylint
-backports.os==0.1.1       # via -r requirements/test.txt, path.py
 blessings==1.7            # via -r requirements/test.txt, curtsies
 bok-choy==0.7.0           # via -r requirements/test.txt
-bpython==0.18             # via -r requirements/test.txt
+bpython==0.19             # via -r requirements/test.txt
 certifi==2019.11.28       # via -r requirements/test.txt, requests
 chardet==3.0.4            # via -r requirements/test.txt, requests
 click==7.1.1              # via -r requirements/pip_tools.txt, pip-tools
-configparser==4.0.2       # via -r requirements/test.txt, importlib-metadata, pylint
-contextlib2==0.6.0.post1  # via -r requirements/test.txt, importlib-metadata, zipp
 coverage==4.4.1           # via -r requirements/test.txt, pytest-cov
 curtsies==0.3.1           # via -r requirements/test.txt, bpython
 ddt==1.1.1                # via -r requirements/test.txt
-django-appconf==1.0.3     # via -r requirements/test.txt
+defusedxml==0.6.0         # via -r requirements/test.txt, python3-openid, social-auth-core
+django-appconf==1.0.4     # via -r requirements/test.txt
 django-braces==1.14.0     # via -r requirements/test.txt
 django-countries==5.5     # via -c requirements/constraints.txt, -r requirements/test.txt
 django-crispy-forms==1.8.1  # via -c requirements/constraints.txt, -r requirements/test.txt
 django-debug-toolbar==1.11  # via -c requirements/constraints.txt, -r requirements/local.in
-django-dynamic-fixture==3.0.3  # via -r requirements/test.txt
+django-dynamic-fixture==3.1.0  # via -r requirements/test.txt
+django-lang-pref-middleware==0.2.0  # via -r requirements/test.txt
 django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/test.txt
-django-soapbox==1.5       # via -r requirements/test.txt
+django-soapbox==1.6       # via -r requirements/test.txt
 django-waffle==0.18.0     # via -c requirements/constraints.txt, -r requirements/test.txt, edx-django-utils, edx-drf-extensions
 django-webpack-loader==0.7.0  # via -r requirements/test.txt
-django==1.11.29           # via -c requirements/constraints.txt, -r requirements/test.txt, django-appconf, django-braces, django-debug-toolbar, django-model-utils, django-soapbox, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, pinax-announcements, rest-condition
+django==2.2.12            # via -c requirements/constraints.txt, -r requirements/test.txt, django-appconf, django-braces, django-debug-toolbar, django-lang-pref-middleware, django-model-utils, django-soapbox, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, pinax-announcements, rest-condition
 djangorestframework-csv==2.1.0  # via -r requirements/test.txt
 djangorestframework==3.9.4  # via -c requirements/constraints.txt, -r requirements/test.txt, djangorestframework-csv, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -c requirements/constraints.txt, -r requirements/test.txt, edx-drf-extensions
 edx-analytics-data-api-client==0.15.5  # via -r requirements/test.txt
 edx-auth-backends==3.0.2  # via -r requirements/test.txt
-edx-ccx-keys==1.0.0       # via -r requirements/test.txt
-edx-django-release-util==0.3.6  # via -r requirements/test.txt
+edx-ccx-keys==1.0.1       # via -r requirements/test.txt
+edx-django-release-util==0.4.2  # via -r requirements/test.txt
 edx-django-utils==2.0.4   # via -c requirements/constraints.txt, -r requirements/test.txt, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==5.0.0  # via -r requirements/test.txt
+edx-drf-extensions==5.0.2  # via -r requirements/test.txt
 edx-i18n-tools==0.5.0     # via -r requirements/test.txt
-edx-opaque-keys==2.0.1    # via -r requirements/test.txt, edx-ccx-keys, edx-drf-extensions
+edx-opaque-keys==2.0.2    # via -r requirements/test.txt, edx-ccx-keys, edx-drf-extensions
 edx-rest-api-client==3.0.2  # via -c requirements/constraints.txt, -r requirements/test.txt
 elasticsearch==2.4.1      # via -r requirements/test.txt
-enum34==1.1.10            # via -r requirements/test.txt, astroid
-funcsigs==1.0.2           # via -r requirements/test.txt, mock, pytest
-future==0.18.2            # via -r requirements/test.txt, backports.os, pyjwkest
-futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, -r requirements/test.txt, isort
+future==0.18.2            # via -r requirements/test.txt, pyjwkest
 greenlet==0.4.15          # via -r requirements/test.txt, bpython
 httpretty==0.8.14         # via -r requirements/test.txt
 idna==2.9                 # via -r requirements/test.txt, requests
-importlib-metadata==1.5.0  # via -r requirements/test.txt, path.py, pluggy, pytest
+importlib-metadata==1.6.0  # via -r requirements/test.txt, path.py, pluggy, pytest
 isort==4.3.21             # via -r requirements/test.txt, pylint
 lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
 lazy==1.4                 # via -r requirements/test.txt, bok-choy
@@ -64,17 +57,17 @@ logilab-common==1.4.0     # via -r requirements/test.txt
 logutils==0.3.5           # via -r requirements/test.txt
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
 mock==1.3.0               # via -r requirements/test.txt, sure
-more-itertools==5.0.0     # via -r requirements/test.txt, pytest
+more-itertools==8.2.0     # via -r requirements/test.txt, pytest
 needle==0.5.0             # via -r requirements/test.txt, bok-choy
 newrelic==5.10.0.138      # via -r requirements/test.txt, edx-django-utils
 nose==1.3.7               # via -r requirements/test.txt, needle
 oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib, social-auth-core
 packaging==20.3           # via -r requirements/test.txt, pytest
 path.py==11.5.2           # via -r requirements/test.txt, edx-i18n-tools
-pathlib2==2.3.5           # via -r requirements/test.txt, importlib-metadata, pytest, pytest-django
+pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pbr==5.4.4                # via -r requirements/test.txt, mock, stevedore
 pep257==0.7.0             # via -r requirements/test.txt
-pillow==6.2.2             # via -r requirements/test.txt, needle
+pillow==7.1.1             # via -r requirements/test.txt, needle
 pinax-announcements==3.0.2  # via -r requirements/test.txt
 pip-tools==4.5.1          # via -r requirements/pip_tools.txt
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
@@ -83,43 +76,40 @@ psutil==1.2.1             # via -r requirements/test.txt, edx-django-utils
 py==1.8.1                 # via -r requirements/test.txt, pytest
 pycodestyle==2.5.0        # via -r requirements/test.txt
 pycryptodomex==3.9.7      # via -r requirements/test.txt, pyjwkest
-pygments==2.5.2           # via -r requirements/test.txt, bpython
+pygments==2.6.1           # via -r requirements/test.txt, bpython
 pyjwkest==1.4.2           # via -r requirements/test.txt, edx-drf-extensions
 pyjwt==1.7.1              # via -r requirements/test.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint==1.7.1             # via -r requirements/test.txt
 pymongo==3.10.1           # via -r requirements/test.txt, edx-opaque-keys
 pyparsing==2.4.6          # via -r requirements/test.txt, packaging
 pytest-cov==2.8.1         # via -r requirements/test.txt
-pytest-django==3.8.0      # via -r requirements/test.txt
-pytest==4.6.9             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest-django==3.9.0      # via -r requirements/test.txt
+pytest==5.4.1             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/test.txt, edx-drf-extensions
-python-openid==2.2.5 ; python_version == "2.7"  # via -c requirements/constraints.txt, -r requirements/test.txt, social-auth-core
+python3-openid==3.1.0     # via -r requirements/test.txt, social-auth-core
 pytz==2019.3              # via -r requirements/test.txt, django
-pyyaml==5.3               # via -r requirements/test.txt, edx-django-release-util, edx-i18n-tools
+pyyaml==5.3.1             # via -r requirements/test.txt, edx-django-release-util, edx-i18n-tools
 regex==2020.2.20          # via -r requirements/test.txt, awesome-slugify
 requests-oauthlib==1.3.0  # via -r requirements/test.txt, social-auth-core
 requests==2.23.0          # via -r requirements/test.txt, bpython, edx-analytics-data-api-client, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/test.txt, edx-drf-extensions
-scandir==1.10.0           # via -r requirements/test.txt, pathlib2
 selenium==2.53.6          # via -r requirements/test.txt, bok-choy, needle
 semantic-version==2.8.4   # via -r requirements/test.txt, edx-drf-extensions
-singledispatch==3.4.0.3   # via -r requirements/test.txt, astroid, pylint
-six==1.14.0               # via -r requirements/pip_tools.txt, -r requirements/test.txt, astroid, blessings, bok-choy, bpython, django-appconf, django-braces, django-countries, django-dynamic-fixture, djangorestframework-csv, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-opaque-keys, libsass, logilab-common, mock, more-itertools, packaging, pathlib2, pip-tools, pyjwkest, pylint, pytest, python-dateutil, singledispatch, social-auth-app-django, social-auth-core, stevedore, sure, transifex-client, unittest2
+six==1.14.0               # via -r requirements/pip_tools.txt, -r requirements/test.txt, astroid, blessings, bok-choy, bpython, django-braces, django-countries, django-dynamic-fixture, djangorestframework-csv, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-opaque-keys, libsass, logilab-common, mock, packaging, pathlib2, pip-tools, pyjwkest, pylint, python-dateutil, social-auth-app-django, social-auth-core, stevedore, sure, transifex-client, unittest2
 slumber==0.7.1            # via -r requirements/test.txt, edx-rest-api-client
 social-auth-app-django==3.1.0  # via -r requirements/test.txt, edx-auth-backends
-social-auth-core==3.2.0   # via -r requirements/test.txt, edx-auth-backends, social-auth-app-django
-sqlparse==0.3.1           # via django-debug-toolbar
+social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/test.txt, edx-auth-backends, social-auth-app-django
+sqlparse==0.3.1           # via -r requirements/test.txt, django, django-debug-toolbar
 stevedore==1.32.0         # via -r requirements/test.txt, edx-opaque-keys
 sure==1.4.11              # via -r requirements/test.txt
 testfixtures==4.14.3      # via -r requirements/test.txt
 traceback2==1.4.0         # via -r requirements/test.txt, unittest2
 transifex-client==0.12.4  # via -r requirements/local.in
-typing==3.7.4.1           # via -r requirements/test.txt, curtsies
 unicodecsv==0.14.1        # via -r requirements/test.txt, djangorestframework-csv
 unidecode==0.4.21         # via -r requirements/test.txt, awesome-slugify
 unittest2==1.1.0          # via -r requirements/test.txt
 urllib3==1.25.8           # via -r requirements/test.txt, elasticsearch, requests, transifex-client
-wcwidth==0.1.8            # via -r requirements/test.txt, curtsies, pytest
+wcwidth==0.1.9            # via -r requirements/test.txt, curtsies, pytest
 wrapt==1.11.2             # via -c requirements/constraints.txt, -r requirements/test.txt, astroid
 zipp==1.2.0               # via -r requirements/test.txt, importlib-metadata
 

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,6 +4,7 @@
 #
 #    make upgrade
 #
+-e git+https://github.com/python-social-auth/social-app-django.git@ffa0fb99a80d11479bea2c4eae9a01ee835d52b9#egg=social-auth-app-django  # via -r requirements/base.txt
 awesome-slugify==1.6.5    # via -r requirements/base.txt
 blessings==1.7            # via -r requirements/base.txt, curtsies
 bpython==0.19             # via -r requirements/base.txt
@@ -66,7 +67,6 @@ rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
 semantic-version==2.8.4   # via -r requirements/base.txt, edx-drf-extensions
 six==1.14.0               # via -r requirements/base.txt, blessings, bpython, django-braces, django-countries, djangorestframework-csv, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-opaque-keys, libsass, pyjwkest, python-dateutil, python-memcached, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
-social-auth-app-django==3.1.0  # via -r requirements/base.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/base.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.3.1           # via -r requirements/base.txt, django
 stevedore==1.32.0         # via -r requirements/base.txt, edx-opaque-keys

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,42 +4,40 @@
 #
 #    make upgrade
 #
--e git+https://github.com/edx/django-lang-pref-middleware.git@0.1.0#egg=django-lang-pref-middleware  # via -r requirements/base.txt
 awesome-slugify==1.6.5    # via -r requirements/base.txt
-backports.os==0.1.1       # via -r requirements/base.txt, path.py
 blessings==1.7            # via -r requirements/base.txt, curtsies
-bpython==0.18             # via -r requirements/base.txt
+bpython==0.19             # via -r requirements/base.txt
 certifi==2019.11.28       # via -r requirements/base.txt, requests
 chardet==3.0.4            # via -r requirements/base.txt, requests
-configparser==4.0.2       # via -r requirements/base.txt, importlib-metadata
-contextlib2==0.6.0.post1  # via -r requirements/base.txt, importlib-metadata, zipp
 curtsies==0.3.1           # via -r requirements/base.txt, bpython
-django-appconf==1.0.3     # via -r requirements/base.txt
+defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social-auth-core
+django-appconf==1.0.4     # via -r requirements/base.txt
 django-braces==1.14.0     # via -r requirements/base.txt
 django-countries==5.5     # via -c requirements/constraints.txt, -r requirements/base.txt
 django-crispy-forms==1.8.1  # via -c requirements/constraints.txt, -r requirements/base.txt
+django-lang-pref-middleware==0.2.0  # via -r requirements/base.txt
 django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/base.txt
-django-soapbox==1.5       # via -r requirements/base.txt
+django-soapbox==1.6       # via -r requirements/base.txt
 django-waffle==0.18.0     # via -c requirements/constraints.txt, -r requirements/base.txt, edx-django-utils, edx-drf-extensions
 django-webpack-loader==0.7.0  # via -r requirements/base.txt
-django==1.11.29           # via -c requirements/constraints.txt, -r requirements/base.txt, django-appconf, django-braces, django-model-utils, django-soapbox, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, pinax-announcements, rest-condition
+django==2.2.12            # via -c requirements/constraints.txt, -r requirements/base.txt, django-appconf, django-braces, django-lang-pref-middleware, django-model-utils, django-soapbox, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, pinax-announcements, rest-condition
 djangorestframework-csv==2.1.0  # via -r requirements/base.txt
 djangorestframework==3.9.4  # via -c requirements/constraints.txt, -r requirements/base.txt, djangorestframework-csv, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -c requirements/constraints.txt, -r requirements/base.txt, edx-drf-extensions
 edx-analytics-data-api-client==0.15.5  # via -r requirements/base.txt
 edx-auth-backends==3.0.2  # via -r requirements/base.txt
-edx-ccx-keys==1.0.0       # via -r requirements/base.txt
-edx-django-release-util==0.3.6  # via -r requirements/base.txt
+edx-ccx-keys==1.0.1       # via -r requirements/base.txt
+edx-django-release-util==0.4.2  # via -r requirements/base.txt
 edx-django-utils==2.0.4   # via -c requirements/constraints.txt, -r requirements/base.txt, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==5.0.0  # via -r requirements/base.txt
+edx-drf-extensions==5.0.2  # via -r requirements/base.txt
 edx-i18n-tools==0.5.0     # via -r requirements/base.txt
-edx-opaque-keys==2.0.1    # via -r requirements/base.txt, edx-ccx-keys, edx-drf-extensions
+edx-opaque-keys==2.0.2    # via -r requirements/base.txt, edx-ccx-keys, edx-drf-extensions
 edx-rest-api-client==3.0.2  # via -c requirements/constraints.txt, -r requirements/base.txt
-future==0.18.2            # via -r requirements/base.txt, backports.os, pyjwkest
+future==0.18.2            # via -r requirements/base.txt, pyjwkest
 greenlet==0.4.15          # via -r requirements/base.txt, bpython
 gunicorn==19.10.0         # via -c requirements/constraints.txt, -r requirements/production.in
 idna==2.9                 # via -r requirements/base.txt, requests
-importlib-metadata==1.5.0  # via -r requirements/base.txt, path.py
+importlib-metadata==1.6.0  # via -r requirements/base.txt, path.py
 libsass==0.11.1           # via -r requirements/base.txt
 logutils==0.3.5           # via -r requirements/base.txt
 mysqlclient==1.4.6        # via -c requirements/constraints.txt, -r requirements/production.in
@@ -47,35 +45,33 @@ newrelic==5.10.0.138      # via -r requirements/base.txt, edx-django-utils
 nodeenv==1.3.5            # via -r requirements/production.in
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 path.py==11.5.2           # via -r requirements/base.txt, edx-i18n-tools
-pathlib2==2.3.5           # via -r requirements/base.txt, importlib-metadata
 pbr==5.4.4                # via -r requirements/base.txt, stevedore
 pinax-announcements==3.0.2  # via -r requirements/base.txt
 polib==1.1.0              # via -r requirements/base.txt, edx-i18n-tools
 psutil==1.2.1             # via -r requirements/base.txt, edx-django-utils
 pycryptodomex==3.9.7      # via -r requirements/base.txt, pyjwkest
-pygments==2.5.2           # via -r requirements/base.txt, bpython
+pygments==2.6.1           # via -r requirements/base.txt, bpython
 pyjwkest==1.4.2           # via -r requirements/base.txt, edx-drf-extensions
 pyjwt==1.7.1              # via -r requirements/base.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pymongo==3.10.1           # via -r requirements/base.txt, edx-opaque-keys
 python-dateutil==2.8.1    # via -r requirements/base.txt, edx-drf-extensions
 python-memcached==1.58    # via -r requirements/production.in
-python-openid==2.2.5 ; python_version == "2.7"  # via -c requirements/constraints.txt, -r requirements/base.txt, social-auth-core
+python3-openid==3.1.0     # via -r requirements/base.txt, social-auth-core
 pytz==2019.3              # via -r requirements/base.txt, django
-pyyaml==5.3               # via -r requirements/base.txt, -r requirements/production.in, edx-django-release-util, edx-i18n-tools
+pyyaml==5.3.1             # via -r requirements/base.txt, -r requirements/production.in, edx-django-release-util, edx-i18n-tools
 regex==2020.2.20          # via -r requirements/base.txt, awesome-slugify
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
 requests==2.23.0          # via -r requirements/base.txt, bpython, edx-analytics-data-api-client, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
-scandir==1.10.0           # via -r requirements/base.txt, pathlib2
 semantic-version==2.8.4   # via -r requirements/base.txt, edx-drf-extensions
-six==1.14.0               # via -r requirements/base.txt, blessings, bpython, django-appconf, django-braces, django-countries, djangorestframework-csv, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-opaque-keys, libsass, pathlib2, pyjwkest, python-dateutil, python-memcached, social-auth-app-django, social-auth-core, stevedore
+six==1.14.0               # via -r requirements/base.txt, blessings, bpython, django-braces, django-countries, djangorestframework-csv, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-opaque-keys, libsass, pyjwkest, python-dateutil, python-memcached, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 social-auth-app-django==3.1.0  # via -r requirements/base.txt, edx-auth-backends
-social-auth-core==3.2.0   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
+social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/base.txt, edx-auth-backends, social-auth-app-django
+sqlparse==0.3.1           # via -r requirements/base.txt, django
 stevedore==1.32.0         # via -r requirements/base.txt, edx-opaque-keys
-typing==3.7.4.1           # via -r requirements/base.txt, curtsies
 unicodecsv==0.14.1        # via -r requirements/base.txt, djangorestframework-csv
 unidecode==0.4.21         # via -r requirements/base.txt, awesome-slugify
 urllib3==1.25.8           # via -r requirements/base.txt, requests
-wcwidth==0.1.8            # via -r requirements/base.txt, curtsies
+wcwidth==0.1.9            # via -r requirements/base.txt, curtsies
 zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,55 +4,48 @@
 #
 #    make upgrade
 #
--e git+https://github.com/edx/django-lang-pref-middleware.git@0.1.0#egg=django-lang-pref-middleware  # via -r requirements/base.txt
 argparse==1.4.0           # via unittest2
 astroid==1.6.6            # via -c requirements/constraints.txt, -r requirements/test.in, pylint
-atomicwrites==1.3.0       # via pytest
 attrs==19.3.0             # via pytest
 awesome-slugify==1.6.5    # via -r requirements/base.txt
-backports.functools-lru-cache==1.6.1  # via astroid, isort, pylint
-backports.os==0.1.1       # via -r requirements/base.txt, path.py
 blessings==1.7            # via -r requirements/base.txt, curtsies
 bok-choy==0.7.0           # via -r requirements/test.in
-bpython==0.18             # via -r requirements/base.txt
+bpython==0.19             # via -r requirements/base.txt
 certifi==2019.11.28       # via -r requirements/base.txt, requests
 chardet==3.0.4            # via -r requirements/base.txt, requests
-configparser==4.0.2       # via -r requirements/base.txt, importlib-metadata, pylint
-contextlib2==0.6.0.post1  # via -r requirements/base.txt, importlib-metadata, zipp
 coverage==4.4.1           # via -r requirements/test.in, pytest-cov
 curtsies==0.3.1           # via -r requirements/base.txt, bpython
 ddt==1.1.1                # via -r requirements/test.in
-django-appconf==1.0.3     # via -r requirements/base.txt
+defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social-auth-core
+django-appconf==1.0.4     # via -r requirements/base.txt
 django-braces==1.14.0     # via -r requirements/base.txt
 django-countries==5.5     # via -c requirements/constraints.txt, -r requirements/base.txt
 django-crispy-forms==1.8.1  # via -c requirements/constraints.txt, -r requirements/base.txt
-django-dynamic-fixture==3.0.3  # via -r requirements/test.in
+django-dynamic-fixture==3.1.0  # via -r requirements/test.in
+django-lang-pref-middleware==0.2.0  # via -r requirements/base.txt
 django-model-utils==3.2.0  # via -c requirements/constraints.txt, -r requirements/base.txt
-django-soapbox==1.5       # via -r requirements/base.txt
+django-soapbox==1.6       # via -r requirements/base.txt
 django-waffle==0.18.0     # via -c requirements/constraints.txt, -r requirements/base.txt, edx-django-utils, edx-drf-extensions
 django-webpack-loader==0.7.0  # via -r requirements/base.txt
-django==1.11.29           # via -c requirements/constraints.txt, -r requirements/base.txt, django-appconf, django-braces, django-model-utils, django-soapbox, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, pinax-announcements, rest-condition
+django==2.2.12            # via -c requirements/constraints.txt, -r requirements/base.txt, django-appconf, django-braces, django-lang-pref-middleware, django-model-utils, django-soapbox, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, pinax-announcements, rest-condition
 djangorestframework-csv==2.1.0  # via -r requirements/base.txt
 djangorestframework==3.9.4  # via -c requirements/constraints.txt, -r requirements/base.txt, djangorestframework-csv, drf-jwt, edx-drf-extensions, rest-condition
 drf-jwt==1.14.0           # via -c requirements/constraints.txt, -r requirements/base.txt, edx-drf-extensions
 edx-analytics-data-api-client==0.15.5  # via -r requirements/base.txt
 edx-auth-backends==3.0.2  # via -r requirements/base.txt
-edx-ccx-keys==1.0.0       # via -r requirements/base.txt
-edx-django-release-util==0.3.6  # via -r requirements/base.txt
+edx-ccx-keys==1.0.1       # via -r requirements/base.txt
+edx-django-release-util==0.4.2  # via -r requirements/base.txt
 edx-django-utils==2.0.4   # via -c requirements/constraints.txt, -r requirements/base.txt, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==5.0.0  # via -r requirements/base.txt
+edx-drf-extensions==5.0.2  # via -r requirements/base.txt
 edx-i18n-tools==0.5.0     # via -r requirements/base.txt
-edx-opaque-keys==2.0.1    # via -r requirements/base.txt, edx-ccx-keys, edx-drf-extensions
+edx-opaque-keys==2.0.2    # via -r requirements/base.txt, edx-ccx-keys, edx-drf-extensions
 edx-rest-api-client==3.0.2  # via -c requirements/constraints.txt, -r requirements/base.txt
 elasticsearch==2.4.1      # via -r requirements/test.in
-enum34==1.1.10            # via astroid
-funcsigs==1.0.2           # via mock, pytest
-future==0.18.2            # via -r requirements/base.txt, backports.os, pyjwkest
-futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, isort
+future==0.18.2            # via -r requirements/base.txt, pyjwkest
 greenlet==0.4.15          # via -r requirements/base.txt, bpython
 httpretty==0.8.14         # via -r requirements/test.in
 idna==2.9                 # via -r requirements/base.txt, requests
-importlib-metadata==1.5.0  # via -r requirements/base.txt, path.py, pluggy, pytest
+importlib-metadata==1.6.0  # via -r requirements/base.txt, path.py, pluggy, pytest
 isort==4.3.21             # via pylint
 lazy-object-proxy==1.4.3  # via astroid
 lazy==1.4                 # via bok-choy
@@ -62,17 +55,17 @@ logilab-common==1.4.0     # via -r requirements/test.in
 logutils==0.3.5           # via -r requirements/base.txt
 mccabe==0.6.1             # via pylint
 mock==1.3.0               # via -r requirements/test.in, sure
-more-itertools==5.0.0     # via pytest
+more-itertools==8.2.0     # via pytest
 needle==0.5.0             # via bok-choy
 newrelic==5.10.0.138      # via -r requirements/base.txt, edx-django-utils
 nose==1.3.7               # via needle
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 packaging==20.3           # via pytest
 path.py==11.5.2           # via -r requirements/base.txt, edx-i18n-tools
-pathlib2==2.3.5           # via -r requirements/base.txt, importlib-metadata, pytest, pytest-django
+pathlib2==2.3.5           # via pytest
 pbr==5.4.4                # via -r requirements/base.txt, mock, stevedore
 pep257==0.7.0             # via -r requirements/test.in
-pillow==6.2.2             # via needle
+pillow==7.1.1             # via needle
 pinax-announcements==3.0.2  # via -r requirements/base.txt
 pluggy==0.13.1            # via pytest
 polib==1.1.0              # via -r requirements/base.txt, edx-i18n-tools
@@ -80,41 +73,39 @@ psutil==1.2.1             # via -r requirements/base.txt, edx-django-utils
 py==1.8.1                 # via pytest
 pycodestyle==2.5.0        # via -r requirements/test.in
 pycryptodomex==3.9.7      # via -r requirements/base.txt, pyjwkest
-pygments==2.5.2           # via -r requirements/base.txt, bpython
+pygments==2.6.1           # via -r requirements/base.txt, bpython
 pyjwkest==1.4.2           # via -r requirements/base.txt, edx-drf-extensions
 pyjwt==1.7.1              # via -r requirements/base.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint==1.7.1             # via -r requirements/test.in
 pymongo==3.10.1           # via -r requirements/base.txt, edx-opaque-keys
 pyparsing==2.4.6          # via packaging
 pytest-cov==2.8.1         # via -r requirements/test.in
-pytest-django==3.8.0      # via -r requirements/test.in
-pytest==4.6.9             # via -r requirements/test.in, pytest-cov, pytest-django
+pytest-django==3.9.0      # via -r requirements/test.in
+pytest==5.4.1             # via -r requirements/test.in, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/base.txt, edx-drf-extensions
-python-openid==2.2.5 ; python_version == "2.7"  # via -c requirements/constraints.txt, -r requirements/base.txt, social-auth-core
+python3-openid==3.1.0     # via -r requirements/base.txt, social-auth-core
 pytz==2019.3              # via -r requirements/base.txt, django
-pyyaml==5.3               # via -r requirements/base.txt, edx-django-release-util, edx-i18n-tools
+pyyaml==5.3.1             # via -r requirements/base.txt, edx-django-release-util, edx-i18n-tools
 regex==2020.2.20          # via -r requirements/base.txt, awesome-slugify
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
 requests==2.23.0          # via -r requirements/base.txt, bpython, edx-analytics-data-api-client, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
-scandir==1.10.0           # via -r requirements/base.txt, pathlib2
 selenium==2.53.6          # via -r requirements/test.in, bok-choy, needle
 semantic-version==2.8.4   # via -r requirements/base.txt, edx-drf-extensions
-singledispatch==3.4.0.3   # via astroid, pylint
-six==1.14.0               # via -r requirements/base.txt, astroid, blessings, bok-choy, bpython, django-appconf, django-braces, django-countries, django-dynamic-fixture, djangorestframework-csv, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-opaque-keys, libsass, logilab-common, mock, more-itertools, packaging, pathlib2, pyjwkest, pylint, pytest, python-dateutil, singledispatch, social-auth-app-django, social-auth-core, stevedore, sure, unittest2
+six==1.14.0               # via -r requirements/base.txt, astroid, blessings, bok-choy, bpython, django-braces, django-countries, django-dynamic-fixture, djangorestframework-csv, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-opaque-keys, libsass, logilab-common, mock, packaging, pathlib2, pyjwkest, pylint, python-dateutil, social-auth-app-django, social-auth-core, stevedore, sure, unittest2
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 social-auth-app-django==3.1.0  # via -r requirements/base.txt, edx-auth-backends
-social-auth-core==3.2.0   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
+social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/base.txt, edx-auth-backends, social-auth-app-django
+sqlparse==0.3.1           # via -r requirements/base.txt, django
 stevedore==1.32.0         # via -r requirements/base.txt, edx-opaque-keys
 sure==1.4.11              # via -r requirements/test.in
 testfixtures==4.14.3      # via -r requirements/test.in
 traceback2==1.4.0         # via unittest2
-typing==3.7.4.1           # via -r requirements/base.txt, curtsies
 unicodecsv==0.14.1        # via -r requirements/base.txt, djangorestframework-csv
 unidecode==0.4.21         # via -r requirements/base.txt, awesome-slugify
 unittest2==1.1.0          # via -r requirements/test.in
 urllib3==1.25.8           # via -r requirements/base.txt, elasticsearch, requests
-wcwidth==0.1.8            # via -r requirements/base.txt, curtsies, pytest
+wcwidth==0.1.9            # via -r requirements/base.txt, curtsies, pytest
 wrapt==1.11.2             # via -c requirements/constraints.txt, astroid
 zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,6 +4,7 @@
 #
 #    make upgrade
 #
+-e git+https://github.com/python-social-auth/social-app-django.git@ffa0fb99a80d11479bea2c4eae9a01ee835d52b9#egg=social-auth-app-django  # via -r requirements/base.txt
 argparse==1.4.0           # via unittest2
 astroid==1.6.6            # via -c requirements/constraints.txt, -r requirements/test.in, pylint
 attrs==19.3.0             # via pytest
@@ -94,7 +95,6 @@ selenium==2.53.6          # via -r requirements/test.in, bok-choy, needle
 semantic-version==2.8.4   # via -r requirements/base.txt, edx-drf-extensions
 six==1.14.0               # via -r requirements/base.txt, astroid, blessings, bok-choy, bpython, django-braces, django-countries, django-dynamic-fixture, djangorestframework-csv, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-opaque-keys, libsass, logilab-common, mock, packaging, pathlib2, pyjwkest, pylint, python-dateutil, social-auth-app-django, social-auth-core, stevedore, sure, unittest2
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
-social-auth-app-django==3.1.0  # via -r requirements/base.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/base.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.3.1           # via -r requirements/base.txt, django
 stevedore==1.32.0         # via -r requirements/base.txt, edx-opaque-keys

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -5,23 +5,17 @@
 #    make upgrade
 #
 appdirs==1.4.3            # via virtualenv
-configparser==4.0.2       # via importlib-metadata
-contextlib2==0.6.0.post1  # via importlib-metadata, importlib-resources, virtualenv, zipp
 distlib==0.3.0            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
-importlib-metadata==1.5.0  # via importlib-resources, pluggy, tox, virtualenv
-importlib-resources==1.3.1  # via virtualenv
+importlib-metadata==1.6.0  # via importlib-resources, pluggy, tox, virtualenv
+importlib-resources==1.4.0  # via virtualenv
 packaging==20.3           # via tox
-pathlib2==2.3.5           # via importlib-metadata, importlib-resources, virtualenv
 pluggy==0.13.1            # via tox
 py==1.8.1                 # via tox
 pyparsing==2.4.6          # via packaging
-scandir==1.10.0           # via pathlib2
-singledispatch==3.4.0.3   # via importlib-resources
-six==1.14.0               # via packaging, pathlib2, tox, virtualenv
+six==1.14.0               # via packaging, tox, virtualenv
 toml==0.10.0              # via tox
 tox-battery==0.5.2        # via -r requirements/tox.in
-tox==3.14.5               # via -r requirements/tox.in, tox-battery
-typing==3.7.4.1           # via importlib-resources
-virtualenv==20.0.10       # via tox
+tox==3.14.6               # via -r requirements/tox.in, tox-battery
+virtualenv==20.0.15       # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -7,28 +7,22 @@
 appdirs==1.4.3            # via -r requirements/tox.txt, virtualenv
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
-codecov==2.0.16           # via -r requirements/travis.in
-configparser==4.0.2       # via -r requirements/tox.txt, importlib-metadata
-contextlib2==0.6.0.post1  # via -r requirements/tox.txt, importlib-metadata, importlib-resources, virtualenv, zipp
-coverage==5.0.3           # via codecov
+codecov==2.0.22           # via -r requirements/travis.in
+coverage==5.0.4           # via codecov
 distlib==0.3.0            # via -r requirements/tox.txt, virtualenv
 filelock==3.0.12          # via -r requirements/tox.txt, tox, virtualenv
 idna==2.9                 # via requests
-importlib-metadata==1.5.0  # via -r requirements/tox.txt, importlib-resources, pluggy, tox, virtualenv
-importlib-resources==1.3.1  # via -r requirements/tox.txt, virtualenv
+importlib-metadata==1.6.0  # via -r requirements/tox.txt, importlib-resources, pluggy, tox, virtualenv
+importlib-resources==1.4.0  # via -r requirements/tox.txt, virtualenv
 packaging==20.3           # via -r requirements/tox.txt, tox
-pathlib2==2.3.5           # via -r requirements/tox.txt, importlib-metadata, importlib-resources, virtualenv
 pluggy==0.13.1            # via -r requirements/tox.txt, tox
 py==1.8.1                 # via -r requirements/tox.txt, tox
 pyparsing==2.4.6          # via -r requirements/tox.txt, packaging
 requests==2.23.0          # via codecov
-scandir==1.10.0           # via -r requirements/tox.txt, pathlib2
-singledispatch==3.4.0.3   # via -r requirements/tox.txt, importlib-resources
-six==1.14.0               # via -r requirements/tox.txt, packaging, pathlib2, singledispatch, tox, virtualenv
+six==1.14.0               # via -r requirements/tox.txt, packaging, tox, virtualenv
 toml==0.10.0              # via -r requirements/tox.txt, tox
 tox-battery==0.5.2        # via -r requirements/tox.txt
-tox==3.14.5               # via -r requirements/tox.txt, tox-battery
-typing==3.7.4.1           # via -r requirements/tox.txt, importlib-resources
+tox==3.14.6               # via -r requirements/tox.txt, tox-battery
 urllib3==1.25.8           # via requests
-virtualenv==20.0.10       # via -r requirements/tox.txt, tox
+virtualenv==20.0.15       # via -r requirements/tox.txt, tox
 zipp==1.2.0               # via -r requirements/tox.txt, importlib-metadata, importlib-resources


### PR DESCRIPTION
## Description 
Upgrade to django 2.2 and drop python 2 support.
**tests depend on https://github.com/edx/edx-analytics-dashboard/pull/986**
this https://github.com/edx/edx-analytics-dashboard/pull/986 is necessary. 
Part of .https://openedx.atlassian.net/browse/BOM-1360

### Reviewers
- [ ] @morenol 
- [x]  Is this ready for edX's review? 
- [ ] @jmbowman 
 
### Post-review
- [ ] Rebase and squash commits