### PR TITLE
feat: switch EngagementVideoContentTemplateView and CourseEngagementVideoTimelineCSV  to v1 as default

### DIFF
--- a/analytics_dashboard/courses/views/csv.py
+++ b/analytics_dashboard/courses/views/csv.py
@@ -102,7 +102,7 @@ class CourseEngagementActivityTrendCSV(AnalyticsV1Mixin, CourseCSVResponseMixin,
         return self.course.activity(data_format=data_formats.CSV, end_date=end_date)
 
 
-class CourseEngagementVideoTimelineCSV(AnalyticsV0Mixin, CourseCSVResponseMixin, CourseView):
+class CourseEngagementVideoTimelineCSV(AnalyticsV1Mixin, CourseCSVResponseMixin, CourseView):
     csv_filename_suffix = 'engagement-video-timeline'
 
     def get_data(self):

--- a/analytics_dashboard/courses/views/engagement.py
+++ b/analytics_dashboard/courses/views/engagement.py
@@ -16,7 +16,6 @@ from analytics_dashboard.courses.views import (
     CourseStructureExceptionMixin,
     CourseStructureMixin,
     CourseTemplateWithNavView,
-    AnalyticsV0Mixin,
     AnalyticsV1Mixin,
 )
 
@@ -91,7 +90,7 @@ class EngagementContentView(AnalyticsV1Mixin, EngagementTemplateView):
         return context
 
 
-class EngagementVideoContentTemplateView(AnalyticsV0Mixin, CourseStructureMixin, CourseStructureExceptionMixin,
+class EngagementVideoContentTemplateView(AnalyticsV1Mixin, CourseStructureMixin, CourseStructureExceptionMixin,
                                          EngagementTemplateView):
     page_title = _('Engagement Videos')
     active_secondary_nav_item = 'videos'


### PR DESCRIPTION
This pull request switches the EngagementVideoContentTemplateView to use the v1 database by default. This means that the v1 database will be used for the video views.