### PR TITLE
BOM-1410 Updated drf-jwt constraint comment

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -43,7 +43,7 @@ django-model-utils<4.0.0
 # Dropped support for Django 2.
 django-waffle<0.19.0
 
-# django22 tests are failing. Constraint taken from https://github.com/edx/edx-drf-extensions version 4.0.1
+# django22 tests are failing. Constraint taken from https://github.com/edx/edx-drf-extensions version 5.0.2
 drf-jwt<1.15.0
 
 # 3.0.0 drops Python 2.7 support


### PR DESCRIPTION
**Issue:** [BOM-1410](https://openedx.atlassian.net/browse/BOM-1410)

### Description
- Updated `drf-jwt` constraint message due to new version release of `edx-drf-extensions`.