### PR TITLE
[BD] Remove deprecated assertDictContainsSubset

### DIFF
--- a/analytics_dashboard/courses/tests/test_presenters/test_presenters.py
+++ b/analytics_dashboard/courses/tests/test_presenters/test_presenters.py
@@ -290,7 +290,7 @@ class CourseEngagementVideoPresenterTests(TestCase):
                 expected = [{'id': utils.get_encoded_module_id(video_id), 'url': expected_url}]
                 self.assertEqual(len(actual_videos), len(expected))
                 for index, actual_video in enumerate(actual_videos):
-                    utils.assert_dict_contains_subset(expected[index], actual_video)
+                    utils.assert_dict_contains_subset(actual_video, expected[index])
 
     def test_module_id_to_data_id(self):
         opaque_key_id = 'i4x-edX-DemoX-video-0b9e39477cf34507a7a48f74be381fdd'
@@ -305,7 +305,7 @@ class CourseEngagementVideoPresenterTests(TestCase):
             return '{}-{}'.format(parent_block, child_block)
         user_data = {'users_at_start': 10}
         self.presenter.post_process_adding_data_to_blocks(user_data, 'parent', 'child', url_func)
-        utils.assert_dict_contains_subset({'url': 'parent-child'}, user_data)
+        utils.assert_dict_contains_subset(user_data, {'url': 'parent-child'})
 
         empty_data = {}
         self.presenter.post_process_adding_data_to_blocks(empty_data, 'parent', 'child', None)
@@ -468,7 +468,7 @@ class CourseEngagementVideoPresenterTests(TestCase):
     def assertTimeline(self, expected_timeline, actual_timeline):
         self.assertEqual(len(expected_timeline), len(actual_timeline))
         for expected, actual in zip(expected_timeline, actual_timeline):
-            utils.assert_dict_contains_subset(actual, expected)
+            utils.assert_dict_contains_subset(expected, actual)
 
     def test_build_live_url(self):
         actual_view_live_url = self.presenter.build_view_live_url('a-url', self.VIDEO_ID)
@@ -980,7 +980,7 @@ class CoursePerformancePresenterTests(TestCase):
                 'name': problem['name'],
                 'children': []
             }
-            utils.assert_dict_contains_subset(expected, actual)
+            utils.assert_dict_contains_subset(actual, expected)
 
     def test_sections(self):
         """ Verify the presenter returns a specific assignment. """

--- a/analytics_dashboard/courses/tests/test_presenters/test_presenters.py
+++ b/analytics_dashboard/courses/tests/test_presenters/test_presenters.py
@@ -290,7 +290,7 @@ class CourseEngagementVideoPresenterTests(TestCase):
                 expected = [{'id': utils.get_encoded_module_id(video_id), 'url': expected_url}]
                 self.assertEqual(len(actual_videos), len(expected))
                 for index, actual_video in enumerate(actual_videos):
-                    self.assertDictContainsSubset(expected[index], actual_video)
+                    utils.assert_dict_contains_subset(expected[index], actual_video)
 
     def test_module_id_to_data_id(self):
         opaque_key_id = 'i4x-edX-DemoX-video-0b9e39477cf34507a7a48f74be381fdd'
@@ -305,7 +305,7 @@ class CourseEngagementVideoPresenterTests(TestCase):
             return '{}-{}'.format(parent_block, child_block)
         user_data = {'users_at_start': 10}
         self.presenter.post_process_adding_data_to_blocks(user_data, 'parent', 'child', url_func)
-        self.assertDictContainsSubset({'url': 'parent-child'}, user_data)
+        utils.assert_dict_contains_subset({'url': 'parent-child'}, user_data)
 
         empty_data = {}
         self.presenter.post_process_adding_data_to_blocks(empty_data, 'parent', 'child', None)
@@ -468,7 +468,7 @@ class CourseEngagementVideoPresenterTests(TestCase):
     def assertTimeline(self, expected_timeline, actual_timeline):
         self.assertEqual(len(expected_timeline), len(actual_timeline))
         for expected, actual in zip(expected_timeline, actual_timeline):
-            self.assertDictContainsSubset(actual, expected)
+            utils.assert_dict_contains_subset(actual, expected)
 
     def test_build_live_url(self):
         actual_view_live_url = self.presenter.build_view_live_url('a-url', self.VIDEO_ID)
@@ -980,7 +980,7 @@ class CoursePerformancePresenterTests(TestCase):
                 'name': problem['name'],
                 'children': []
             }
-            self.assertDictContainsSubset(expected, actual)
+            utils.assert_dict_contains_subset(expected, actual)
 
     def test_sections(self):
         """ Verify the presenter returns a specific assignment. """

--- a/analytics_dashboard/courses/tests/test_views/test_engagement.py
+++ b/analytics_dashboard/courses/tests/test_views/test_engagement.py
@@ -190,7 +190,7 @@ class CourseEngagementVideoMixin(CourseEngagementViewTestMixin, CourseStructureV
         expected = {
             'sections': self.sections,
         }
-        utils.assert_dict_contains_subset(expected, context)
+        utils.assert_dict_contains_subset(context, expected)
 
     @httpretty.activate
     @patch('courses.presenters.engagement.CourseEngagementVideoPresenter.sections', Mock(return_value=dict()))

--- a/analytics_dashboard/courses/tests/test_views/test_engagement.py
+++ b/analytics_dashboard/courses/tests/test_views/test_engagement.py
@@ -190,7 +190,7 @@ class CourseEngagementVideoMixin(CourseEngagementViewTestMixin, CourseStructureV
         expected = {
             'sections': self.sections,
         }
-        self.assertDictContainsSubset(expected, context)
+        utils.assert_dict_contains_subset(expected, context)
 
     @httpretty.activate
     @patch('courses.presenters.engagement.CourseEngagementVideoPresenter.sections', Mock(return_value=dict()))

--- a/analytics_dashboard/courses/tests/test_views/test_learners.py
+++ b/analytics_dashboard/courses/tests/test_views/test_learners.py
@@ -53,10 +53,10 @@ class LearnersViewTests(ViewTestMixin, TestCase):
                 course_id=CourseSamples.DEMO_COURSE_ID
             ),
         }
-        assert_dict_contains_subset(dict(list(expected_context_subset.items())), response.context)
+        assert_dict_contains_subset(response.context, dict(list(expected_context_subset.items())))
         assert_dict_contains_subset(
+            response.context['js_data']['course'],
             dict(list(default_expected_context_subset.items())),
-            response.context['js_data']['course']
         )
 
     def get_mock_data(self, *args, **kwargs):

--- a/analytics_dashboard/courses/tests/test_views/test_learners.py
+++ b/analytics_dashboard/courses/tests/test_views/test_learners.py
@@ -15,7 +15,7 @@ from testfixtures import LogCapture
 from waffle.testutils import override_flag, override_switch
 
 from courses.tests.test_views import ViewTestMixin
-from courses.tests.utils import CourseSamples
+from courses.tests.utils import assert_dict_contains_subset, CourseSamples
 
 
 @httpretty.activate
@@ -53,8 +53,8 @@ class LearnersViewTests(ViewTestMixin, TestCase):
                 course_id=CourseSamples.DEMO_COURSE_ID
             ),
         }
-        self.assertDictContainsSubset(dict(list(expected_context_subset.items())), response.context)
-        self.assertDictContainsSubset(
+        assert_dict_contains_subset(dict(list(expected_context_subset.items())), response.context)
+        assert_dict_contains_subset(
             dict(list(default_expected_context_subset.items())),
             response.context['js_data']['course']
         )

--- a/analytics_dashboard/courses/tests/test_views/test_performance.py
+++ b/analytics_dashboard/courses/tests/test_views/test_performance.py
@@ -145,7 +145,7 @@ class CoursePerformanceGradedMixin(CoursePerformanceViewTestMixin):
             'assignments': self.factory.presented_assignments,
             'no_data_message': u'No submissions received for these assignments.'
         }
-        self.assertDictContainsSubset(expected, context)
+        utils.assert_dict_contains_subset(expected, context)
 
     def get_expected_secondary_nav(self, course_id):
         expected = super(CoursePerformanceGradedMixin, self).get_expected_secondary_nav(course_id)
@@ -186,7 +186,7 @@ class CoursePerformanceUngradedMixin(CoursePerformanceViewTestMixin):
             'sections': self.sections,
             'no_data_message': 'No submissions received for these exercises.'
         }
-        self.assertDictContainsSubset(expected, context)
+        utils.assert_dict_contains_subset(expected, context)
 
     def get_expected_secondary_nav(self, course_id):
         expected = super(CoursePerformanceUngradedMixin, self).get_expected_secondary_nav(course_id)
@@ -241,7 +241,7 @@ class CoursePerformanceAnswerDistributionMixin(CoursePerformanceViewTestMixin):
         self.assertValidContext(response.context)
 
         self.assertListEqual(context['questions'], rv.questions)
-        self.assertDictContainsSubset(
+        utils.assert_dict_contains_subset(
             {
                 'page_title': 'Performance: Problem Submissions',
                 'problem_id': problem_id,
@@ -251,7 +251,7 @@ class CoursePerformanceAnswerDistributionMixin(CoursePerformanceViewTestMixin):
                 'active_question': rv.active_question,
                 'questions': rv.questions
             }, context)
-        self.assertDictContainsSubset(
+        utils.assert_dict_contains_subset(
             {
                 'isRandom': rv.is_random,
                 'answerType': rv.answer_type,
@@ -334,7 +334,7 @@ class CoursePerformanceGradedContentViewTests(CoursePerformanceGradedMixin, Test
             'assignment_types': self.factory.presented_assignment_types,
             'grading_policy': self.factory.presented_grading_policy,
         }
-        self.assertDictContainsSubset(expected, context)
+        utils.assert_dict_contains_subset(expected, context)
 
 
 @override_switch('enable_course_api', active=True)
@@ -405,7 +405,7 @@ class CoursePerformanceAssignmentViewTests(CoursePerformanceGradedMixin, TestCas
             'assignment_type': self.assignment_type,
             'assignment': self.assignment,
         }
-        self.assertDictContainsSubset(expected, context)
+        utils.assert_dict_contains_subset(expected, context)
 
     @httpretty.activate
     @patch('courses.presenters.performance.CoursePerformancePresenter.assignment', Mock(return_value=None))
@@ -690,7 +690,7 @@ class CoursePerformanceLearningOutcomesAnswersDistributionViewTests(
         self.assertSecondaryNavs(response.context['secondary_nav_items'], course_id)
 
         self.assertListEqual(context['questions'], rv.questions)
-        self.assertDictContainsSubset(
+        utils.assert_dict_contains_subset(
             {
                 'problem_id': problem_id,
                 'view_live_url': '{}/{}/jump_to/{}'.format(settings.LMS_COURSE_SHORTCUT_BASE_URL, course_id,
@@ -698,7 +698,7 @@ class CoursePerformanceLearningOutcomesAnswersDistributionViewTests(
                 'active_question': rv.active_question,
                 'questions': rv.questions
             }, context)
-        self.assertDictContainsSubset(
+        utils.assert_dict_contains_subset(
             {
                 'isRandom': rv.is_random,
                 'answerType': rv.answer_type,

--- a/analytics_dashboard/courses/tests/test_views/test_performance.py
+++ b/analytics_dashboard/courses/tests/test_views/test_performance.py
@@ -145,7 +145,7 @@ class CoursePerformanceGradedMixin(CoursePerformanceViewTestMixin):
             'assignments': self.factory.presented_assignments,
             'no_data_message': u'No submissions received for these assignments.'
         }
-        utils.assert_dict_contains_subset(expected, context)
+        utils.assert_dict_contains_subset(context, expected)
 
     def get_expected_secondary_nav(self, course_id):
         expected = super(CoursePerformanceGradedMixin, self).get_expected_secondary_nav(course_id)
@@ -186,7 +186,7 @@ class CoursePerformanceUngradedMixin(CoursePerformanceViewTestMixin):
             'sections': self.sections,
             'no_data_message': 'No submissions received for these exercises.'
         }
-        utils.assert_dict_contains_subset(expected, context)
+        utils.assert_dict_contains_subset(context, expected)
 
     def get_expected_secondary_nav(self, course_id):
         expected = super(CoursePerformanceUngradedMixin, self).get_expected_secondary_nav(course_id)
@@ -242,6 +242,7 @@ class CoursePerformanceAnswerDistributionMixin(CoursePerformanceViewTestMixin):
 
         self.assertListEqual(context['questions'], rv.questions)
         utils.assert_dict_contains_subset(
+            context,
             {
                 'page_title': 'Performance: Problem Submissions',
                 'problem_id': problem_id,
@@ -250,14 +251,17 @@ class CoursePerformanceAnswerDistributionMixin(CoursePerformanceViewTestMixin):
                                                            problem_id),
                 'active_question': rv.active_question,
                 'questions': rv.questions
-            }, context)
+            },
+        )
         utils.assert_dict_contains_subset(
+            json.loads(context['page_data'])['course'],
             {
                 'isRandom': rv.is_random,
                 'answerType': rv.answer_type,
                 'answerDistribution': rv.answer_distribution,
                 'answerDistributionLimited': rv.answer_distribution_limited,
-            }, json.loads(context['page_data'])['course'])
+            },
+        )
 
         self.assertPrimaryNav(response.context['primary_nav_item'], course_id)
         self.assertSecondaryNavs(response.context['secondary_nav_items'], course_id)
@@ -334,7 +338,7 @@ class CoursePerformanceGradedContentViewTests(CoursePerformanceGradedMixin, Test
             'assignment_types': self.factory.presented_assignment_types,
             'grading_policy': self.factory.presented_grading_policy,
         }
-        utils.assert_dict_contains_subset(expected, context)
+        utils.assert_dict_contains_subset(context, expected)
 
 
 @override_switch('enable_course_api', active=True)
@@ -405,7 +409,7 @@ class CoursePerformanceAssignmentViewTests(CoursePerformanceGradedMixin, TestCas
             'assignment_type': self.assignment_type,
             'assignment': self.assignment,
         }
-        utils.assert_dict_contains_subset(expected, context)
+        utils.assert_dict_contains_subset(context, expected)
 
     @httpretty.activate
     @patch('courses.presenters.performance.CoursePerformancePresenter.assignment', Mock(return_value=None))
@@ -691,17 +695,21 @@ class CoursePerformanceLearningOutcomesAnswersDistributionViewTests(
 
         self.assertListEqual(context['questions'], rv.questions)
         utils.assert_dict_contains_subset(
+            context,
             {
                 'problem_id': problem_id,
                 'view_live_url': '{}/{}/jump_to/{}'.format(settings.LMS_COURSE_SHORTCUT_BASE_URL, course_id,
                                                            problem_id),
                 'active_question': rv.active_question,
                 'questions': rv.questions
-            }, context)
+            },
+        )
         utils.assert_dict_contains_subset(
+            json.loads(context['page_data'])['course'],
             {
                 'isRandom': rv.is_random,
                 'answerType': rv.answer_type,
                 'answerDistribution': rv.answer_distribution,
                 'answerDistributionLimited': rv.answer_distribution_limited,
-            }, json.loads(context['page_data'])['course'])
+            },
+        )

--- a/analytics_dashboard/courses/tests/utils.py
+++ b/analytics_dashboard/courses/tests/utils.py
@@ -896,7 +896,7 @@ def get_mock_programs():
     }]
 
 
-def assert_dict_contains_subset(subset, dictionary):
+def assert_dict_contains_subset(dictionary, subset):
     """
     This is an alternative method to replace assertDictContainsSubset that
     was deprecated for python 3.

--- a/analytics_dashboard/courses/tests/utils.py
+++ b/analytics_dashboard/courses/tests/utils.py
@@ -894,3 +894,19 @@ def get_mock_programs():
         'program_id': ProgramSamples.DEMO_PROGRAM4_ID,
         'created': CREATED_DATETIME_STRING,
     }]
+
+
+def assert_dict_contains_subset(subset, dictionary):
+    """
+    This is an alternative method to replace assertDictContainsSubset that
+    was deprecated for python 3.
+    This was inspired by
+    https://stackoverflow.com/questions/20050913/python-unittests-assertdictcontainssubset-recommended-alternative?rq=1
+    """
+    assert_message = 'The dict {} is not a subset of {}'.format(
+        subset,
+        dictionary,
+    )
+
+    extracted_content = dict([(key, dictionary.get(key)) for key in subset.keys() if key in dictionary])
+    assert subset == extracted_content, assert_message


### PR DESCRIPTION
## Description 
Remove assertDictContainsSubset and replace it with assert_dics_contains_subset.
Part of .https://openedx.atlassian.net/browse/BOM-1360

### Reviewers
- [ ] @morenol 
- [ ]  Is this ready for edX's review? 
- [ ] @jmbowman 
 
### Post-review
- [ ] Rebase and squash commits