### PR TITLE
Fix python 3.8 failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,10 +58,6 @@ matrix:
       env:
         TESTNAME=test-python-38
         TARGETS="PYTHON_ENV=py38 requirements.js test_python"
-  allow_failures:
-    - python: 3.8
-
-
 
 after_failure:
     # Print the list of running containers to rule out a killed container as a cause of failure

--- a/analytics_dashboard/courses/tests/test_views/__init__.py
+++ b/analytics_dashboard/courses/tests/test_views/__init__.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import json
 import logging
 
-from unittest.mock import _is_started, Mock, patch
+from unittest.mock import Mock, patch
 import httpretty
 from analyticsclient.exceptions import NotFoundError
 from ddt import data, ddt
@@ -343,8 +343,15 @@ class PatchMixin:
             _patch.start()
 
     def stop_patching(self):
-        for _patch in self.patches:
-            if _is_started(_patch):
+        # TODO: Just for the compatibility with python 3.5.
+        # Can be removed once support is dropped
+        try:
+            from unittest.mock import _is_started  # pylint: disable=import-outside-toplevel
+            for _patch in self.patches:
+                if _is_started(_patch):
+                    _patch.stop()
+        except ImportError:
+            for _patch in self.patches:
                 _patch.stop()
 
     def clear_patches(self):


### PR DESCRIPTION
JIRA: [BOM-1627](https://openedx.atlassian.net/browse/BOM-1627)

`_is_started` is removed from mock in python 3.8.3.

> Calling stop() on an unstarted or stopped unittest.mock.patch() object will now return None instead of raising RuntimeError, making the method idempotent

https://mock.readthedocs.io/en/latest/changelog.html#id10

### Changes:

- added python3.8-dev
- removed unittest.mock's  _is_started()
- compatibility for pyhton 3.5 unittest.mock's  _is_started()
- removed allow_failures from python 3.8 travis workers