### PR TITLE
fix: Try resetting msgstr on malformed source po file

### DIFF
--- a/analytics_dashboard/conf/locale/en/LC_MESSAGES/django.po
+++ b/analytics_dashboard/conf/locale/en/LC_MESSAGES/django.po
@@ -23,11 +23,11 @@ msgstr ""
 #: analytics_dashboard/core/templates/core/landing.html:15
 #: analytics_dashboard/templates/_skip_link.html:3
 msgid "Skip to content"
-msgstr "İçeriğe geç."
+msgstr ""
 
 #: analytics_dashboard/core/templates/core/landing.html:23
 msgid "Login"
-msgstr "Giriş yap."
+msgstr ""
 
 #: analytics_dashboard/core/templates/core/landing.html:33
 msgid "Insights to help course teams improve courses."


### PR DESCRIPTION
For some reason, there is a `msgstr` set in a source po file, which is not accurate to do. `msgstr` should be `""` in source po. The history of this string in Transifex looks like it was, at one point, erroneously translated, which I think may have caused it to be pulled down translated.

![image](https://user-images.githubusercontent.com/1985317/162767668-e937d8c1-9e3c-4b55-922b-b6669c20a865.png)
