### PR TITLE
feat: use devstack data api

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ The best way to run this service is with edX Devstack: https://github.com/edx/de
 
 See the [Devstack README](https://github.com/edx/devstack/blob/master/README.rst) for information on how to install and run Insights. For the purposes of devstack this service will be referred to as `insights` and not `analytics-dashboard`.
 
+Provisioning for insights and the data api can be combined:
+
+.. code:: sh
+
+make dev.provision insights+analyticsapi
+
 Getting Started Standalone
 --------------------------
 1. Get the code (e.g. clone the repository).

--- a/analytics_dashboard/settings/devstack.py
+++ b/analytics_dashboard/settings/devstack.py
@@ -13,8 +13,7 @@ DB_OVERRIDES = dict(
 for override, value in DB_OVERRIDES.items():
     DATABASES['default'][override] = value
 
-# TODO: This should get updated when data-api is addedd to devstack
-DATA_API_URL = os.environ.get("API_SERVER_URL", 'http://host.docker.internal:9001/api/v0')
+DATA_API_URL = os.environ.get("API_SERVER_URL", 'http://edx.devstack.analyticsapi:19001/api/v0')
 
 # Set these to the correct values for your OAuth2/OpenID Connect provider (e.g., devstack)
 SOCIAL_AUTH_EDX_OAUTH2_KEY = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_KEY', 'insights-sso-key')


### PR DESCRIPTION
@edx/masters-devs-cosmonauts 

Running insights in devstack should use the devstack data api

Depends on:
https://github.com/edx/edx-analytics-data-api/pull/495
https://github.com/edx/devstack/pull/847