### PR TITLE
feat: switch most enrollments views to v1

### DIFF
--- a/acceptance_tests/test_course_index.py
+++ b/acceptance_tests/test_course_index.py
@@ -120,7 +120,7 @@ class CourseIndexTests(AnalyticsApiClientMixin, AnalyticsDashboardWebAppTestMixi
         """
         # Filter is present
         filter_box = self.page.q(css='#' + filter_id)
-        self.assertTrue(filter_box.present)
+        self.assertTrue(filter_box.present, "missing filter '{display_name}'".format(display_name=display_name))
 
         if clear_existing_filters:
             # Clear any existing filter first

--- a/analytics_dashboard/courses/views/course_summaries.py
+++ b/analytics_dashboard/courses/views/course_summaries.py
@@ -18,14 +18,14 @@ from analytics_dashboard.courses.views import (
     LazyEncoderMixin,
     TemplateView,
     TrackedViewMixin,
-    AnalyticsV0Mixin,
+    AnalyticsV1Mixin,
 )
 from analytics_dashboard.courses.views.csv import DatetimeCSVResponseMixin
 
 logger = logging.getLogger(__name__)
 
 
-class CourseIndex(AnalyticsV0Mixin, CourseAPIMixin, LoginRequiredMixin, TrackedViewMixin, LastUpdatedView,
+class CourseIndex(AnalyticsV1Mixin, CourseAPIMixin, LoginRequiredMixin, TrackedViewMixin, LastUpdatedView,
                   LazyEncoderMixin, TemplateView):
     template_name = 'courses/index.html'
     page_title = _('Courses')
@@ -74,7 +74,7 @@ class CourseIndex(AnalyticsV0Mixin, CourseAPIMixin, LoginRequiredMixin, TrackedV
         return context
 
 
-class CourseIndexCSV(AnalyticsV0Mixin, CourseAPIMixin, LoginRequiredMixin, DatetimeCSVResponseMixin, TemplateView):
+class CourseIndexCSV(AnalyticsV1Mixin, CourseAPIMixin, LoginRequiredMixin, DatetimeCSVResponseMixin, TemplateView):
 
     csv_filename_suffix = 'course-list'
     # Note: we are not using the DRF "renderer_classes" field here because this is a Django view, not a DRF view.

--- a/analytics_dashboard/courses/views/csv.py
+++ b/analytics_dashboard/courses/views/csv.py
@@ -64,14 +64,14 @@ class CourseEnrollmentDemographicsAgeCSV(AnalyticsV0Mixin, CourseCSVResponseMixi
         return self.course.enrollment(demographics.BIRTH_YEAR, data_format=data_formats.CSV)
 
 
-class CourseEnrollmentDemographicsEducationCSV(AnalyticsV0Mixin, CourseCSVResponseMixin, CourseView):
+class CourseEnrollmentDemographicsEducationCSV(AnalyticsV1Mixin, CourseCSVResponseMixin, CourseView):
     csv_filename_suffix = 'enrollment-by-education'
 
     def get_data(self):
         return self.course.enrollment(demographics.EDUCATION, data_format=data_formats.CSV)
 
 
-class CourseEnrollmentDemographicsGenderCSV(AnalyticsV0Mixin, CourseCSVResponseMixin, CourseView):
+class CourseEnrollmentDemographicsGenderCSV(AnalyticsV1Mixin, CourseCSVResponseMixin, CourseView):
     csv_filename_suffix = 'enrollment-by-gender'
 
     def get_data(self):
@@ -86,7 +86,7 @@ class CourseEnrollmentByCountryCSV(AnalyticsV1Mixin, CourseCSVResponseMixin, Cou
         return self.course.enrollment(demographics.LOCATION, data_format=data_formats.CSV)
 
 
-class CourseEnrollmentCSV(AnalyticsV0Mixin, CourseCSVResponseMixin, CourseView):
+class CourseEnrollmentCSV(AnalyticsV1Mixin, CourseCSVResponseMixin, CourseView):
     csv_filename_suffix = 'enrollment'
 
     def get_data(self):
@@ -94,7 +94,7 @@ class CourseEnrollmentCSV(AnalyticsV0Mixin, CourseCSVResponseMixin, CourseView):
         return self.course.enrollment('mode', data_format=data_formats.CSV, end_date=end_date)
 
 
-class CourseEngagementActivityTrendCSV(AnalyticsV0Mixin, CourseCSVResponseMixin, CourseView):
+class CourseEngagementActivityTrendCSV(AnalyticsV1Mixin, CourseCSVResponseMixin, CourseView):
     csv_filename_suffix = 'engagement-activity'
 
     def get_data(self):

--- a/analytics_dashboard/courses/views/enrollment.py
+++ b/analytics_dashboard/courses/views/enrollment.py
@@ -106,7 +106,7 @@ def _enrollment_tertiary_nav():
     return tertiary_nav_items
 
 
-class EnrollmentDemographicsTemplateView(AnalyticsV0Mixin, EnrollmentTemplateView):
+class EnrollmentDemographicsTemplateView(EnrollmentTemplateView):
     """
     Base view for course enrollment demographics pages.
     """
@@ -130,7 +130,7 @@ class EnrollmentDemographicsTemplateView(AnalyticsV0Mixin, EnrollmentTemplateVie
         return formatted_percent
 
 
-class EnrollmentActivityView(AnalyticsV0Mixin, EnrollmentTemplateView):
+class EnrollmentActivityView(AnalyticsV1Mixin, EnrollmentTemplateView):
     template_name = 'courses/enrollment_activity.html'
     page_title = _('Enrollment Activity')
     page_name = {
@@ -171,7 +171,7 @@ class EnrollmentActivityView(AnalyticsV0Mixin, EnrollmentTemplateView):
         return context
 
 
-class EnrollmentDemographicsAgeView(EnrollmentDemographicsTemplateView):
+class EnrollmentDemographicsAgeView(AnalyticsV0Mixin, EnrollmentDemographicsTemplateView):
     template_name = 'courses/enrollment_demographics_age.html'
     page_title = _('Enrollment Demographics by Age')
     page_name = {
@@ -209,7 +209,7 @@ class EnrollmentDemographicsAgeView(EnrollmentDemographicsTemplateView):
         return context
 
 
-class EnrollmentDemographicsEducationView(EnrollmentDemographicsTemplateView):
+class EnrollmentDemographicsEducationView(AnalyticsV1Mixin, EnrollmentDemographicsTemplateView):
     template_name = 'courses/enrollment_demographics_education.html'
     page_title = _('Enrollment Demographics by Education')
     page_name = {
@@ -247,7 +247,7 @@ class EnrollmentDemographicsEducationView(EnrollmentDemographicsTemplateView):
         return context
 
 
-class EnrollmentDemographicsGenderView(EnrollmentDemographicsTemplateView):
+class EnrollmentDemographicsGenderView(AnalyticsV1Mixin, EnrollmentDemographicsTemplateView):
     template_name = 'courses/enrollment_demographics_gender.html'
     page_title = _('Enrollment Demographics by Gender')
     page_name = {


### PR DESCRIPTION
Enrollments views are now all switched to v1 with the exception of age
which is not supported in the v1 API currently. This required pushing
the v0/v1 choice down a level in the demographics inheritance tree.

MST-1250