### PR TITLE
Updated the Build status badge to point to travis-cli.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Part of [Open edX](https://open.edx.org/)
 
-edX Analytics Dashboard [![BuildStatus](https://travis-ci.org/edx/edx-analytics-dashboard.svg?branch=master)](https://travis-ci.org/edx/edx-analytics-dashboard) [![CoverageStatus](https://img.shields.io/coveralls/edx/edx-analytics-dashboard.svg)](https://coveralls.io/r/edx/edx-analytics-dashboard?branch=master)
+edX Analytics Dashboard [![BuildStatus](https://travis-ci.com/edx/edx-analytics-dashboard.svg?branch=master)](https://travis-ci.com/edx/edx-analytics-dashboard) [![CoverageStatus](https://img.shields.io/coveralls/edx/edx-analytics-dashboard.svg)](https://coveralls.io/r/edx/edx-analytics-dashboard?branch=master)
 =======================
 Dashboard to display course analytics to course teams
 


### PR DESCRIPTION
Updated the README file.
Build status badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'

JIRA: https://openedx.atlassian.net/browse/BOM-2089 