### PR TITLE
remove pytest and tox version pins from dashboard

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -216,7 +216,7 @@ stevedore==3.5.0
     #   edx-opaque-keys
 text-unidecode==1.3
     # via python-slugify
-typing-extensions==4.1.1
+typing-extensions==4.2.0
     # via django-countries
 unicodecsv==0.14.1
     # via djangorestframework-csv

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,13 +8,8 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
  
-# TODO: Many pinned dependencies should be unpinned and/or moved to this constraints file.
-
-# Pin to pylint version used in edx-lint
+# Pin to older pylint, newer versions will require significant code cleanup
 pylint==2.4.4
-
-# Newer versions cause build failure on github with `ERROR: Cannot find command 'git' - do you have 'git' installed and in your PATH?`
-tox==3.14.6
 
 # Newer version of django-webpack-loader is not compatible with npm webpack-bundle-tracker > 0.4.3
 django-webpack-loader==0.7.0

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -10,7 +10,7 @@ asgiref==3.5.0
     # via
     #   -r requirements/base.txt
     #   django
-babel==2.9.1
+babel==2.10.1
     # via sphinx
 certifi==2021.10.8
     # via
@@ -318,7 +318,7 @@ text-unidecode==1.3
     # via
     #   -r requirements/base.txt
     #   python-slugify
-typing-extensions==4.1.1
+typing-extensions==4.2.0
     # via
     #   -r requirements/base.txt
     #   django-countries

--- a/requirements/github.txt
+++ b/requirements/github.txt
@@ -27,7 +27,7 @@ packaging==21.3
     # via
     #   -r requirements/tox.txt
     #   tox
-platformdirs==2.5.1
+platformdirs==2.5.2
     # via
     #   -r requirements/tox.txt
     #   virtualenv

--- a/requirements/github.txt
+++ b/requirements/github.txt
@@ -31,7 +31,7 @@ platformdirs==2.5.2
     # via
     #   -r requirements/tox.txt
     #   virtualenv
-pluggy==0.13.1
+pluggy==1.0.0
     # via
     #   -r requirements/tox.txt
     #   tox
@@ -54,9 +54,8 @@ toml==0.10.2
     # via
     #   -r requirements/tox.txt
     #   tox
-tox==3.14.6
+tox==3.25.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/tox.txt
     #   tox-battery
 tox-battery==0.6.1

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -235,7 +235,7 @@ pinax-announcements==4.0.0
     # via -r requirements/test.txt
 pip-tools==6.6.0
     # via -r requirements/pip_tools.txt
-platformdirs==2.5.1
+platformdirs==2.5.2
     # via
     #   -r requirements/tox.txt
     #   virtualenv
@@ -421,7 +421,7 @@ tox-battery==0.6.1
     # via -r requirements/tox.txt
 transifex-client==0.12.4
     # via -r requirements/local.in
-typing-extensions==4.1.1
+typing-extensions==4.2.0
     # via
     #   -r requirements/test.txt
     #   django-countries

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -167,6 +167,10 @@ idna==3.3
     # via
     #   -r requirements/test.txt
     #   requests
+iniconfig==1.1.1
+    # via
+    #   -r requirements/test.txt
+    #   pytest
 isort==4.3.21
     # via
     #   -r requirements/test.txt
@@ -195,10 +199,6 @@ mccabe==0.6.1
     # via
     #   -r requirements/test.txt
     #   pylint
-more-itertools==8.12.0
-    # via
-    #   -r requirements/test.txt
-    #   pytest
 mysqlclient==2.1.0
     # via -r requirements/local.in
 newrelic==7.10.0.175
@@ -239,7 +239,7 @@ platformdirs==2.5.2
     # via
     #   -r requirements/tox.txt
     #   virtualenv
-pluggy==0.13.1
+pluggy==1.0.0
     # via
     #   -r requirements/test.txt
     #   -r requirements/tox.txt
@@ -296,7 +296,7 @@ pyparsing==3.0.8
     #   -r requirements/test.txt
     #   -r requirements/tox.txt
     #   packaging
-pytest==5.4.3
+pytest==7.1.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -412,9 +412,9 @@ tomli==2.0.1
     #   -r requirements/test.txt
     #   coverage
     #   pep517
-tox==3.14.6
+    #   pytest
+tox==3.25.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/tox.txt
     #   tox-battery
 tox-battery==0.6.1
@@ -439,10 +439,6 @@ virtualenv==20.14.1
     # via
     #   -r requirements/tox.txt
     #   tox
-wcwidth==0.2.5
-    # via
-    #   -r requirements/test.txt
-    #   pytest
 wheel==0.37.1
     # via
     #   -r requirements/pip_tools.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -288,7 +288,7 @@ text-unidecode==1.3
     # via
     #   -r requirements/base.txt
     #   python-slugify
-typing-extensions==4.1.1
+typing-extensions==4.2.0
     # via
     #   -r requirements/base.txt
     #   django-countries

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -17,6 +17,3 @@ pytest-cov
 pytest-django
 selenium
 testfixtures
-
-# greater version breaking a11y tests command
-pytest==5.4.3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -13,7 +13,9 @@ astroid==2.3.3
     #   -r requirements/test.in
     #   pylint
 attrs==21.4.0
-    # via pytest
+    # via
+    #   outcome
+    #   pytest
 bok-choy==1.1.1
     # via -r requirements/test.in
 certifi==2021.10.8
@@ -150,6 +152,8 @@ idna==3.3
     # via
     #   -r requirements/base.txt
     #   requests
+iniconfig==1.1.1
+    # via pytest
 isort==4.3.21
     # via pylint
 jinja2==3.1.1
@@ -170,8 +174,6 @@ markupsafe==2.1.1
     #   jinja2
 mccabe==0.6.1
     # via pylint
-more-itertools==8.12.0
-    # via pytest
 newrelic==7.10.0.175
     # via
     #   -r requirements/base.txt
@@ -196,7 +198,7 @@ pbr==5.8.1
     #   stevedore
 pinax-announcements==4.0.0
     # via -r requirements/base.txt
-pluggy==0.13.1
+pluggy==1.0.0
     # via pytest
 polib==1.1.1
     # via
@@ -242,7 +244,7 @@ pymongo==3.12.3
     #   edx-opaque-keys
 pyparsing==3.0.8
     # via packaging
-pytest==5.4.3
+pytest==7.1.1
     # via
     #   -r requirements/test.in
     #   pytest-cov
@@ -342,7 +344,9 @@ text-unidecode==1.3
     #   -r requirements/base.txt
     #   python-slugify
 tomli==2.0.1
-    # via coverage
+    # via
+    #   coverage
+    #   pytest
 typing-extensions==4.2.0
     # via
     #   -r requirements/base.txt
@@ -356,7 +360,5 @@ urllib3==1.26.9
     #   -r requirements/base.txt
     #   requests
     #   selenium
-wcwidth==0.2.5
-    # via pytest
 wrapt==1.11.2
     # via astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -343,7 +343,7 @@ text-unidecode==1.3
     #   python-slugify
 tomli==2.0.1
     # via coverage
-typing-extensions==4.1.1
+typing-extensions==4.2.0
     # via
     #   -r requirements/base.txt
     #   django-countries

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -14,7 +14,7 @@ packaging==21.3
     # via tox
 platformdirs==2.5.2
     # via virtualenv
-pluggy==0.13.1
+pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
@@ -26,9 +26,8 @@ six==1.16.0
     #   virtualenv
 toml==0.10.2
     # via tox
-tox==3.14.6
+tox==3.25.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/tox.in
     #   tox-battery
 tox-battery==0.6.1

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -12,7 +12,7 @@ filelock==3.6.0
     #   virtualenv
 packaging==21.3
     # via tox
-platformdirs==2.5.1
+platformdirs==2.5.2
     # via virtualenv
 pluggy==0.13.1
     # via tox


### PR DESCRIPTION
remove version pins for pytest and for tox, both used only in testing

pylint pin cannot be removed until we do a bunch of code scrubbing