### PR TITLE
fix: do not block merge on translations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         shell: bash
         env:
           TESTNAME: test-i18n
-          TARGETS: "generate_fake_translations validate_translations"
+          TARGETS: "generate_fake_translations"
       - name: test acceptance
         run: ./.github/scripts/testing.sh
         shell: bash


### PR DESCRIPTION
validate that translation extraction works in general
but do not demand new translations as part of default CI