### PR TITLE
chore: remove ancient command-line convenience package

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,6 +1,5 @@
 -c constraints.txt
 
-bpython							        # MIT License
 Django									# BSD License
 django-appconf
 django-braces							# BSD

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,10 +10,6 @@
     #   edx-auth-backends
 asgiref==3.4.1
     # via django
-blessings==1.7
-    # via curtsies
-bpython==0.22.1
-    # via -r requirements/base.in
 certifi==2021.10.8
     # via requests
 cffi==1.15.0
@@ -26,12 +22,6 @@ code-annotations==1.2.0
     # via edx-toggles
 cryptography==36.0.0
     # via pyjwt
-curtsies==0.3.10
-    # via bpython
-cwcwidth==0.1.5
-    # via
-    #   bpython
-    #   curtsies
 defusedxml==0.7.1
     # via
     #   python3-openid
@@ -121,8 +111,6 @@ edx-toggles==4.2.0
     # via -r requirements/base.in
 future==0.18.2
     # via pyjwkest
-greenlet==1.1.2
-    # via bpython
 idna==3.3
     # via requests
 jinja2==3.0.3
@@ -157,8 +145,6 @@ pycparser==2.21
     # via cffi
 pycryptodomex==3.11.0
     # via pyjwkest
-pygments==2.10.0
-    # via bpython
 pyjwkest==1.4.2
     # via edx-drf-extensions
 pyjwt[crypto]==2.3.0
@@ -168,7 +154,7 @@ pyjwt[crypto]==2.3.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pymongo==3.12.1
+pymongo==4.0
     # via edx-opaque-keys
 python-dateutil==2.8.2
     # via edx-drf-extensions
@@ -180,8 +166,6 @@ python3-openid==3.2.0
     # via social-auth-core
 pytz==2021.3
     # via django
-pyxdg==0.27
-    # via bpython
 pyyaml==6.0
     # via
     #   code-annotations
@@ -190,7 +174,6 @@ pyyaml==6.0
 requests==2.26.0
     # via
     #   -r requirements/base.in
-    #   bpython
     #   edx-analytics-data-api-client
     #   edx-drf-extensions
     #   edx-rest-api-client
@@ -204,7 +187,6 @@ semantic-version==2.8.5
     # via edx-drf-extensions
 six==1.16.0
     # via
-    #   blessings
     #   djangorestframework-csv
     #   edx-auth-backends
     #   edx-ccx-keys
@@ -230,8 +212,6 @@ stevedore==3.5.0
     #   edx-opaque-keys
 text-unidecode==1.3
     # via python-slugify
-typing-extensions==4.0.0
-    # via bpython
 unicodecsv==0.14.1
     # via djangorestframework-csv
 urllib3==1.26.7

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -16,12 +16,6 @@ asgiref==3.4.1
     #   django
 babel==2.9.1
     # via sphinx
-blessings==1.7
-    # via
-    #   -r requirements/base.txt
-    #   curtsies
-bpython==0.22.1
-    # via -r requirements/base.txt
 certifi==2021.10.8
     # via
     #   -r requirements/base.txt
@@ -46,15 +40,6 @@ cryptography==36.0.0
     # via
     #   -r requirements/base.txt
     #   pyjwt
-curtsies==0.3.10
-    # via
-    #   -r requirements/base.txt
-    #   bpython
-cwcwidth==0.1.5
-    # via
-    #   -r requirements/base.txt
-    #   bpython
-    #   curtsies
 defusedxml==0.7.1
     # via
     #   -r requirements/base.txt
@@ -154,10 +139,6 @@ future==0.18.2
     # via
     #   -r requirements/base.txt
     #   pyjwkest
-greenlet==1.1.2
-    # via
-    #   -r requirements/base.txt
-    #   bpython
 idna==3.3
     # via
     #   -r requirements/base.txt
@@ -218,10 +199,7 @@ pycryptodomex==3.11.0
     #   -r requirements/base.txt
     #   pyjwkest
 pygments==2.10.0
-    # via
-    #   -r requirements/base.txt
-    #   bpython
-    #   sphinx
+    # via sphinx
 pyjwkest==1.4.2
     # via
     #   -r requirements/base.txt
@@ -234,7 +212,7 @@ pyjwt[crypto]==2.3.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pymongo==3.12.1
+pymongo==4.0
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -257,10 +235,6 @@ pytz==2021.3
     #   -r requirements/base.txt
     #   babel
     #   django
-pyxdg==0.27
-    # via
-    #   -r requirements/base.txt
-    #   bpython
 pyyaml==6.0
     # via
     #   -r requirements/base.txt
@@ -270,7 +244,6 @@ pyyaml==6.0
 requests==2.26.0
     # via
     #   -r requirements/base.txt
-    #   bpython
     #   edx-analytics-data-api-client
     #   edx-drf-extensions
     #   edx-rest-api-client
@@ -290,7 +263,6 @@ semantic-version==2.8.5
 six==1.16.0
     # via
     #   -r requirements/base.txt
-    #   blessings
     #   djangorestframework-csv
     #   edx-auth-backends
     #   edx-ccx-keys
@@ -342,10 +314,6 @@ text-unidecode==1.3
     # via
     #   -r requirements/base.txt
     #   python-slugify
-typing-extensions==4.0.0
-    # via
-    #   -r requirements/base.txt
-    #   bpython
 unicodecsv==0.14.1
     # via
     #   -r requirements/base.txt

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -24,13 +24,7 @@ backports.entry-points-selectable==1.1.1
     # via
     #   -r requirements/tox.txt
     #   virtualenv
-blessings==1.7
-    # via
-    #   -r requirements/test.txt
-    #   curtsies
 bok-choy==1.1.1
-    # via -r requirements/test.txt
-bpython==0.22.1
     # via -r requirements/test.txt
 certifi==2021.10.8
     # via
@@ -62,15 +56,6 @@ cryptography==36.0.0
     # via
     #   -r requirements/test.txt
     #   pyjwt
-curtsies==0.3.10
-    # via
-    #   -r requirements/test.txt
-    #   bpython
-cwcwidth==0.1.5
-    # via
-    #   -r requirements/test.txt
-    #   bpython
-    #   curtsies
 ddt==1.4.4
     # via -r requirements/test.txt
 defusedxml==0.7.1
@@ -184,10 +169,6 @@ future==0.18.2
     # via
     #   -r requirements/test.txt
     #   pyjwkest
-greenlet==1.1.2
-    # via
-    #   -r requirements/test.txt
-    #   bpython
 httpretty==1.1.4
     # via -r requirements/test.txt
 idna==3.3
@@ -298,10 +279,6 @@ pycryptodomex==3.11.0
     #   pyjwkest
 pydocstyle==6.1.1
     # via -r requirements/test.txt
-pygments==2.10.0
-    # via
-    #   -r requirements/test.txt
-    #   bpython
 pyjwkest==1.4.2
     # via
     #   -r requirements/test.txt
@@ -318,7 +295,7 @@ pylint==2.4.4
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
-pymongo==3.12.1
+pymongo==4.0
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
@@ -352,10 +329,6 @@ pytz==2021.3
     # via
     #   -r requirements/test.txt
     #   django
-pyxdg==0.27
-    # via
-    #   -r requirements/test.txt
-    #   bpython
 pyyaml==6.0
     # via
     #   -r requirements/test.txt
@@ -365,7 +338,6 @@ pyyaml==6.0
 requests==2.26.0
     # via
     #   -r requirements/test.txt
-    #   bpython
     #   edx-analytics-data-api-client
     #   edx-drf-extensions
     #   edx-rest-api-client
@@ -390,7 +362,6 @@ six==1.16.0
     #   -r requirements/test.txt
     #   -r requirements/tox.txt
     #   astroid
-    #   blessings
     #   bok-choy
     #   django-dynamic-fixture
     #   djangorestframework-csv
@@ -454,10 +425,6 @@ tox-battery==0.6.1
     # via -r requirements/tox.txt
 transifex-client==0.12.4
     # via -r requirements/local.in
-typing-extensions==4.0.0
-    # via
-    #   -r requirements/test.txt
-    #   bpython
 unicodecsv==0.14.1
     # via
     #   -r requirements/test.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -12,12 +12,6 @@ asgiref==3.4.1
     # via
     #   -r requirements/base.txt
     #   django
-blessings==1.7
-    # via
-    #   -r requirements/base.txt
-    #   curtsies
-bpython==0.22.1
-    # via -r requirements/base.txt
 certifi==2021.10.8
     # via
     #   -r requirements/base.txt
@@ -42,15 +36,6 @@ cryptography==36.0.0
     # via
     #   -r requirements/base.txt
     #   pyjwt
-curtsies==0.3.10
-    # via
-    #   -r requirements/base.txt
-    #   bpython
-cwcwidth==0.1.5
-    # via
-    #   -r requirements/base.txt
-    #   bpython
-    #   curtsies
 defusedxml==0.7.1
     # via
     #   -r requirements/base.txt
@@ -146,10 +131,6 @@ future==0.18.2
     # via
     #   -r requirements/base.txt
     #   pyjwkest
-greenlet==1.1.2
-    # via
-    #   -r requirements/base.txt
-    #   bpython
 gunicorn==20.1.0
     # via -r requirements/production.in
 idna==3.3
@@ -210,10 +191,6 @@ pycryptodomex==3.11.0
     # via
     #   -r requirements/base.txt
     #   pyjwkest
-pygments==2.10.0
-    # via
-    #   -r requirements/base.txt
-    #   bpython
 pyjwkest==1.4.2
     # via
     #   -r requirements/base.txt
@@ -226,7 +203,7 @@ pyjwt[crypto]==2.3.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pymongo==3.12.1
+pymongo==4.0
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -248,10 +225,6 @@ pytz==2021.3
     # via
     #   -r requirements/base.txt
     #   django
-pyxdg==0.27
-    # via
-    #   -r requirements/base.txt
-    #   bpython
 pyyaml==6.0
     # via
     #   -r requirements/base.txt
@@ -262,7 +235,6 @@ pyyaml==6.0
 requests==2.26.0
     # via
     #   -r requirements/base.txt
-    #   bpython
     #   edx-analytics-data-api-client
     #   edx-drf-extensions
     #   edx-rest-api-client
@@ -281,7 +253,6 @@ semantic-version==2.8.5
 six==1.16.0
     # via
     #   -r requirements/base.txt
-    #   blessings
     #   djangorestframework-csv
     #   edx-auth-backends
     #   edx-ccx-keys
@@ -315,10 +286,6 @@ text-unidecode==1.3
     # via
     #   -r requirements/base.txt
     #   python-slugify
-typing-extensions==4.0.0
-    # via
-    #   -r requirements/base.txt
-    #   bpython
 unicodecsv==0.14.1
     # via
     #   -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -18,14 +18,8 @@ astroid==2.3.3
     #   pylint
 attrs==21.2.0
     # via pytest
-blessings==1.7
-    # via
-    #   -r requirements/base.txt
-    #   curtsies
 bok-choy==1.1.1
     # via -r requirements/test.in
-bpython==0.22.1
-    # via -r requirements/base.txt
 certifi==2021.10.8
     # via
     #   -r requirements/base.txt
@@ -54,15 +48,6 @@ cryptography==36.0.0
     # via
     #   -r requirements/base.txt
     #   pyjwt
-curtsies==0.3.10
-    # via
-    #   -r requirements/base.txt
-    #   bpython
-cwcwidth==0.1.5
-    # via
-    #   -r requirements/base.txt
-    #   bpython
-    #   curtsies
 ddt==1.4.4
     # via -r requirements/test.in
 defusedxml==0.7.1
@@ -163,10 +148,6 @@ future==0.18.2
     # via
     #   -r requirements/base.txt
     #   pyjwkest
-greenlet==1.1.2
-    # via
-    #   -r requirements/base.txt
-    #   bpython
 httpretty==1.1.4
     # via -r requirements/test.in
 idna==3.3
@@ -243,10 +224,6 @@ pycryptodomex==3.11.0
     #   pyjwkest
 pydocstyle==6.1.1
     # via -r requirements/test.in
-pygments==2.10.0
-    # via
-    #   -r requirements/base.txt
-    #   bpython
 pyjwkest==1.4.2
     # via
     #   -r requirements/base.txt
@@ -263,7 +240,7 @@ pylint==2.4.4
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.in
-pymongo==3.12.1
+pymongo==4.0
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -294,10 +271,6 @@ pytz==2021.3
     # via
     #   -r requirements/base.txt
     #   django
-pyxdg==0.27
-    # via
-    #   -r requirements/base.txt
-    #   bpython
 pyyaml==6.0
     # via
     #   -r requirements/base.txt
@@ -307,7 +280,6 @@ pyyaml==6.0
 requests==2.26.0
     # via
     #   -r requirements/base.txt
-    #   bpython
     #   edx-analytics-data-api-client
     #   edx-drf-extensions
     #   edx-rest-api-client
@@ -331,7 +303,6 @@ six==1.16.0
     # via
     #   -r requirements/base.txt
     #   astroid
-    #   blessings
     #   bok-choy
     #   django-dynamic-fixture
     #   djangorestframework-csv
@@ -372,10 +343,6 @@ text-unidecode==1.3
     #   python-slugify
 tomli==1.2.2
     # via coverage
-typing-extensions==4.0.0
-    # via
-    #   -r requirements/base.txt
-    #   bpython
 unicodecsv==0.14.1
     # via
     #   -r requirements/base.txt


### PR DESCRIPTION
bpython is a [more interactive and colorized repl for python](https://www.bpython-interpreter.org/); I have no
idea why we would be installing that here.