### PR TITLE
build: remove deprecated codecov package & use GHA instead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,5 +68,5 @@ jobs:
           TESTNAME: test-python
           NODE: ${{ matrix.node }}
           TARGETS: "requirements.js static test_python"
-      - name: code cov
-        run: codecov --disable pycov
+      - name: codecov
+        uses: codecov/codecov-action@v3

--- a/requirements/github.in
+++ b/requirements/github.in
@@ -3,4 +3,3 @@
 -c constraints.txt
 -r tox.txt
 
-codecov

--- a/requirements/github.txt
+++ b/requirements/github.txt
@@ -8,8 +8,6 @@ certifi==2022.12.7
     # via requests
 charset-normalizer==3.1.0
     # via requests
-codecov==2.1.12
-    # via -r requirements/github.in
 coverage==7.2.2
     # via codecov
 distlib==0.3.6


### PR DESCRIPTION
Context: https://about.codecov.io/blog/message-regarding-the-pypi-package/
