### PR TITLE
fix: Update package version for django-webpack-loader

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -79,7 +79,7 @@ django-waffle==2.2.0
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
-django-webpack-loader==1.0.0
+django-webpack-loader==0.7.0
     # via -r requirements/base.txt
 django==2.2.24
     # via


### PR DESCRIPTION
django-webpack-loader should be pinned at 0.7.0. The constraint was added in https://github.com/edx/edx-analytics-dashboard/pull/1134 but the version for the package in production.txt was not updated.