### PR TITLE
Added retry in OAuth request with no timeout

### DIFF
--- a/analytics_dashboard/courses/permissions.py
+++ b/analytics_dashboard/courses/permissions.py
@@ -152,6 +152,7 @@ def _refresh_user_course_permissions(user):
         user (User) --  User whose permissions should be refreshed
     """
     response_data = None
+    response = None
     try:
         client = OAuthAPIClient(
             settings.BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL,
@@ -186,14 +187,14 @@ def _refresh_user_course_permissions(user):
                 logger.debug('Completed retrieval of course_ids. Retrieved info for %d courses.', len(course_ids))
 
         allowed_courses = list(set(course_ids))
-
-    except Exception as e:
+    except Exception as exception:
         logger.exception(
-            "Unable to retrieve course permissions for username=%s and response=%s",
+            "Unable to retrieve course permissions for username=%s and response_data=%s response=%s",
             user.username,
-            response_data
+            response_data,
+            response
         )
-        raise PermissionsRetrievalFailedError(e)
+        raise PermissionsRetrievalFailedError(exception)
 
     set_user_course_permissions(user, allowed_courses)
 


### PR DESCRIPTION
### [TNL-7448](https://openedx.atlassian.net/browse/TNL-7448)

There is HTTP Error 504 on Insights which is caused by timing out while calling  OAuth token.  On Local machine, I was able to reproduce a similar issue so I have added logs to confirm the cause and also added request retry with None timeout in case of exception.

