### PR TITLE
Fix js tests in new docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,9 @@ RUN apt-get update && apt-get install --no-install-recommends -qy \
   python3-virtualenv \
   python3.8-distutils \
   libmysqlclient-dev \
-  libssl-dev && \
+  libssl-dev \
+  # needed by phantomjs
+  libfontconfig && \
   rm -rf /var/lib/apt/lists/*
 
 RUN locale-gen en_US.UTF-8


### PR DESCRIPTION
Seems like `libfontconfig` package is needed by phantomjs and we aren't currently installing this package in our docker image. I tried running CI on Ansible free Image and faced this [issue](https://github.com/openedx/edx-analytics-dashboard/actions/runs/3601054077/jobs/6066410495#step:8:2086). I have added this package to the image now and tried building the image and then ran the `js tests` locally. All js tests passed with the new local image that I built.