### PR TITLE
chore: Switch from edx-sphinx-theme to sphinx-book-theme

### DIFF
--- a/docs/en_us/dashboard/source/conf.py
+++ b/docs/en_us/dashboard/source/conf.py
@@ -4,11 +4,46 @@ import datetime
 import os
 import sys
 
-import edx_theme
 # on_rtd is whether we are on readthedocs.org, this line of code grabbed from docs.readthedocs.org
-html_theme = 'edx_theme'
+html_theme = 'sphinx_book_theme'
 
-html_theme_path = [edx_theme.get_html_theme_path()]
+# html_theme_path = []
+
+html_logo = "https://logos.openedx.org/open-edx-logo-color.png"
+
+html_favicon = "https://logos.openedx.org/open-edx-favicon.ico"
+
+html_theme_options = {
+ "repository_url": "https://github.com/openedx/edx-analytics-dashboard",
+ "repository_branch": "master",
+ "path_to_docs": "docs/en_us/dashboard/source",
+ "home_page_in_toc": True,
+ "use_repository_button": True,
+ "use_issues_button": True,
+ "use_edit_page_button": True,
+ # Please don't change unless you know what you're doing.
+ "extra_footer": """
+        <a rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/">
+            <img
+                alt="Creative Commons License"
+                style="border-width:0"
+                src="https://i.creativecommons.org/l/by-sa/4.0/80x15.png"/>
+        </a>
+        <br>
+        These works by
+            <a
+                xmlns:cc="https://creativecommons.org/ns#"
+                href="https://openedx.org"
+                property="cc:attributionName"
+                rel="cc:attributionURL"
+            >Axim Collaborative, Inc</a>
+        are licensed under a
+            <a
+                rel="license"
+                href="https://creativecommons.org/licenses/by-sa/4.0/"
+            >Creative Commons Attribution-ShareAlike 4.0 International License</a>.
+    """
+}
 
 sys.path.append(os.path.abspath('../../../'))
 sys.path.append(os.path.abspath('../../'))
@@ -29,12 +64,14 @@ master_doc = 'index'
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['edx_theme']
+extensions = []
 
 # General information about the project.
 project = 'Using edX Insights'
 
-copyright = '{year}, edX Inc. and licensed under a Creative Commons Attribution-ShareAlike 4.0 International License unless otherwise specified'.format(
+author = 'Axim Collaborative, Inc'
+
+copyright = '{year}, Axim Collaborative, Inc and licensed under a Creative Commons Attribution-ShareAlike 4.0 International License unless otherwise specified'.format(
     year=datetime.datetime.now().year)
 
 # The short X.Y version.

--- a/requirements/doc.in
+++ b/requirements/doc.in
@@ -3,4 +3,4 @@
 -r base.txt # Core dependencies of edx-analytics-dashboard
 
 Sphinx
-edx_sphinx_theme
+sphinx-book-theme

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,6 +4,8 @@
 #
 #    make upgrade
 #
+accessible-pygments==0.0.4
+    # via pydata-sphinx-theme
 alabaster==0.7.13
     # via sphinx
 asgiref==3.6.0
@@ -12,7 +14,11 @@ asgiref==3.6.0
     #   django
     #   django-countries
 babel==2.12.1
-    # via sphinx
+    # via
+    #   pydata-sphinx-theme
+    #   sphinx
+beautifulsoup4==4.12.2
+    # via pydata-sphinx-theme
 certifi==2022.12.7
     # via
     #   -r requirements/base.txt
@@ -105,7 +111,9 @@ djangorestframework==3.14.0
 djangorestframework-csv==2.1.1
     # via -r requirements/base.txt
 docutils==0.19
-    # via sphinx
+    # via
+    #   pydata-sphinx-theme
+    #   sphinx
 drf-jwt==1.19.2
     # via
     #   -r requirements/base.txt
@@ -135,8 +143,6 @@ edx-opaque-keys==2.3.0
     #   edx-drf-extensions
 edx-rest-api-client==5.5.0
     # via -r requirements/base.txt
-edx-sphinx-theme==3.1.0
-    # via -r requirements/doc.in
 edx-toggles==5.0.0
     # via -r requirements/base.txt
 future==0.18.3
@@ -174,7 +180,9 @@ oauthlib==3.2.2
     #   requests-oauthlib
     #   social-auth-core
 packaging==23.1
-    # via sphinx
+    # via
+    #   pydata-sphinx-theme
+    #   sphinx
 path==16.6.0
     # via
     #   -r requirements/base.txt
@@ -204,8 +212,13 @@ pycryptodomex==3.17
     # via
     #   -r requirements/base.txt
     #   pyjwkest
+pydata-sphinx-theme==0.13.3
+    # via sphinx-book-theme
 pygments==2.15.1
-    # via sphinx
+    # via
+    #   accessible-pygments
+    #   pydata-sphinx-theme
+    #   sphinx
 pyjwkest==1.4.2
     # via
     #   -r requirements/base.txt
@@ -277,7 +290,6 @@ six==1.16.0
     #   edx-ccx-keys
     #   edx-django-release-util
     #   edx-drf-extensions
-    #   edx-sphinx-theme
     #   pyjwkest
     #   python-dateutil
 slumber==0.7.1
@@ -295,11 +307,16 @@ social-auth-core==4.4.1
     #   -r requirements/base.txt
     #   edx-auth-backends
     #   social-auth-app-django
+soupsieve==2.4.1
+    # via beautifulsoup4
 sphinx==5.3.0
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/doc.in
-    #   edx-sphinx-theme
+    #   pydata-sphinx-theme
+    #   sphinx-book-theme
+sphinx-book-theme==1.0.1
+    # via -r requirements/doc.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
@@ -330,6 +347,7 @@ typing-extensions==4.5.0
     # via
     #   -r requirements/base.txt
     #   django-countries
+    #   pydata-sphinx-theme
 unicodecsv==0.14.1
     # via
     #   -r requirements/base.txt


### PR DESCRIPTION
The edx-sphinx theme is being deprecated, and replaced with sphinx-book-theme. This removes references to the deprecated theme and replaces them with the new standard theme for the platform.

**Testing instructions:**
- Run `make docs` and see that the docs are generated properly and use the sphinx-book-theme

See https://github.com/openedx/public-engineering/issues/200