### PR TITLE
hook up masters count to index page

### DIFF
--- a/acceptance_tests/test_course_index.py
+++ b/acceptance_tests/test_course_index.py
@@ -317,6 +317,7 @@ class CourseIndexTests(AnalyticsApiClientMixin, AnalyticsDashboardWebAppTestMixi
         i = 7
         count_change_i_days = course_summaries[0]['count_change_%s_days' % i]
         verified_enrollment = course_summaries[0]['enrollment_modes']['verified']['count']
+        masters_enrollment = course_summaries[0]['enrollment_modes']['masters']['count']
 
         tooltip = 'Current enrollments across all of your courses.'
         self.assertMetricTileValid('current_enrollment', current_enrollment, tooltip)
@@ -329,3 +330,6 @@ class CourseIndexTests(AnalyticsApiClientMixin, AnalyticsDashboardWebAppTestMixi
 
         tooltip = 'Verified enrollments across all of your courses.'
         self.assertMetricTileValid('verified_enrollment', verified_enrollment, tooltip)
+
+        tooltip = "Master's enrollments across all of your courses."
+        self.assertMetricTileValid('masters_enrollment', masters_enrollment, tooltip)

--- a/analytics_dashboard/courses/presenters/course_summaries.py
+++ b/analytics_dashboard/courses/presenters/course_summaries.py
@@ -1,5 +1,6 @@
 from functools import reduce  # pylint: disable=redefined-builtin
 
+from analyticsclient.constants import enrollment_modes
 from django.conf import settings
 from django.core.cache import cache
 from waffle import switch_is_active
@@ -81,7 +82,10 @@ class CourseSummariesPresenter(BasePresenter):
             'total_enrollment': reduce(lambda x, y: x + y.get('cumulative_count', 0), summaries, 0),
             'current_enrollment': reduce(lambda x, y: x + y.get('count', 0), summaries, 0),
             'enrollment_change_7_days': reduce(lambda x, y: x + y.get('count_change_7_days', 0), summaries, 0),
-            'verified_enrollment': reduce(lambda x, y: x + y.get('enrollment_modes', {}).get('verified',
+            'verified_enrollment': reduce(lambda x, y: x + y.get('enrollment_modes', {}).get(enrollment_modes.VERIFIED,
+                                                                                             {}).get('count', 0),
+                                          summaries, 0),
+            'masters_enrollment': reduce(lambda x, y: x + y.get('enrollment_modes', {}).get(enrollment_modes.MASTERS,
                                                                                              {}).get('count', 0),
                                           summaries, 0),
         }

--- a/analytics_dashboard/courses/tests/test_presenters/test_course_summaries.py
+++ b/analytics_dashboard/courses/tests/test_presenters/test_course_summaries.py
@@ -103,6 +103,12 @@ class CourseSummariesPresenterTests(TestCase):
                     'cumulative_count': 4087,
                     'count_change_7_days': 0,
                     'passing_users': 100,
+                },
+                'masters': {
+                    'count': 1101,
+                    'cumulative_count': 1103,
+                    'count_change_7_days': 0,
+                    'passing_users': 0,
                 }
             },
             'created': utils.CREATED_DATETIME_STRING,
@@ -115,7 +121,7 @@ class CourseSummariesPresenterTests(TestCase):
             'end_date': None,
             'pacing_type': 'instructor_paced',
             'availability': None,
-            'count': None,
+            'count': 0,
             'cumulative_count': 1,
             'count_change_7_days': 0,
             'enrollment_modes': {
@@ -146,6 +152,12 @@ class CourseSummariesPresenterTests(TestCase):
                 'honor': {
                     'count': 1,
                     'cumulative_count': 1,
+                    'count_change_7_days': 0,
+                    'passing_users': 0,
+                },
+                'masters': {
+                    'count': 10,
+                    'cumulative_count': 10,
                     'count_change_7_days': 0,
                     'passing_users': 0,
                 }
@@ -233,3 +245,14 @@ class CourseSummariesPresenterTests(TestCase):
             summaries, last_updated = presenter.get_course_summaries()
             self.assertListEqual(summaries, [])
             self.assertIsNone(last_updated)
+
+    def test_get_course_summary_metrics(self):
+        metrics = CourseSummariesPresenter().get_course_summary_metrics(self._PRESENTER_SUMMARIES.values())
+        expected = {
+            'total_enrollment': 5111,
+            'current_enrollment': 3888,
+            'enrollment_change_7_days': 4,
+            'verified_enrollment': 13,
+            'masters_enrollment': 1111,
+        }
+        self.assertEqual(metrics, expected)


### PR DESCRIPTION
Apparently just missed in 2019 when the code was put in.

First diff puts in the obvious line and adds a check for the card in an existing test. Second diff takes the whole function and rewrites it for readability and efficiency and adds the test that was never written for it.

MST-868