### PR TITLE
Push docker image to edxops/insights repo now

### DIFF
--- a/.github/docker-compose-github.yml
+++ b/.github/docker-compose-github.yml
@@ -12,7 +12,7 @@ services:
       ELASTICSEARCH_LEARNERS_UPDATE_INDEX: 'index_update'
     command: /edx/app/analytics_api/venvs/analytics_api/bin/python /edx/app/analytics_api/analytics_api/manage.py runserver 0.0.0.0:80 --settings analyticsdataserver.settings.local
   insights:
-    image: edxops/insights:latest
+    image: edxops/insights-dev:latest
     container_name: insights_testing
     volumes:
       - ..:/edx/app/insights/edx_analytics_dashboard

--- a/.github/docker-compose-github.yml
+++ b/.github/docker-compose-github.yml
@@ -12,8 +12,7 @@ services:
       ELASTICSEARCH_LEARNERS_UPDATE_INDEX: 'index_update'
     command: /edx/app/analytics_api/venvs/analytics_api/bin/python /edx/app/analytics_api/analytics_api/manage.py runserver 0.0.0.0:80 --settings analyticsdataserver.settings.local
   insights:
-    #Temporary, just testing that CI works fine with Ansible free Image.
-    image: edxops/insights-dev:latest
+    image: edxops/insights:latest
     container_name: insights_testing
     volumes:
       - ..:/edx/app/insights/edx_analytics_dashboard

--- a/.github/docker-compose-github.yml
+++ b/.github/docker-compose-github.yml
@@ -12,7 +12,8 @@ services:
       ELASTICSEARCH_LEARNERS_UPDATE_INDEX: 'index_update'
     command: /edx/app/analytics_api/venvs/analytics_api/bin/python /edx/app/analytics_api/analytics_api/manage.py runserver 0.0.0.0:80 --settings analyticsdataserver.settings.local
   insights:
-    image: edxops/insights:latest
+    #Temporary, just testing that CI works fine with Ansible free Image.
+    image: edxops/insights-dev:latest
     container_name: insights_testing
     volumes:
       - ..:/edx/app/insights/edx_analytics_dashboard

--- a/.github/docker-compose-github.yml
+++ b/.github/docker-compose-github.yml
@@ -12,7 +12,7 @@ services:
       ELASTICSEARCH_LEARNERS_UPDATE_INDEX: 'index_update'
     command: /edx/app/analytics_api/venvs/analytics_api/bin/python /edx/app/analytics_api/analytics_api/manage.py runserver 0.0.0.0:80 --settings analyticsdataserver.settings.local
   insights:
-    image: edxops/insights-dev:latest
+    image: edxops/insights:latest
     container_name: insights_testing
     volumes:
       - ..:/edx/app/insights/edx_analytics_dashboard

--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -34,7 +34,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
           target: dev
-          repository: edxops/insights-dev
+          repository: edxops/insights
           tags: ${{ steps.get-tag-name.outputs.result }},${{ github.sha }}
 
       # - name: Build and push prod Docker image
@@ -44,5 +44,5 @@ jobs:
       #     username: ${{ secrets.DOCKERHUB_USERNAME }}
       #     password: ${{ secrets.DOCKERHUB_PASSWORD }}
       #     target: prod
-      #     repository: edxops/insights
+      #     repository: edxops/insights-prod
       #     tags: ${{ steps.get-tag-name.outputs.result }},${{ github.sha }}


### PR DESCRIPTION
As we have disabled the Insights-Image-builder job, we should now push the newer image to edxops/insights original repo and use that in devstack too.