### PR TITLE
test: remove django-dynamic-fixture library for the repository tests do not use it

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -117,8 +117,6 @@ django-crum==0.7.9
     #   edx-toggles
 django-debug-toolbar==3.2.2
     # via -r requirements/local.in
-django-dynamic-fixture==3.1.2
-    # via -r requirements/test.txt
 django-lang-pref-middleware==1.1.0
     # via -r requirements/test.txt
 django-model-utils==4.1.1
@@ -399,7 +397,6 @@ six==1.16.0
     #   blessings
     #   bok-choy
     #   django-braces
-    #   django-dynamic-fixture
     #   djangorestframework-csv
     #   edx-auth-backends
     #   edx-ccx-keys

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -7,7 +7,6 @@ astroid
 bok-choy
 coverage
 ddt
-django-dynamic-fixture
 elasticsearch==2.4.1
 httpretty
 pycodestyle

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -101,8 +101,6 @@ django-crum==0.7.9
     #   -r requirements/base.txt
     #   edx-django-utils
     #   edx-toggles
-django-dynamic-fixture==3.1.2
-    # via -r requirements/test.in
 django-lang-pref-middleware==1.1.0
     # via -r requirements/base.txt
 django-model-utils==4.1.1
@@ -340,7 +338,6 @@ six==1.16.0
     #   blessings
     #   bok-choy
     #   django-braces
-    #   django-dynamic-fixture
     #   djangorestframework-csv
     #   edx-auth-backends
     #   edx-ccx-keys


### PR DESCRIPTION
This is PR to remove the library django-dynamic-fixture because the repository do not use it.