### PR TITLE
replace the outdated git protocol to fix maple build for insights

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "datatables": "1.10.13",
     "datatables-bootstrap3-plugin": "0.6.0",
     "edx-pattern-library": "0.16.6",
-    "edx-ui-toolkit": "git://github.com/edx/edx-ui-toolkit.git#29759050aff2f4f3cb6921432855ad057bd69bb1",
+    "edx-ui-toolkit": "https://github.com/edx/edx-ui-toolkit.git#29759050aff2f4f3cb6921432855ad057bd69bb1",
     "extract-text-webpack-plugin": "3.0.2",
     "file-loader": "0.11.2",
     "font-awesome": "4.6.3",


### PR DESCRIPTION
currently the `maple` image build for insights is failing because of the outdated `git` protocol