### PR TITLE
build: cleanup data-dog metrics upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,16 +62,3 @@ matrix:
 after_failure:
     # Print the list of running containers to rule out a killed container as a cause of failure
     - docker ps
-
-deploy:
-    - provider: s3
-      access_key_id: $S3_ACCESS_KEY_ID
-      secret_access_key: $S3_SECRET_ACCESS_KEY
-      bucket: $S3_BUCKET
-      skip_cleanup: true
-      local_dir: $TRAVIS_BUILD_DIR/build-metrics
-      upload_dir: edx-analytics-dashboard/master
-      acl: public_read
-      on:
-        branch: master
-        condition: "$TESTNAME = test-python"


### PR DESCRIPTION
missed cleaning this up when I removed the data dog scripts in https://github.com/edx/edx-analytics-dashboard/pull/1171. This file no longer exists so the 'upload' is failing on the master branch