### PR TITLE
BOM-2782: Use DeploymentMonitoringMiddleware in settings

### DIFF
--- a/analytics_dashboard/settings/base.py
+++ b/analytics_dashboard/settings/base.py
@@ -170,6 +170,7 @@ TEMPLATES = [
 ########## MIDDLEWARE CONFIGURATION
 # See: https://docs.djangoproject.com/en/1.11/ref/settings/#middleware-classes
 MIDDLEWARE = [
+    'edx_django_utils.monitoring.DeploymentMonitoringMiddleware',
     'edx_django_utils.cache.middleware.RequestCacheMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,7 +18,7 @@ certifi==2021.5.30
     # via requests
 cffi==1.14.6
     # via cryptography
-charset-normalizer==2.0.4
+charset-normalizer==2.0.6
     # via requests
 click==8.0.1
     # via code-annotations
@@ -26,7 +26,7 @@ code-annotations==1.2.0
     # via edx-toggles
 cryptography==3.4.8
     # via pyjwt
-curtsies==0.3.5
+curtsies==0.3.7
     # via bpython
 cwcwidth==0.1.4
     # via
@@ -55,13 +55,13 @@ django==3.2.7
     #   edx-toggles
     #   pinax-announcements
     #   rest-condition
-django-appconf==1.0.4
+django-appconf==1.0.5
     # via -r requirements/base.in
 django-braces==1.14.0
     # via -r requirements/base.in
 django-countries==7.2.1
     # via -r requirements/base.in
-django-crispy-forms==1.12.0
+django-crispy-forms==1.13.0
     # via -r requirements/base.in
 django-crum==0.7.9
     # via
@@ -102,7 +102,7 @@ edx-ccx-keys==1.2.1
     # via -r requirements/base.in
 edx-django-release-util==1.1.0
     # via -r requirements/base.in
-edx-django-utils==4.3.0
+edx-django-utils==4.4.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
@@ -135,7 +135,7 @@ logutils==0.3.5
     # via -r requirements/base.in
 markupsafe==2.0.1
     # via jinja2
-newrelic==6.8.1.164
+newrelic==7.0.0.166
     # via edx-django-utils
 oauthlib==3.1.1
     # via
@@ -157,7 +157,7 @@ psutil==5.8.0
     # via edx-django-utils
 pycparser==2.20
     # via cffi
-pycryptodomex==3.10.1
+pycryptodomex==3.10.4
     # via pyjwkest
 pygments==2.10.0
     # via bpython
@@ -228,7 +228,7 @@ social-auth-core==3.2.0
     #   -c requirements/constraints.txt
     #   edx-auth-backends
     #   social-auth-app-django
-sqlparse==0.4.1
+sqlparse==0.4.2
     # via django
 stevedore==3.4.0
     # via
@@ -240,5 +240,5 @@ text-unidecode==1.3
     # via python-slugify
 unicodecsv==0.14.1
     # via djangorestframework-csv
-urllib3==1.26.6
+urllib3==1.26.7
     # via requests

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -30,7 +30,7 @@ cffi==1.14.6
     # via
     #   -r requirements/base.txt
     #   cryptography
-charset-normalizer==2.0.4
+charset-normalizer==2.0.6
     # via
     #   -r requirements/base.txt
     #   requests
@@ -46,7 +46,7 @@ cryptography==3.4.8
     # via
     #   -r requirements/base.txt
     #   pyjwt
-curtsies==0.3.5
+curtsies==0.3.7
     # via
     #   -r requirements/base.txt
     #   bpython
@@ -79,13 +79,13 @@ django==3.2.7
     #   edx-toggles
     #   pinax-announcements
     #   rest-condition
-django-appconf==1.0.4
+django-appconf==1.0.5
     # via -r requirements/base.txt
 django-braces==1.14.0
     # via -r requirements/base.txt
 django-countries==7.2.1
     # via -r requirements/base.txt
-django-crispy-forms==1.12.0
+django-crispy-forms==1.13.0
     # via -r requirements/base.txt
 django-crum==0.7.9
     # via
@@ -131,7 +131,7 @@ edx-ccx-keys==1.2.1
     # via -r requirements/base.txt
 edx-django-release-util==1.1.0
     # via -r requirements/base.txt
-edx-django-utils==4.3.0
+edx-django-utils==4.4.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
@@ -179,7 +179,7 @@ markupsafe==2.0.1
     # via
     #   -r requirements/base.txt
     #   jinja2
-newrelic==6.8.1.164
+newrelic==7.0.0.166
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -215,7 +215,7 @@ pycparser==2.20
     # via
     #   -r requirements/base.txt
     #   cffi
-pycryptodomex==3.10.1
+pycryptodomex==3.10.4
     # via
     #   -r requirements/base.txt
     #   pyjwkest
@@ -322,7 +322,7 @@ social-auth-core==3.2.0
     #   -r requirements/base.txt
     #   edx-auth-backends
     #   social-auth-app-django
-sphinx==4.1.2
+sphinx==4.2.0
     # via
     #   -r requirements/doc.in
     #   edx-sphinx-theme
@@ -338,7 +338,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlparse==0.4.1
+sqlparse==0.4.2
     # via
     #   -r requirements/base.txt
     #   django
@@ -356,7 +356,7 @@ unicodecsv==0.14.1
     # via
     #   -r requirements/base.txt
     #   djangorestframework-csv
-urllib3==1.26.6
+urllib3==1.26.7
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/github.txt
+++ b/requirements/github.txt
@@ -16,11 +16,11 @@ codecov==2.1.12
     # via -r requirements/github.in
 coverage==5.5
     # via codecov
-distlib==0.3.2
+distlib==0.3.3
     # via
     #   -r requirements/tox.txt
     #   virtualenv
-filelock==3.0.12
+filelock==3.1.0
     # via
     #   -r requirements/tox.txt
     #   tox
@@ -31,7 +31,7 @@ packaging==21.0
     # via
     #   -r requirements/tox.txt
     #   tox
-platformdirs==2.3.0
+platformdirs==2.4.0
     # via
     #   -r requirements/tox.txt
     #   virtualenv
@@ -67,7 +67,7 @@ tox-battery==0.6.1
     # via -r requirements/tox.txt
 urllib3==1.26.7
     # via requests
-virtualenv==20.7.2
+virtualenv==20.8.1
     # via
     #   -r requirements/tox.txt
     #   tox

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -40,7 +40,7 @@ cffi==1.14.6
     # via
     #   -r requirements/test.txt
     #   cryptography
-charset-normalizer==2.0.4
+charset-normalizer==2.0.6
     # via
     #   -r requirements/test.txt
     #   requests
@@ -62,7 +62,7 @@ cryptography==3.4.8
     # via
     #   -r requirements/test.txt
     #   pyjwt
-curtsies==0.3.5
+curtsies==0.3.7
     # via
     #   -r requirements/test.txt
     #   bpython
@@ -78,7 +78,7 @@ defusedxml==0.7.1
     #   -r requirements/test.txt
     #   python3-openid
     #   social-auth-core
-distlib==0.3.2
+distlib==0.3.3
     # via
     #   -r requirements/tox.txt
     #   virtualenv
@@ -102,13 +102,13 @@ django==3.2.7
     #   edx-toggles
     #   pinax-announcements
     #   rest-condition
-django-appconf==1.0.4
+django-appconf==1.0.5
     # via -r requirements/test.txt
 django-braces==1.14.0
     # via -r requirements/test.txt
 django-countries==7.2.1
     # via -r requirements/test.txt
-django-crispy-forms==1.12.0
+django-crispy-forms==1.13.0
     # via -r requirements/test.txt
 django-crum==0.7.9
     # via
@@ -156,7 +156,7 @@ edx-ccx-keys==1.2.1
     # via -r requirements/test.txt
 edx-django-release-util==1.1.0
     # via -r requirements/test.txt
-edx-django-utils==4.3.0
+edx-django-utils==4.4.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
@@ -177,7 +177,7 @@ edx-toggles==4.2.0
     # via -r requirements/test.txt
 elasticsearch==2.4.1
     # via -r requirements/test.txt
-filelock==3.0.12
+filelock==3.1.0
     # via
     #   -r requirements/tox.txt
     #   tox
@@ -224,13 +224,13 @@ mccabe==0.6.1
     # via
     #   -r requirements/test.txt
     #   pylint
-more-itertools==8.8.0
+more-itertools==8.10.0
     # via
     #   -r requirements/test.txt
     #   pytest
 mysqlclient==2.0.3
     # via -r requirements/local.in
-newrelic==6.8.1.164
+newrelic==7.0.0.166
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -262,9 +262,9 @@ pep517==0.11.0
     #   pip-tools
 pinax-announcements==4.0.0
     # via -r requirements/test.txt
-pip-tools==6.2.0
+pip-tools==6.3.0
     # via -r requirements/pip_tools.txt
-platformdirs==2.3.0
+platformdirs==2.4.0
     # via
     #   -r requirements/tox.txt
     #   virtualenv
@@ -294,7 +294,7 @@ pycparser==2.20
     # via
     #   -r requirements/test.txt
     #   cffi
-pycryptodomex==3.10.1
+pycryptodomex==3.10.4
     # via
     #   -r requirements/test.txt
     #   pyjwkest
@@ -428,7 +428,7 @@ social-auth-core==3.2.0
     #   -r requirements/test.txt
     #   edx-auth-backends
     #   social-auth-app-django
-sqlparse==0.4.1
+sqlparse==0.4.2
     # via
     #   -r requirements/test.txt
     #   django
@@ -439,7 +439,7 @@ stevedore==3.4.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-testfixtures==6.18.1
+testfixtures==6.18.2
     # via -r requirements/test.txt
 text-unidecode==1.3
     # via
@@ -468,14 +468,14 @@ unicodecsv==0.14.1
     # via
     #   -r requirements/test.txt
     #   djangorestframework-csv
-urllib3==1.26.6
+urllib3==1.26.7
     # via
     #   -r requirements/test.txt
     #   elasticsearch
     #   requests
     #   selenium
     #   transifex-client
-virtualenv==20.7.2
+virtualenv==20.8.1
     # via
     #   -r requirements/tox.txt
     #   tox

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -4,5 +4,5 @@
 #
 #    make upgrade
 #
-newrelic==6.8.1.164
+newrelic==7.0.0.166
     # via -r requirements/optional.in

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -8,7 +8,7 @@ click==8.0.1
     # via pip-tools
 pep517==0.11.0
     # via pip-tools
-pip-tools==6.2.0
+pip-tools==6.3.0
     # via -r requirements/pip_tools.in
 tomli==1.2.1
     # via pep517

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -26,7 +26,7 @@ cffi==1.14.6
     # via
     #   -r requirements/base.txt
     #   cryptography
-charset-normalizer==2.0.4
+charset-normalizer==2.0.6
     # via
     #   -r requirements/base.txt
     #   requests
@@ -42,7 +42,7 @@ cryptography==3.4.8
     # via
     #   -r requirements/base.txt
     #   pyjwt
-curtsies==0.3.5
+curtsies==0.3.7
     # via
     #   -r requirements/base.txt
     #   bpython
@@ -75,13 +75,13 @@ django==3.2.7
     #   edx-toggles
     #   pinax-announcements
     #   rest-condition
-django-appconf==1.0.4
+django-appconf==1.0.5
     # via -r requirements/base.txt
 django-braces==1.14.0
     # via -r requirements/base.txt
 django-countries==7.2.1
     # via -r requirements/base.txt
-django-crispy-forms==1.12.0
+django-crispy-forms==1.13.0
     # via -r requirements/base.txt
 django-crum==0.7.9
     # via
@@ -125,7 +125,7 @@ edx-ccx-keys==1.2.1
     # via -r requirements/base.txt
 edx-django-release-util==1.1.0
     # via -r requirements/base.txt
-edx-django-utils==4.3.0
+edx-django-utils==4.4.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
@@ -172,7 +172,7 @@ markupsafe==2.0.1
     #   jinja2
 mysqlclient==2.0.3
     # via -r requirements/production.in
-newrelic==6.8.1.164
+newrelic==7.0.0.166
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -208,7 +208,7 @@ pycparser==2.20
     # via
     #   -r requirements/base.txt
     #   cffi
-pycryptodomex==3.10.1
+pycryptodomex==3.10.4
     # via
     #   -r requirements/base.txt
     #   pyjwkest
@@ -311,7 +311,7 @@ social-auth-core==3.2.0
     #   -r requirements/base.txt
     #   edx-auth-backends
     #   social-auth-app-django
-sqlparse==0.4.1
+sqlparse==0.4.2
     # via
     #   -r requirements/base.txt
     #   django
@@ -329,7 +329,7 @@ unicodecsv==0.14.1
     # via
     #   -r requirements/base.txt
     #   djangorestframework-csv
-urllib3==1.26.6
+urllib3==1.26.7
     # via
     #   -r requirements/base.txt
     #   requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -34,7 +34,7 @@ cffi==1.14.6
     # via
     #   -r requirements/base.txt
     #   cryptography
-charset-normalizer==2.0.4
+charset-normalizer==2.0.6
     # via
     #   -r requirements/base.txt
     #   requests
@@ -54,7 +54,7 @@ cryptography==3.4.8
     # via
     #   -r requirements/base.txt
     #   pyjwt
-curtsies==0.3.5
+curtsies==0.3.7
     # via
     #   -r requirements/base.txt
     #   bpython
@@ -88,13 +88,13 @@ defusedxml==0.7.1
     #   edx-toggles
     #   pinax-announcements
     #   rest-condition
-django-appconf==1.0.4
+django-appconf==1.0.5
     # via -r requirements/base.txt
 django-braces==1.14.0
     # via -r requirements/base.txt
 django-countries==7.2.1
     # via -r requirements/base.txt
-django-crispy-forms==1.12.0
+django-crispy-forms==1.13.0
     # via -r requirements/base.txt
 django-crum==0.7.9
     # via
@@ -140,7 +140,7 @@ edx-ccx-keys==1.2.1
     # via -r requirements/base.txt
 edx-django-release-util==1.1.0
     # via -r requirements/base.txt
-edx-django-utils==4.3.0
+edx-django-utils==4.4.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
@@ -195,9 +195,9 @@ markupsafe==2.0.1
     #   jinja2
 mccabe==0.6.1
     # via pylint
-more-itertools==8.8.0
+more-itertools==8.10.0
     # via pytest
-newrelic==6.8.1.164
+newrelic==7.0.0.166
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -239,7 +239,7 @@ pycparser==2.20
     # via
     #   -r requirements/base.txt
     #   cffi
-pycryptodomex==3.10.1
+pycryptodomex==3.10.4
     # via
     #   -r requirements/base.txt
     #   pyjwkest
@@ -364,7 +364,7 @@ social-auth-core==3.2.0
     #   -r requirements/base.txt
     #   edx-auth-backends
     #   social-auth-app-django
-sqlparse==0.4.1
+sqlparse==0.4.2
     # via
     #   -r requirements/base.txt
     #   django
@@ -374,7 +374,7 @@ stevedore==3.4.0
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-testfixtures==6.18.1
+testfixtures==6.18.2
     # via -r requirements/test.in
 text-unidecode==1.3
     # via
@@ -386,7 +386,7 @@ unicodecsv==0.14.1
     # via
     #   -r requirements/base.txt
     #   djangorestframework-csv
-urllib3==1.26.6
+urllib3==1.26.7
     # via
     #   -r requirements/base.txt
     #   elasticsearch

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -6,15 +6,15 @@
 #
 backports.entry-points-selectable==1.1.0
     # via virtualenv
-distlib==0.3.2
+distlib==0.3.3
     # via virtualenv
-filelock==3.0.12
+filelock==3.1.0
     # via
     #   tox
     #   virtualenv
 packaging==21.0
     # via tox
-platformdirs==2.3.0
+platformdirs==2.4.0
     # via virtualenv
 pluggy==0.13.1
     # via tox
@@ -35,5 +35,5 @@ tox==3.14.6
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/tox.in
-virtualenv==20.7.2
+virtualenv==20.8.1
     # via tox


### PR DESCRIPTION
**Issue:** [BOM-2782](https://openedx.atlassian.net/browse/BOM-2782)

### Description
- Added the `DeploymentMonitroringMiddleware` to record `Django` and `Python` versions in the `NewRelic`.
