### PR TITLE
Remove the extra slash in the favicon.ico href link

### DIFF
--- a/analytics_dashboard/templates/base.html
+++ b/analytics_dashboard/templates/base.html
@@ -13,7 +13,7 @@ Base template pages.
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <link rel="shortcut icon" type="image/png" href="{{STATIC_URL}}/images/favicon.ico"/>
+    <link rel="shortcut icon" type="image/png" href="{{STATIC_URL}}images/favicon.ico"/>
 
     <title>{% block title %}| {% settings_value 'FULL_APPLICATION_NAME' %}{% endblock title %}</title>
 


### PR DESCRIPTION
https://openedx.atlassian.net/browse/DESUPPORT-698

The malformed link is in the base template.

The extra slash is making the pages point to this icon link:
https://d2hgjz8aywqlvr.cloudfront.net/static//images/favicon.ico
instead of this correct icon link:
https://d2hgjz8aywqlvr.cloudfront.net/static/images/favicon.ico
This change should make all Insights pages load the new updated logo as the favicon.

BTW, the `STATIC_URL` value is supposed to have a trailing `/` - it's explicitly called out in this doc:
https://docs.djangoproject.com/en/dev/ref/settings/#static-url