### PR TITLE
feat: release performance views using v1 version of analytics api

### DIFF
--- a/analytics_dashboard/courses/views/csv.py
+++ b/analytics_dashboard/courses/views/csv.py
@@ -110,7 +110,7 @@ class CourseEngagementVideoTimelineCSV(AnalyticsV1Mixin, CourseCSVResponseMixin,
         return modules.video_timeline(data_format=data_formats.CSV)
 
 
-class PerformanceAnswerDistributionCSV(AnalyticsV0Mixin, CourseCSVResponseMixin, CourseView):
+class PerformanceAnswerDistributionCSV(AnalyticsV1Mixin, CourseCSVResponseMixin, CourseView):
     csv_filename_suffix = 'performance-answer-distribution'
 
     def get_data(self):
@@ -118,7 +118,7 @@ class PerformanceAnswerDistributionCSV(AnalyticsV0Mixin, CourseCSVResponseMixin,
         return modules.answer_distribution(data_format=data_formats.CSV)
 
 
-class PerformanceProblemResponseCSV(AnalyticsV0Mixin, CourseView):
+class PerformanceProblemResponseCSV(AnalyticsV1Mixin, CourseView):
     """
     Query the Data API to get a temporary secure download URL, and redirect to that.
     """

--- a/analytics_dashboard/courses/views/performance.py
+++ b/analytics_dashboard/courses/views/performance.py
@@ -18,13 +18,13 @@ from analytics_dashboard.courses.views import (
     CourseStructureExceptionMixin,
     CourseStructureMixin,
     CourseTemplateWithNavView,
-    AnalyticsV0Mixin,
+    AnalyticsV1Mixin,
 )
 
 logger = logging.getLogger(__name__)
 
 
-class PerformanceTemplateView(AnalyticsV0Mixin, CourseStructureExceptionMixin, CourseTemplateWithNavView,
+class PerformanceTemplateView(AnalyticsV1Mixin, CourseStructureExceptionMixin, CourseTemplateWithNavView,
                               CourseAPIMixin):
     """
     Base view for course performance pages.


### PR DESCRIPTION
This pull request switches the performance views to use the v1 database by default. This means that the v1 database will be used for the performance views.