### PR TITLE
BOM-2247: Upgrade pip-tools to v5.5.*

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,7 +19,7 @@ cwcwidth==0.1.4           # via bpython, curtsies
 defusedxml==0.7.1         # via python3-openid, social-auth-core
 django-appconf==1.0.4     # via -r requirements/base.in
 django-braces==1.14.0     # via -r requirements/base.in
-django-countries==7.1     # via -r requirements/base.in
+django-countries==7.2     # via -r requirements/base.in
 django-crispy-forms==1.11.2  # via -r requirements/base.in
 django-crum==0.7.9        # via edx-django-utils, edx-toggles
 django-lang-pref-middleware==1.0.0  # via -r requirements/base.in
@@ -35,14 +35,14 @@ edx-analytics-data-api-client==0.17.0  # via -r requirements/base.in
 edx-auth-backends==3.3.3  # via -r requirements/base.in
 edx-ccx-keys==1.2.0       # via -r requirements/base.in
 edx-django-release-util==1.0.0  # via -r requirements/base.in
-edx-django-utils==3.16.0  # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client, edx-toggles
+edx-django-utils==4.0.0   # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client, edx-toggles
 edx-drf-extensions==6.5.0  # via -r requirements/base.in
 edx-i18n-tools==0.5.3     # via -r requirements/base.in
 edx-opaque-keys==2.2.0    # via -r requirements/base.in, edx-ccx-keys, edx-drf-extensions
 edx-rest-api-client==5.3.0  # via -r requirements/base.in
 edx-toggles==4.1.0        # via -r requirements/base.in
 future==0.18.2            # via pyjwkest
-greenlet==1.0.0           # via bpython
+greenlet==1.1.0           # via bpython
 idna==2.10                # via requests
 jinja2==2.11.3            # via code-annotations
 libsass==0.11.1           # via -r requirements/base.in
@@ -52,18 +52,18 @@ newrelic==6.2.0.156       # via edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 path.py==12.5.0           # via -r requirements/base.in, edx-i18n-tools
 path==15.1.2              # via path.py
-pbr==5.5.1                # via stevedore
+pbr==5.6.0                # via stevedore
 pinax-announcements==4.0.0  # via -r requirements/base.in
 polib==1.1.1              # via edx-i18n-tools
 psutil==5.8.0             # via edx-django-utils
 pycparser==2.20           # via cffi
 pycryptodomex==3.10.1     # via pyjwkest
-pygments==2.8.1           # via bpython
+pygments==2.9.0           # via bpython
 pyjwkest==1.4.2           # via edx-drf-extensions
-pyjwt[crypto]==2.0.1      # via drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
-pymongo==3.11.3           # via edx-opaque-keys
+pyjwt[crypto]==2.1.0      # via drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
+pymongo==3.11.4           # via edx-opaque-keys
 python-dateutil==2.8.1    # via edx-drf-extensions
-python-slugify==4.0.1     # via code-annotations
+python-slugify==5.0.2     # via code-annotations
 python3-openid==3.2.0     # via social-auth-core
 pytz==2021.1              # via django
 pyxdg==0.27               # via bpython
@@ -73,7 +73,7 @@ requests-oauthlib==1.3.0  # via social-auth-core
 requests==2.25.1          # via -r requirements/base.in, bpython, edx-analytics-data-api-client, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via edx-drf-extensions
 semantic-version==2.8.5   # via edx-drf-extensions
-six==1.15.0               # via blessings, django-braces, djangorestframework-csv, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, libsass, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core
+six==1.16.0               # via blessings, django-braces, djangorestframework-csv, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, libsass, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core
 slumber==0.7.1            # via edx-rest-api-client
 social-auth-core==3.2.0   # via -c requirements/constraints.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.4.1           # via django

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -14,7 +14,7 @@
 # TODO: Many pinned dependencies should be unpinned and/or moved to this constraints file.
 
 # See https://openedx.atlassian.net/browse/BOM-2247 for details.
-pip-tools==5.3.0
+pip-tools<6.0
 
 # Pin to pylint version used in edx-lint
 pylint==2.4.4

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -7,7 +7,7 @@
 -e git+https://github.com/python-social-auth/social-app-django.git@ffa0fb99a80d11479bea2c4eae9a01ee835d52b9#egg=social-auth-app-django  # via -r requirements/base.txt, edx-auth-backends
 alabaster==0.7.12         # via sphinx
 awesome-slugify==1.6.5    # via -r requirements/base.txt
-babel==2.9.0              # via sphinx
+babel==2.9.1              # via sphinx
 blessings==1.7            # via -r requirements/base.txt, curtsies
 bpython==0.21             # via -r requirements/base.txt
 certifi==2020.12.5        # via -r requirements/base.txt, requests
@@ -21,7 +21,7 @@ cwcwidth==0.1.4           # via -r requirements/base.txt, bpython, curtsies
 defusedxml==0.7.1         # via -r requirements/base.txt, python3-openid, social-auth-core
 django-appconf==1.0.4     # via -r requirements/base.txt
 django-braces==1.14.0     # via -r requirements/base.txt
-django-countries==7.1     # via -r requirements/base.txt
+django-countries==7.2     # via -r requirements/base.txt
 django-crispy-forms==1.11.2  # via -r requirements/base.txt
 django-crum==0.7.9        # via -r requirements/base.txt, edx-django-utils, edx-toggles
 django-lang-pref-middleware==1.0.0  # via -r requirements/base.txt
@@ -38,14 +38,14 @@ edx-analytics-data-api-client==0.17.0  # via -r requirements/base.txt
 edx-auth-backends==3.3.3  # via -r requirements/base.txt
 edx-ccx-keys==1.2.0       # via -r requirements/base.txt
 edx-django-release-util==1.0.0  # via -r requirements/base.txt
-edx-django-utils==3.16.0  # via -r requirements/base.txt, edx-drf-extensions, edx-rest-api-client, edx-toggles
+edx-django-utils==4.0.0   # via -r requirements/base.txt, edx-drf-extensions, edx-rest-api-client, edx-toggles
 edx-drf-extensions==6.5.0  # via -r requirements/base.txt
 edx-i18n-tools==0.5.3     # via -r requirements/base.txt
 edx-opaque-keys==2.2.0    # via -r requirements/base.txt, edx-ccx-keys, edx-drf-extensions
 edx-rest-api-client==5.3.0  # via -r requirements/base.txt
 edx-toggles==4.1.0        # via -r requirements/base.txt
 future==0.18.2            # via -r requirements/base.txt, pyjwkest
-greenlet==1.0.0           # via -r requirements/base.txt, bpython
+greenlet==1.1.0           # via -r requirements/base.txt, bpython
 idna==2.10                # via -r requirements/base.txt, requests
 imagesize==1.2.0          # via sphinx
 jinja2==2.11.3            # via -r requirements/base.txt, code-annotations, sphinx
@@ -56,18 +56,18 @@ newrelic==6.2.0.156       # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 path.py==12.5.0           # via -r requirements/base.txt, edx-i18n-tools
 path==15.1.2              # via -r requirements/base.txt, path.py
-pbr==5.5.1                # via -r requirements/base.txt, stevedore
+pbr==5.6.0                # via -r requirements/base.txt, stevedore
 pinax-announcements==4.0.0  # via -r requirements/base.txt
 polib==1.1.1              # via -r requirements/base.txt, edx-i18n-tools
 psutil==5.8.0             # via -r requirements/base.txt, edx-django-utils
 pycparser==2.20           # via -r requirements/base.txt, cffi
 pycryptodomex==3.10.1     # via -r requirements/base.txt, pyjwkest
-pygments==2.8.1           # via -r requirements/base.txt, bpython, sphinx
+pygments==2.9.0           # via -r requirements/base.txt, bpython, sphinx
 pyjwkest==1.4.2           # via -r requirements/base.txt, edx-drf-extensions
-pyjwt[crypto]==2.0.1      # via -r requirements/base.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
-pymongo==3.11.3           # via -r requirements/base.txt, edx-opaque-keys
+pyjwt[crypto]==2.1.0      # via -r requirements/base.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
+pymongo==3.11.4           # via -r requirements/base.txt, edx-opaque-keys
 python-dateutil==2.8.1    # via -r requirements/base.txt, edx-drf-extensions
-python-slugify==4.0.1     # via -r requirements/base.txt, code-annotations
+python-slugify==5.0.2     # via -r requirements/base.txt, code-annotations
 python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
 pytz==2021.1              # via -r requirements/base.txt, babel, django
 pyxdg==0.27               # via -r requirements/base.txt, bpython
@@ -77,7 +77,7 @@ requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
 requests==2.25.1          # via -r requirements/base.txt, bpython, edx-analytics-data-api-client, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
 semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions
-six==1.15.0               # via -r requirements/base.txt, blessings, django-braces, djangorestframework-csv, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, libsass, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, sphinx
+six==1.16.0               # via -r requirements/base.txt, blessings, django-braces, djangorestframework-csv, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, libsass, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, sphinx
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 snowballstemmer==2.1.0    # via sphinx
 social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/base.txt, edx-auth-backends, social-auth-app-django

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -6,7 +6,7 @@
 #
 -e git+https://github.com/python-social-auth/social-app-django.git@ffa0fb99a80d11479bea2c4eae9a01ee835d52b9#egg=social-auth-app-django  # via -r requirements/test.txt, edx-auth-backends
 astroid==2.3.3            # via -r requirements/test.txt, pylint
-attrs==20.3.0             # via -r requirements/test.txt, pytest
+attrs==21.2.0             # via -r requirements/test.txt, pytest
 awesome-slugify==1.6.5    # via -r requirements/test.txt
 blessings==1.7            # via -r requirements/test.txt, curtsies
 bok-choy==1.1.1           # via -r requirements/test.txt
@@ -24,7 +24,7 @@ ddt==1.4.2                # via -r requirements/test.txt
 defusedxml==0.7.1         # via -r requirements/test.txt, python3-openid, social-auth-core
 django-appconf==1.0.4     # via -r requirements/test.txt
 django-braces==1.14.0     # via -r requirements/test.txt
-django-countries==7.1     # via -r requirements/test.txt
+django-countries==7.2     # via -r requirements/test.txt
 django-crispy-forms==1.11.2  # via -r requirements/test.txt
 django-crum==0.7.9        # via -r requirements/test.txt, edx-django-utils, edx-toggles
 django-debug-toolbar==3.2.1  # via -r requirements/local.in
@@ -42,7 +42,7 @@ edx-analytics-data-api-client==0.17.0  # via -r requirements/test.txt
 edx-auth-backends==3.3.3  # via -r requirements/test.txt
 edx-ccx-keys==1.2.0       # via -r requirements/test.txt
 edx-django-release-util==1.0.0  # via -r requirements/test.txt
-edx-django-utils==3.16.0  # via -r requirements/test.txt, edx-drf-extensions, edx-rest-api-client, edx-toggles
+edx-django-utils==4.0.0   # via -r requirements/test.txt, edx-drf-extensions, edx-rest-api-client, edx-toggles
 edx-drf-extensions==6.5.0  # via -r requirements/test.txt
 edx-i18n-tools==0.5.3     # via -r requirements/test.txt
 edx-opaque-keys==2.2.0    # via -r requirements/test.txt, edx-ccx-keys, edx-drf-extensions
@@ -50,7 +50,7 @@ edx-rest-api-client==5.3.0  # via -r requirements/test.txt
 edx-toggles==4.1.0        # via -r requirements/test.txt
 elasticsearch==2.4.1      # via -r requirements/test.txt
 future==0.18.2            # via -r requirements/test.txt, pyjwkest
-greenlet==1.0.0           # via -r requirements/test.txt, bpython
+greenlet==1.1.0           # via -r requirements/test.txt, bpython
 httpretty==1.0.5          # via -r requirements/test.txt
 idna==2.10                # via -r requirements/test.txt, requests
 isort==4.3.21             # via -r requirements/test.txt, pylint
@@ -67,9 +67,9 @@ oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib, soc
 packaging==20.9           # via -r requirements/test.txt, pytest
 path.py==12.5.0           # via -r requirements/test.txt, edx-i18n-tools
 path==15.1.2              # via -r requirements/test.txt, path.py
-pbr==5.5.1                # via -r requirements/test.txt, stevedore
+pbr==5.6.0                # via -r requirements/test.txt, stevedore
 pinax-announcements==4.0.0  # via -r requirements/test.txt
-pip-tools==5.3.0          # via -c requirements/constraints.txt, -r requirements/pip_tools.txt
+pip-tools==5.5.0          # via -c requirements/constraints.txt, -r requirements/pip_tools.txt
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
 polib==1.1.1              # via -r requirements/test.txt, edx-i18n-tools
 psutil==5.8.0             # via -r requirements/test.txt, edx-django-utils
@@ -78,17 +78,17 @@ pycodestyle==2.7.0        # via -r requirements/test.txt
 pycparser==2.20           # via -r requirements/test.txt, cffi
 pycryptodomex==3.10.1     # via -r requirements/test.txt, pyjwkest
 pydocstyle==6.0.0         # via -r requirements/test.txt
-pygments==2.8.1           # via -r requirements/test.txt, bpython
+pygments==2.9.0           # via -r requirements/test.txt, bpython
 pyjwkest==1.4.2           # via -r requirements/test.txt, edx-drf-extensions
-pyjwt[crypto]==2.0.1      # via -r requirements/test.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
+pyjwt[crypto]==2.1.0      # via -r requirements/test.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint==2.4.4             # via -c requirements/constraints.txt, -r requirements/test.txt
-pymongo==3.11.3           # via -r requirements/test.txt, edx-opaque-keys
+pymongo==3.11.4           # via -r requirements/test.txt, edx-opaque-keys
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-cov==2.11.1        # via -r requirements/test.txt
 pytest-django==4.2.0      # via -r requirements/test.txt
 pytest==5.4.3             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/test.txt, edx-drf-extensions
-python-slugify==4.0.1     # via -r requirements/test.txt, code-annotations
+python-slugify==5.0.2     # via -r requirements/test.txt, code-annotations
 python3-openid==3.2.0     # via -r requirements/test.txt, social-auth-core
 pytz==2021.1              # via -r requirements/test.txt, django
 pyxdg==0.27               # via -r requirements/test.txt, bpython
@@ -99,7 +99,7 @@ requests==2.25.1          # via -r requirements/test.txt, bpython, edx-analytics
 rest-condition==1.0.3     # via -r requirements/test.txt, edx-drf-extensions
 selenium==3.141.0         # via -r requirements/test.txt, bok-choy
 semantic-version==2.8.5   # via -r requirements/test.txt, edx-drf-extensions
-six==1.15.0               # via -r requirements/pip_tools.txt, -r requirements/test.txt, astroid, blessings, bok-choy, django-braces, django-dynamic-fixture, djangorestframework-csv, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, libsass, pip-tools, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, transifex-client
+six==1.16.0               # via -r requirements/test.txt, astroid, blessings, bok-choy, django-braces, django-dynamic-fixture, djangorestframework-csv, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, libsass, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, transifex-client
 slumber==0.7.1            # via -r requirements/test.txt, edx-rest-api-client
 snowballstemmer==2.1.0    # via -r requirements/test.txt, pydocstyle
 social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/test.txt, edx-auth-backends, social-auth-app-django

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -5,8 +5,7 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==5.3.0          # via -c requirements/constraints.txt, -r requirements/pip_tools.in
-six==1.15.0               # via pip-tools
+pip-tools==5.5.0          # via -c requirements/constraints.txt, -r requirements/pip_tools.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -19,7 +19,7 @@ cwcwidth==0.1.4           # via -r requirements/base.txt, bpython, curtsies
 defusedxml==0.7.1         # via -r requirements/base.txt, python3-openid, social-auth-core
 django-appconf==1.0.4     # via -r requirements/base.txt
 django-braces==1.14.0     # via -r requirements/base.txt
-django-countries==7.1     # via -r requirements/base.txt
+django-countries==7.2     # via -r requirements/base.txt
 django-crispy-forms==1.11.2  # via -r requirements/base.txt
 django-crum==0.7.9        # via -r requirements/base.txt, edx-django-utils, edx-toggles
 django-lang-pref-middleware==1.0.0  # via -r requirements/base.txt
@@ -35,14 +35,14 @@ edx-analytics-data-api-client==0.17.0  # via -r requirements/base.txt
 edx-auth-backends==3.3.3  # via -r requirements/base.txt
 edx-ccx-keys==1.2.0       # via -r requirements/base.txt
 edx-django-release-util==1.0.0  # via -r requirements/base.txt
-edx-django-utils==3.16.0  # via -r requirements/base.txt, edx-drf-extensions, edx-rest-api-client, edx-toggles
+edx-django-utils==4.0.0   # via -r requirements/base.txt, edx-drf-extensions, edx-rest-api-client, edx-toggles
 edx-drf-extensions==6.5.0  # via -r requirements/base.txt
 edx-i18n-tools==0.5.3     # via -r requirements/base.txt
 edx-opaque-keys==2.2.0    # via -r requirements/base.txt, edx-ccx-keys, edx-drf-extensions
 edx-rest-api-client==5.3.0  # via -r requirements/base.txt
 edx-toggles==4.1.0        # via -r requirements/base.txt
 future==0.18.2            # via -r requirements/base.txt, pyjwkest
-greenlet==1.0.0           # via -r requirements/base.txt, bpython
+greenlet==1.1.0           # via -r requirements/base.txt, bpython
 gunicorn==20.1.0          # via -r requirements/production.in
 idna==2.10                # via -r requirements/base.txt, requests
 jinja2==2.11.3            # via -r requirements/base.txt, code-annotations
@@ -55,19 +55,19 @@ nodeenv==1.6.0            # via -r requirements/production.in
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 path.py==12.5.0           # via -r requirements/base.txt, edx-i18n-tools
 path==15.1.2              # via -r requirements/base.txt, path.py
-pbr==5.5.1                # via -r requirements/base.txt, stevedore
+pbr==5.6.0                # via -r requirements/base.txt, stevedore
 pinax-announcements==4.0.0  # via -r requirements/base.txt
 polib==1.1.1              # via -r requirements/base.txt, edx-i18n-tools
 psutil==5.8.0             # via -r requirements/base.txt, edx-django-utils
 pycparser==2.20           # via -r requirements/base.txt, cffi
 pycryptodomex==3.10.1     # via -r requirements/base.txt, pyjwkest
-pygments==2.8.1           # via -r requirements/base.txt, bpython
+pygments==2.9.0           # via -r requirements/base.txt, bpython
 pyjwkest==1.4.2           # via -r requirements/base.txt, edx-drf-extensions
-pyjwt[crypto]==2.0.1      # via -r requirements/base.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
-pymongo==3.11.3           # via -r requirements/base.txt, edx-opaque-keys
+pyjwt[crypto]==2.1.0      # via -r requirements/base.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
+pymongo==3.11.4           # via -r requirements/base.txt, edx-opaque-keys
 python-dateutil==2.8.1    # via -r requirements/base.txt, edx-drf-extensions
 python-memcached==1.59    # via -r requirements/production.in
-python-slugify==4.0.1     # via -r requirements/base.txt, code-annotations
+python-slugify==5.0.2     # via -r requirements/base.txt, code-annotations
 python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
 pytz==2021.1              # via -r requirements/base.txt, django
 pyxdg==0.27               # via -r requirements/base.txt, bpython
@@ -77,7 +77,7 @@ requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
 requests==2.25.1          # via -r requirements/base.txt, bpython, edx-analytics-data-api-client, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
 semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions
-six==1.15.0               # via -r requirements/base.txt, blessings, django-braces, djangorestframework-csv, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, libsass, pyjwkest, python-dateutil, python-memcached, social-auth-app-django, social-auth-core
+six==1.16.0               # via -r requirements/base.txt, blessings, django-braces, djangorestframework-csv, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, libsass, pyjwkest, python-dateutil, python-memcached, social-auth-app-django, social-auth-core
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/base.txt, edx-auth-backends, social-auth-app-django
 sqlparse==0.4.1           # via -r requirements/base.txt, django

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,7 +6,7 @@
 #
 -e git+https://github.com/python-social-auth/social-app-django.git@ffa0fb99a80d11479bea2c4eae9a01ee835d52b9#egg=social-auth-app-django  # via -r requirements/base.txt, edx-auth-backends
 astroid==2.3.3            # via -r requirements/test.in, pylint
-attrs==20.3.0             # via pytest
+attrs==21.2.0             # via pytest
 awesome-slugify==1.6.5    # via -r requirements/base.txt
 blessings==1.7            # via -r requirements/base.txt, curtsies
 bok-choy==1.1.1           # via -r requirements/test.in
@@ -24,7 +24,7 @@ ddt==1.4.2                # via -r requirements/test.in
 defusedxml==0.7.1         # via -r requirements/base.txt, python3-openid, social-auth-core
 django-appconf==1.0.4     # via -r requirements/base.txt
 django-braces==1.14.0     # via -r requirements/base.txt
-django-countries==7.1     # via -r requirements/base.txt
+django-countries==7.2     # via -r requirements/base.txt
 django-crispy-forms==1.11.2  # via -r requirements/base.txt
 django-crum==0.7.9        # via -r requirements/base.txt, edx-django-utils, edx-toggles
 django-dynamic-fixture==3.1.1  # via -r requirements/test.in
@@ -40,7 +40,7 @@ edx-analytics-data-api-client==0.17.0  # via -r requirements/base.txt
 edx-auth-backends==3.3.3  # via -r requirements/base.txt
 edx-ccx-keys==1.2.0       # via -r requirements/base.txt
 edx-django-release-util==1.0.0  # via -r requirements/base.txt
-edx-django-utils==3.16.0  # via -r requirements/base.txt, edx-drf-extensions, edx-rest-api-client, edx-toggles
+edx-django-utils==4.0.0   # via -r requirements/base.txt, edx-drf-extensions, edx-rest-api-client, edx-toggles
 edx-drf-extensions==6.5.0  # via -r requirements/base.txt
 edx-i18n-tools==0.5.3     # via -r requirements/base.txt
 edx-opaque-keys==2.2.0    # via -r requirements/base.txt, edx-ccx-keys, edx-drf-extensions
@@ -48,7 +48,7 @@ edx-rest-api-client==5.3.0  # via -r requirements/base.txt
 edx-toggles==4.1.0        # via -r requirements/base.txt
 elasticsearch==2.4.1      # via -r requirements/test.in
 future==0.18.2            # via -r requirements/base.txt, pyjwkest
-greenlet==1.0.0           # via -r requirements/base.txt, bpython
+greenlet==1.1.0           # via -r requirements/base.txt, bpython
 httpretty==1.0.5          # via -r requirements/test.in
 idna==2.10                # via -r requirements/base.txt, requests
 isort==4.3.21             # via pylint
@@ -65,7 +65,7 @@ oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, soc
 packaging==20.9           # via pytest
 path.py==12.5.0           # via -r requirements/base.txt, edx-i18n-tools
 path==15.1.2              # via -r requirements/base.txt, path.py
-pbr==5.5.1                # via -r requirements/base.txt, stevedore
+pbr==5.6.0                # via -r requirements/base.txt, stevedore
 pinax-announcements==4.0.0  # via -r requirements/base.txt
 pluggy==0.13.1            # via pytest
 polib==1.1.1              # via -r requirements/base.txt, edx-i18n-tools
@@ -75,17 +75,17 @@ pycodestyle==2.7.0        # via -r requirements/test.in
 pycparser==2.20           # via -r requirements/base.txt, cffi
 pycryptodomex==3.10.1     # via -r requirements/base.txt, pyjwkest
 pydocstyle==6.0.0         # via -r requirements/test.in
-pygments==2.8.1           # via -r requirements/base.txt, bpython
+pygments==2.9.0           # via -r requirements/base.txt, bpython
 pyjwkest==1.4.2           # via -r requirements/base.txt, edx-drf-extensions
-pyjwt[crypto]==2.0.1      # via -r requirements/base.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
+pyjwt[crypto]==2.1.0      # via -r requirements/base.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint==2.4.4             # via -c requirements/constraints.txt, -r requirements/test.in
-pymongo==3.11.3           # via -r requirements/base.txt, edx-opaque-keys
+pymongo==3.11.4           # via -r requirements/base.txt, edx-opaque-keys
 pyparsing==2.4.7          # via packaging
 pytest-cov==2.11.1        # via -r requirements/test.in
 pytest-django==4.2.0      # via -r requirements/test.in
 pytest==5.4.3             # via -r requirements/test.in, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/base.txt, edx-drf-extensions
-python-slugify==4.0.1     # via -r requirements/base.txt, code-annotations
+python-slugify==5.0.2     # via -r requirements/base.txt, code-annotations
 python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
 pytz==2021.1              # via -r requirements/base.txt, django
 pyxdg==0.27               # via -r requirements/base.txt, bpython
@@ -96,7 +96,7 @@ requests==2.25.1          # via -r requirements/base.txt, bpython, edx-analytics
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
 selenium==3.141.0         # via -r requirements/test.in, bok-choy
 semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions
-six==1.15.0               # via -r requirements/base.txt, astroid, blessings, bok-choy, django-braces, django-dynamic-fixture, djangorestframework-csv, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, libsass, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core
+six==1.16.0               # via -r requirements/base.txt, astroid, blessings, bok-choy, django-braces, django-dynamic-fixture, djangorestframework-csv, edx-auth-backends, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, libsass, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 snowballstemmer==2.1.0    # via pydocstyle
 social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/base.txt, edx-auth-backends, social-auth-app-django

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -11,8 +11,8 @@ packaging==20.9           # via tox
 pluggy==0.13.1            # via tox
 py==1.10.0                # via tox
 pyparsing==2.4.7          # via packaging
-six==1.15.0               # via tox, virtualenv
+six==1.16.0               # via tox, virtualenv
 toml==0.10.2              # via tox
 tox-battery==0.6.1        # via -r requirements/tox.in
 tox==3.14.6               # via -c requirements/constraints.txt, -r requirements/tox.in, tox-battery
-virtualenv==20.4.4        # via tox
+virtualenv==20.4.6        # via tox

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -17,9 +17,9 @@ pluggy==0.13.1            # via -r requirements/tox.txt, tox
 py==1.10.0                # via -r requirements/tox.txt, tox
 pyparsing==2.4.7          # via -r requirements/tox.txt, packaging
 requests==2.25.1          # via codecov
-six==1.15.0               # via -r requirements/tox.txt, tox, virtualenv
+six==1.16.0               # via -r requirements/tox.txt, tox, virtualenv
 toml==0.10.2              # via -r requirements/tox.txt, tox
 tox-battery==0.6.1        # via -r requirements/tox.txt
 tox==3.14.6               # via -c requirements/constraints.txt, -r requirements/tox.txt, tox-battery
 urllib3==1.26.4           # via requests
-virtualenv==20.4.4        # via -r requirements/tox.txt, tox
+virtualenv==20.4.6        # via -r requirements/tox.txt, tox


### PR DESCRIPTION
Currently, we are have pinned pip to version 20.1.1 in configuration, which is compatible with pip-tools < 6.0 So in this PR we are upgrading pip-tools to 5.5* according to this compatibility chart
https://github.com/jazzband/pip-tools/#versions-and-compatibility

Relevant JIRA: https://openedx.atlassian.net/browse/BOM-2247