### PR TITLE
increase timeout on call course_ids api for permissions

### DIFF
--- a/analytics_dashboard/courses/permissions.py
+++ b/analytics_dashboard/courses/permissions.py
@@ -171,6 +171,7 @@ def _refresh_user_course_permissions(user):
                     'page': page,
                     'page_size': 1000,
                 },
+                timeout=(3.05, 15),  # the course_ids API can be slow, so use a higher READ timeout
             )
             response_data = response.json()
             response.raise_for_status()  # response_data could be an error response

--- a/analytics_dashboard/courses/tests/test_permissions.py
+++ b/analytics_dashboard/courses/tests/test_permissions.py
@@ -223,7 +223,8 @@ class PermissionsTests(TestCase):
                         'page_size': 1000,
                         'role': 'staff',
                         'username': self.user.username
-                    }
+                    },
+                    timeout=(3.05, 15)
                 ),
                 mock.call().get().json(),
                 mock.call().get().raise_for_status(),


### PR DESCRIPTION
Some partners have reported failures on loading insights data. Inspection of Splunk logs indicates a timeout on the call to course_ids for these partners. The timeouts are 499s- nginx for "client hung up before server finished". This will bump up the READ timeout in the rest client from 5 to 15 seconds. I don't have any data to prove that 15 is an adequate number. I highly doubt that the timeout issues are caused by the CONNECT section of the request, so I am leaving it as the default (3.05). See: https://github.com/edx/edx-rest-api-client/blob/master/edx_rest_api_client/client.py#L22-L23