### PR TITLE
feat: switch geographic view to v1 default

### DIFF
--- a/analytics_dashboard/courses/views/csv.py
+++ b/analytics_dashboard/courses/views/csv.py
@@ -8,7 +8,7 @@ from django.http import HttpResponse, HttpResponseRedirect
 from django.utils import timezone
 
 from analytics_dashboard.courses.presenters.performance import CourseReportDownloadPresenter
-from analytics_dashboard.courses.views import CourseView, AnalyticsV0Mixin
+from analytics_dashboard.courses.views import CourseView, AnalyticsV0Mixin, AnalyticsV1Mixin
 
 logger = logging.getLogger(__name__)
 
@@ -79,7 +79,7 @@ class CourseEnrollmentDemographicsGenderCSV(AnalyticsV0Mixin, CourseCSVResponseM
         return self.course.enrollment(demographics.GENDER, end_date=end_date, data_format=data_formats.CSV)
 
 
-class CourseEnrollmentByCountryCSV(AnalyticsV0Mixin, CourseCSVResponseMixin, CourseView):
+class CourseEnrollmentByCountryCSV(AnalyticsV1Mixin, CourseCSVResponseMixin, CourseView):
     csv_filename_suffix = 'enrollment-location'
 
     def get_data(self):

--- a/analytics_dashboard/courses/views/enrollment.py
+++ b/analytics_dashboard/courses/views/enrollment.py
@@ -10,12 +10,12 @@ from analytics_dashboard.courses.presenters.enrollment import (
     CourseEnrollmentDemographicsPresenter,
     CourseEnrollmentPresenter,
 )
-from analytics_dashboard.courses.views import CourseTemplateWithNavView, AnalyticsV0Mixin
+from analytics_dashboard.courses.views import CourseTemplateWithNavView, AnalyticsV0Mixin, AnalyticsV1Mixin
 
 logger = logging.getLogger(__name__)
 
 
-class EnrollmentTemplateView(AnalyticsV0Mixin, CourseTemplateWithNavView):
+class EnrollmentTemplateView(CourseTemplateWithNavView):
     """
     Base view for course enrollment pages.
     """
@@ -52,7 +52,7 @@ class EnrollmentTemplateView(AnalyticsV0Mixin, CourseTemplateWithNavView):
     active_primary_nav_item = 'enrollment'
 
 
-class EnrollmentDemographicsTemplateView(EnrollmentTemplateView):
+class EnrollmentDemographicsTemplateView(AnalyticsV0Mixin, EnrollmentTemplateView):
     """
     Base view for course enrollment demographics pages.
     """
@@ -104,7 +104,7 @@ class EnrollmentDemographicsTemplateView(EnrollmentTemplateView):
         return formatted_percent
 
 
-class EnrollmentActivityView(EnrollmentTemplateView):
+class EnrollmentActivityView(AnalyticsV0Mixin, EnrollmentTemplateView):
     template_name = 'courses/enrollment_activity.html'
     page_title = _('Enrollment Activity')
     page_name = {
@@ -259,7 +259,7 @@ class EnrollmentDemographicsGenderView(EnrollmentDemographicsTemplateView):
         return context
 
 
-class EnrollmentGeographyView(EnrollmentTemplateView):
+class EnrollmentGeographyView(AnalyticsV1Mixin, EnrollmentTemplateView):
     template_name = 'courses/enrollment_geography.html'
     page_title = _('Enrollment Geography')
     page_name = {


### PR DESCRIPTION
had to push mixins down one level in enrollment in order to add v1 to geographic only

MST-1203

tested on devstack, tested that base enrollment view does not get switched, and tested that if the v1 available config setting is not True it defaults to v0 even with the v1 mixin.