### PR TITLE
fix: install pkg-config dependency for mysqlclient>=2.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@ FROM ubuntu:focal as app
 
 ENV DEBIAN_FRONTEND noninteractive
 
+# Packages installed:
+
+# pkg-config; mysqlclient>=2.2.0 requires pkg-config (https://github.com/PyMySQL/mysqlclient/issues/620)
+
 RUN apt-get update && apt-get install --no-install-recommends -qy \
   language-pack-en \
   build-essential \
@@ -9,6 +13,7 @@ RUN apt-get update && apt-get install --no-install-recommends -qy \
   python3-virtualenv \
   python3.8-distutils \
   libmysqlclient-dev \
+  pkg-config \
   libssl-dev \
   # needed by phantomjs
   libfontconfig \


### PR DESCRIPTION
**JIRA:** None.

**Description:**

Repositiories that depend on mysqlclient>=2.2.0 will need to install the package pkg-config in their Dockerfile: https://github.com/PyMySQL/mysqlclient/issues/620. This commit installs the pkg-config package in the Dockerfile.

If this is missing, then pip install of mysqlclient fails with an error that includes the following:

```
Exception: Can not find valid pkg-config name.
Specify MYSQLCLIENT_CFLAGS and MYSQLCLIENT_LDFLAGS env vars manually
```

See https://github.com/edx/edx-arch-experiments/issues/349.

**Author concerns:** None.

**Dependencies:** None.

**Installation instructions:** None.

**Testing instructions:**

Build the Dockerfile using `docker build -f Dockerfile .`.