### PR TITLE
docs: Remove the CONTRIBUTING.md file now that there is a fallback.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,0 @@
-Contributions are very welcome.
-
-Please read [How To Contribute](https://github.com/openedx/edx-platform/blob/master/CONTRIBUTING.rst) for details.


### PR DESCRIPTION
There is now a centralized CONTRIBUTING.md file, so we don't need this
generic on in this repo.
