### PR TITLE
control age enrollments visibility by setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,16 @@ The following flags are available:
 |--------------------------------|-------------------------------------------------------|
 | display_learner_analytics      | Display Learner Analytics links                       |
 
+
+Settings describe features which are not expected to be toggled on and off without significant system changes.
+
+The following setting is available:
+
+| Flag                           | Purpose                                               |
+|--------------------------------|-------------------------------------------------------|
+| ENROLLMENT_AGE_AVAILABLE      | Display age as part of enrollment demographics                       |
+
+
 Authentication & Authorization
 ------------------------------
 This section is only necessary if running I stand alone service OAuth2 is automatically configured by provisioning in devstack.

--- a/analytics_dashboard/core/utils.py
+++ b/analytics_dashboard/core/utils.py
@@ -2,10 +2,8 @@ from hashlib import md5
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.http import Http404
 from django.utils.translation import ugettext_lazy as _
 from soapbox.models import Message
-from waffle import switch_is_active
 
 from common import clients
 
@@ -33,22 +31,6 @@ class CourseStructureApiClient(clients.CourseStructureApiClient):
     """
     def __init__(self, url, access_token, timeout=settings.LMS_DEFAULT_TIMEOUT):
         super().__init__(url, access_token=access_token, timeout=timeout)
-
-
-def feature_flagged(feature_flag):
-    """
-    A decorator for class-based views which throws 404s when a waffle
-    flag is not enabled.
-    """
-    def decorator(cls):
-        def dispatch(self, request, *args, **kwargs):
-            if not switch_is_active(feature_flag):
-                raise Http404
-
-            return super(cls, self).dispatch(request, *args, **kwargs)
-        cls.dispatch = dispatch
-        return cls
-    return decorator
 
 
 def translate_dict_values(items, keys):

--- a/analytics_dashboard/courses/tests/test_views/__init__.py
+++ b/analytics_dashboard/courses/tests/test_views/__init__.py
@@ -188,7 +188,7 @@ class CourseViewTestMixin(CourseAPIMixin, NavAssertMixin, ViewTestMixin):
         response = self.client.get(path, follow=True)
         self.assertEqual(response.status_code, 404)
 
-    def assertViewIsValid(self, course_id):
+    def getAndValidateView(self, course_id):
         raise NotImplementedError
 
     @httpretty.activate
@@ -197,7 +197,7 @@ class CourseViewTestMixin(CourseAPIMixin, NavAssertMixin, ViewTestMixin):
     @override_switch('display_course_name_in_nav', active=True)
     def test_valid_course(self, course_id):
         self.mock_course_detail(course_id)
-        self.assertViewIsValid(course_id)
+        self.getAndValidateView(course_id)
 
     def assertValidMissingDataContext(self, context):
         raise NotImplementedError

--- a/analytics_dashboard/courses/tests/test_views/__init__.py
+++ b/analytics_dashboard/courses/tests/test_views/__init__.py
@@ -157,9 +157,6 @@ class ViewTestMixin(AuthTestMixin):
 
 
 class NavAssertMixin:
-    def generate_course_name(self, course_id):
-        return 'Test ' + course_id
-
     def assertPrimaryNav(self, nav, course_id):
         raise NotImplementedError
 
@@ -209,6 +206,9 @@ class CourseViewTestMixin(CourseAPIMixin, NavAssertMixin, ViewTestMixin):
             context = response.context
 
         self.assertValidMissingDataContext(context)
+
+    def generate_course_name(self, course_id):
+        return 'Test ' + course_id
 
     def assertValidCourseName(self, course_id, context):
         course_name = self.generate_course_name(course_id)

--- a/analytics_dashboard/courses/tests/test_views/test_engagement.py
+++ b/analytics_dashboard/courses/tests/test_views/test_engagement.py
@@ -96,7 +96,7 @@ class CourseEngagementContentViewTests(CourseViewTestMixin, CourseEngagementView
         })
         return expected
 
-    def assertViewIsValid(self, course_id):
+    def getAndValidateView(self, course_id):
         rv = utils.mock_engagement_activity_summary_and_trend_data()
         with patch(self.presenter_method, Mock(return_value=rv)):
             response = self.client.get(self.path(course_id=course_id))

--- a/analytics_dashboard/courses/tests/test_views/test_engagement.py
+++ b/analytics_dashboard/courses/tests/test_views/test_engagement.py
@@ -1,7 +1,7 @@
 from unittest.mock import Mock, patch
 import analyticsclient.constants.activity_types as AT
 import httpretty
-from ddt import ddt
+from ddt import ddt, data
 from django.test import TestCase
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
@@ -87,6 +87,14 @@ class CourseEngagementContentViewTests(CourseViewTestMixin, CourseEngagementView
     presenter_method = \
         'analytics_dashboard.courses.presenters.engagement.CourseEngagementActivityPresenter.get_summary_and_trend_data'
     active_secondary_nav_label = 'Content'
+
+    @httpretty.activate
+    @data(CourseSamples.DEMO_COURSE_ID, CourseSamples.DEPRECATED_DEMO_COURSE_ID)
+    @override_switch('enable_course_api', active=True)
+    @override_switch('display_course_name_in_nav', active=True)
+    def test_valid_course(self, course_id):
+        self.mock_course_detail(course_id)
+        self.getAndValidateView(course_id)
 
     def get_expected_secondary_nav(self, course_id):
         expected = super().get_expected_secondary_nav(course_id)

--- a/analytics_dashboard/courses/tests/test_views/test_enrollment.py
+++ b/analytics_dashboard/courses/tests/test_views/test_enrollment.py
@@ -18,7 +18,7 @@ class CourseEnrollmentActivityViewTests(CourseEnrollmentViewTestMixin, TestCase)
     presenter_method = \
         'analytics_dashboard.courses.presenters.enrollment.CourseEnrollmentPresenter.get_summary_and_trend_data'
 
-    def getAndValidateView(self, course_id):
+    def getAndValidateView(self, course_id, age_available):
         summary, enrollment_data = utils.get_mock_enrollment_summary_and_trend(course_id)
         rv = summary, enrollment_data
         with mock.patch(self.presenter_method, return_value=rv):
@@ -42,7 +42,7 @@ class CourseEnrollmentActivityViewTests(CourseEnrollmentViewTestMixin, TestCase)
         self.assertListEqual(trend_data, expected)
 
         self.assertPrimaryNav(context['primary_nav_item'], course_id)
-        self.assertSecondaryNavs(context['secondary_nav_items'], course_id)
+        self.assertSecondaryNavs(context['secondary_nav_items'], course_id, age_available)
         self.assertValidCourseName(course_id, response.context)
 
     def assertValidMissingDataContext(self, context):
@@ -60,7 +60,7 @@ class CourseEnrollmentGeographyViewTests(CourseEnrollmentViewTestMixin, TestCase
     def get_mock_data(self, course_id):
         return utils.get_mock_api_enrollment_geography_data(course_id)
 
-    def getAndValidateView(self, course_id):
+    def getAndValidateView(self, course_id, age_available):
         with mock.patch(self.presenter_method, return_value=utils.get_mock_presenter_enrollment_geography_data()):
             response = self.client.get(self.path(course_id=course_id))
             context = response.context
@@ -76,6 +76,8 @@ class CourseEnrollmentGeographyViewTests(CourseEnrollmentViewTestMixin, TestCase
             self.assertEqual(page_data['course']['enrollmentByCountry'], expected_data)
 
             self.assertValidCourseName(course_id, response.context)
+            self.assertPrimaryNav(context['primary_nav_item'], course_id)
+            self.assertSecondaryNavs(context['secondary_nav_items'], course_id, age_available)
 
     def assertValidMissingDataContext(self, context):
         self.assertIsNone(context['update_message'])
@@ -89,7 +91,7 @@ class CourseEnrollmentDemographicsAge(CourseEnrollmentDemographicsMixin, TestCas
     presenter_method = \
         'analytics_dashboard.courses.presenters.enrollment.CourseEnrollmentDemographicsPresenter.get_ages'
 
-    def getAndValidateView(self, course_id):
+    def getAndValidateView(self, course_id, age_available):
         last_updated, summary, binned_ages, known_percent = utils.get_presenter_ages()
         rv = last_updated, summary, binned_ages, known_percent
         with mock.patch(self.presenter_method, return_value=rv):
@@ -109,7 +111,7 @@ class CourseEnrollmentDemographicsAge(CourseEnrollmentDemographicsMixin, TestCas
         actual_ages = page_data['course']['ages']
         self.assertListEqual(actual_ages, binned_ages)
         self.assertDictEqual(context['summary'], summary)
-        self.assertAllNavs(context, course_id)
+        self.assertAllNavs(context, course_id, age_available)
 
         self.assertValidCourseName(course_id, response.context)
 
@@ -128,7 +130,7 @@ class CourseEnrollmentDemographicsEducation(CourseEnrollmentDemographicsMixin, T
     presenter_method = \
         'analytics_dashboard.courses.presenters.enrollment.CourseEnrollmentDemographicsPresenter.get_education'
 
-    def getAndValidateView(self, course_id):
+    def getAndValidateView(self, course_id, age_available):
         last_updated, summary, education_data, known_percent = utils.get_presenter_education()
         rv = last_updated, summary, education_data, known_percent
         with mock.patch(self.presenter_method, return_value=rv):
@@ -148,7 +150,7 @@ class CourseEnrollmentDemographicsEducation(CourseEnrollmentDemographicsMixin, T
         actual_education = page_data['course']['education']
         self.assertListEqual(actual_education, education_data)
         self.assertDictEqual(context['summary'], summary)
-        self.assertAllNavs(context, course_id)
+        self.assertAllNavs(context, course_id, age_available)
 
         self.assertValidCourseName(course_id, response.context)
 
@@ -167,7 +169,7 @@ class CourseEnrollmentDemographicsGender(CourseEnrollmentDemographicsMixin, Test
     presenter_method = \
         'analytics_dashboard.courses.presenters.enrollment.CourseEnrollmentDemographicsPresenter.get_gender'
 
-    def getAndValidateView(self, course_id):
+    def getAndValidateView(self, course_id, age_available):
         last_updated, gender_data, trend, known_percent = utils.get_presenter_gender(course_id)
         rv = last_updated, gender_data, trend, known_percent
         with mock.patch(self.presenter_method, return_value=rv):
@@ -190,7 +192,7 @@ class CourseEnrollmentDemographicsGender(CourseEnrollmentDemographicsMixin, Test
         actual_trends = page_data['course']['genderTrend']
         self.assertListEqual(actual_trends, trend)
 
-        self.assertAllNavs(context, course_id)
+        self.assertAllNavs(context, course_id, age_available)
         self.assertValidCourseName(course_id, response.context)
 
     def get_mock_data(self, course_id):

--- a/analytics_dashboard/courses/tests/test_views/test_enrollment.py
+++ b/analytics_dashboard/courses/tests/test_views/test_enrollment.py
@@ -18,7 +18,7 @@ class CourseEnrollmentActivityViewTests(CourseEnrollmentViewTestMixin, TestCase)
     presenter_method = \
         'analytics_dashboard.courses.presenters.enrollment.CourseEnrollmentPresenter.get_summary_and_trend_data'
 
-    def assertViewIsValid(self, course_id):
+    def getAndValidateView(self, course_id):
         summary, enrollment_data = utils.get_mock_enrollment_summary_and_trend(course_id)
         rv = summary, enrollment_data
         with mock.patch(self.presenter_method, return_value=rv):
@@ -60,7 +60,7 @@ class CourseEnrollmentGeographyViewTests(CourseEnrollmentViewTestMixin, TestCase
     def get_mock_data(self, course_id):
         return utils.get_mock_api_enrollment_geography_data(course_id)
 
-    def assertViewIsValid(self, course_id):
+    def getAndValidateView(self, course_id):
         with mock.patch(self.presenter_method, return_value=utils.get_mock_presenter_enrollment_geography_data()):
             response = self.client.get(self.path(course_id=course_id))
             context = response.context
@@ -89,7 +89,7 @@ class CourseEnrollmentDemographicsAge(CourseEnrollmentDemographicsMixin, TestCas
     presenter_method = \
         'analytics_dashboard.courses.presenters.enrollment.CourseEnrollmentDemographicsPresenter.get_ages'
 
-    def assertViewIsValid(self, course_id):
+    def getAndValidateView(self, course_id):
         last_updated, summary, binned_ages, known_percent = utils.get_presenter_ages()
         rv = last_updated, summary, binned_ages, known_percent
         with mock.patch(self.presenter_method, return_value=rv):
@@ -128,7 +128,7 @@ class CourseEnrollmentDemographicsEducation(CourseEnrollmentDemographicsMixin, T
     presenter_method = \
         'analytics_dashboard.courses.presenters.enrollment.CourseEnrollmentDemographicsPresenter.get_education'
 
-    def assertViewIsValid(self, course_id):
+    def getAndValidateView(self, course_id):
         last_updated, summary, education_data, known_percent = utils.get_presenter_education()
         rv = last_updated, summary, education_data, known_percent
         with mock.patch(self.presenter_method, return_value=rv):
@@ -167,7 +167,7 @@ class CourseEnrollmentDemographicsGender(CourseEnrollmentDemographicsMixin, Test
     presenter_method = \
         'analytics_dashboard.courses.presenters.enrollment.CourseEnrollmentDemographicsPresenter.get_gender'
 
-    def assertViewIsValid(self, course_id):
+    def getAndValidateView(self, course_id):
         last_updated, gender_data, trend, known_percent = utils.get_presenter_gender(course_id)
         rv = last_updated, gender_data, trend, known_percent
         with mock.patch(self.presenter_method, return_value=rv):

--- a/analytics_dashboard/courses/tests/test_views/test_pages.py
+++ b/analytics_dashboard/courses/tests/test_views/test_pages.py
@@ -14,7 +14,7 @@ from analytics_dashboard.courses.tests.utils import CourseSamples
 class CourseHomeViewTests(CourseViewTestMixin, TestCase):
     viewname = 'courses:home'
 
-    def assertViewIsValid(self, course_id):
+    def getAndValidateView(self, course_id):
         response = self.client.get(self.path(course_id=course_id))
         self.assertEqual(response.status_code, 200)
 

--- a/analytics_dashboard/courses/tests/test_views/test_pages.py
+++ b/analytics_dashboard/courses/tests/test_views/test_pages.py
@@ -14,6 +14,14 @@ from analytics_dashboard.courses.tests.utils import CourseSamples
 class CourseHomeViewTests(CourseViewTestMixin, TestCase):
     viewname = 'courses:home'
 
+    @httpretty.activate
+    @data(CourseSamples.DEMO_COURSE_ID, CourseSamples.DEPRECATED_DEMO_COURSE_ID)
+    @override_switch('enable_course_api', active=True)
+    @override_switch('display_course_name_in_nav', active=True)
+    def test_valid_course(self, course_id):
+        self.mock_course_detail(course_id)
+        self.getAndValidateView(course_id)
+
     def getAndValidateView(self, course_id):
         response = self.client.get(self.path(course_id=course_id))
         self.assertEqual(response.status_code, 200)

--- a/analytics_dashboard/courses/views/__init__.py
+++ b/analytics_dashboard/courses/views/__init__.py
@@ -38,7 +38,7 @@ from analytics_dashboard.courses.presenters.performance import CourseReportDownl
 from analytics_dashboard.courses.serializers import LazyEncoder
 from analytics_dashboard.courses.utils import get_page_name, is_feature_enabled
 from analytics_dashboard.courses.waffle import (
-    DISPLAY_LEARNER_ANALYTICS,
+    DISPLAY_LEARNER_ANALYTICS, age_available,
 )
 from analytics_dashboard.help.views import ContextSensitiveHelpMixin
 
@@ -537,21 +537,19 @@ class CourseHome(AnalyticsV0Mixin, CourseTemplateWithNavView):
     def get_table_items(self):
         items = []
 
-        enrollment_items = {
-            'name': _('Enrollment'),
-            'icon': 'fa-child',
-            'heading': _('Who are my learners?'),
-            'items': [
-                {
-                    'title': ugettext_noop('How many learners are in my course?'),
-                    'view': 'courses:enrollment:activity',
-                    'breadcrumbs': [_('Activity')],
-                    'fragment': '',
-                    'scope': 'course',
-                    'lens': 'enrollment',
-                    'report': 'activity',
-                    'depth': ''
-                },
+        enrollment_subitems = [
+            {
+                'title': ugettext_noop('How many learners are in my course?'),
+                'view': 'courses:enrollment:activity',
+                'breadcrumbs': [_('Activity')],
+                'fragment': '',
+                'scope': 'course',
+                'lens': 'enrollment',
+                'report': 'activity',
+                'depth': ''
+            }]
+        if age_available():
+            enrollment_subitems = enrollment_subitems + [
                 {
                     'title': ugettext_noop('How old are my learners?'),
                     'view': 'courses:enrollment:demographics_age',
@@ -561,38 +559,45 @@ class CourseHome(AnalyticsV0Mixin, CourseTemplateWithNavView):
                     'lens': 'enrollment',
                     'report': 'demographics',
                     'depth': 'age'
-                },
-                {
-                    'title': ugettext_noop('What level of education do my learners have?'),
-                    'view': 'courses:enrollment:demographics_education',
-                    'breadcrumbs': [_('Demographics'), _('Education')],
-                    'fragment': '',
-                    'scope': 'course',
-                    'lens': 'enrollment',
-                    'report': 'demographics',
-                    'depth': 'education'
-                },
-                {
-                    'title': ugettext_noop('What is the learner gender breakdown?'),
-                    'view': 'courses:enrollment:demographics_gender',
-                    'breadcrumbs': [_('Demographics'), _('Gender')],
-                    'fragment': '',
-                    'scope': 'course',
-                    'lens': 'enrollment',
-                    'report': 'demographics',
-                    'depth': 'gender'
-                },
-                {
-                    'title': ugettext_noop('Where are my learners?'),
-                    'view': 'courses:enrollment:geography',
-                    'breadcrumbs': [_('Geography')],
-                    'fragment': '',
-                    'scope': 'course',
-                    'lens': 'enrollment',
-                    'report': 'geography',
-                    'depth': ''
-                },
-            ],
+                }]
+        enrollment_subitems = enrollment_subitems + [
+            {
+                'title': ugettext_noop('What level of education do my learners have?'),
+                'view': 'courses:enrollment:demographics_education',
+                'breadcrumbs': [_('Demographics'), _('Education')],
+                'fragment': '',
+                'scope': 'course',
+                'lens': 'enrollment',
+                'report': 'demographics',
+                'depth': 'education'
+            },
+            {
+                'title': ugettext_noop('What is the learner gender breakdown?'),
+                'view': 'courses:enrollment:demographics_gender',
+                'breadcrumbs': [_('Demographics'), _('Gender')],
+                'fragment': '',
+                'scope': 'course',
+                'lens': 'enrollment',
+                'report': 'demographics',
+                'depth': 'gender'
+            },
+            {
+                'title': ugettext_noop('Where are my learners?'),
+                'view': 'courses:enrollment:geography',
+                'breadcrumbs': [_('Geography')],
+                'fragment': '',
+                'scope': 'course',
+                'lens': 'enrollment',
+                'report': 'geography',
+                'depth': ''
+            },
+        ]
+
+        enrollment_items = {
+            'name': _('Enrollment'),
+            'icon': 'fa-child',
+            'heading': _('Who are my learners?'),
+            'items': enrollment_subitems,
         }
         items.append(enrollment_items)
 

--- a/analytics_dashboard/courses/waffle.py
+++ b/analytics_dashboard/courses/waffle.py
@@ -4,7 +4,7 @@ for edx's analytics dashboard.
 """
 
 
-from edx_toggles.toggles import NonNamespacedWaffleFlag
+from edx_toggles.toggles import NonNamespacedWaffleFlag, SettingToggle
 
 # .. toggle_name: display_learner_analytics
 # .. toggle_implementation: WaffleFlag
@@ -20,3 +20,17 @@ from edx_toggles.toggles import NonNamespacedWaffleFlag
 #   https://github.com/edx/edx-analytics-dashboard/pull/522
 DISPLAY_LEARNER_ANALYTICS = NonNamespacedWaffleFlag(
     'display_learner_analytics', __name__)
+
+# .. toggle_name: ENROLLMENT_AGE_AVAILABLE
+# .. toggle_implementation: SettingToggle
+# .. toggle_default: True
+# .. toggle_description: Turn this toggle on to show age demographic information in the analytics dashboard.
+#      Turn it off if your installation cannot or does not collect or share age information.
+# .. toggle_use_cases: opt_out
+# .. toggle_creation_date: 2021-01-12
+# .. toggle_tickets: https://openedx.atlassian.net/browse/MST-1241
+ENROLLMENT_AGE_AVAILABLE = SettingToggle('ENROLLMENT_AGE_AVAILABLE', default=True)
+
+
+def age_available():
+    return ENROLLMENT_AGE_AVAILABLE.is_enabled()

--- a/analytics_dashboard/settings/base.py
+++ b/analytics_dashboard/settings/base.py
@@ -321,6 +321,9 @@ DATA_API_URL_V1 = 'http://127.0.0.1:9001/api/v1'
 DATA_API_AUTH_TOKEN = 'changeme'
 ########## END DATA API CONFIGURATION
 
+# can this installation collect and display age info
+ENROLLMENT_AGE_AVAILABLE = True
+
 # used to determine if a course ID is valid
 LMS_COURSE_VALIDATION_BASE_URL = None
 

--- a/analytics_dashboard/settings/devstack.py
+++ b/analytics_dashboard/settings/devstack.py
@@ -17,6 +17,8 @@ DATA_API_URL = os.environ.get("API_SERVER_URL", 'http://edx.devstack.analyticsap
 DATA_API_V1_ENABLED = True
 DATA_API_URL_V1 = os.environ.get("API_SERVER_URL", 'http://edx.devstack.analyticsapi:19001/api/v1')
 
+ENROLLMENT_AGE_AVAILABLE = True
+
 # Set these to the correct values for your OAuth2/OpenID Connect provider (e.g., devstack)
 SOCIAL_AUTH_EDX_OAUTH2_KEY = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_KEY', 'insights-sso-key')
 SOCIAL_AUTH_EDX_OAUTH2_SECRET = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_SECRET', 'insights-sso-secret')


### PR DESCRIPTION
The first three commits are cleanups that I ran across trying to figure out how to make this work. The one that creates the most noise if you look at the overall diff is a rename of assertFoo to getAndCheckFoo since the function is not an assert.

Tested locally by toggling devstack setting True/False.

The test mixin structure here is somewhat inverted, where the most abstract mixins have the tests and lower levels provide functions to fill them in. I pushed one test definition down a bit to get actual control of the test closer to where it is used. This structure reuses a tiny amount of code at a high cost in readability, there is more refactoring that could happen here.

Also nav items are class variables, so I had to introduce an easy way to rerun their creation during test. Again, there is more refactoring that could happen here to make nav construction less of a weird mix between class variables and instance functions.

Similarly Insights currently has switches, one waffle, and now a setting, so it's a bit of a hodgepodge. This set of things doesn't actually give complete control over what is displayed either. More to refactor later.

This will go with another PR to remove the age endpoint from the V1 API which is considerably smaller. That's the actual work detailed in the ticket, this part is implied but not there. And we will have to make a change to production settings to disable age in Insights before releasing enrollments.

[MST-1241](https://openedx.atlassian.net/browse/MST-1241)