### PR TITLE
build: include pymemcache dependency

### DIFF
--- a/requirements/production.in
+++ b/requirements/production.in
@@ -8,4 +8,5 @@ mysqlclient
 PyYAML										# MIT License
 gunicorn        							# MIT
 python-memcached
+pymemcache
 nodeenv     								# BSD

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -198,6 +198,8 @@ pyjwt[crypto]==2.8.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
+pymemcache==4.0.0
+    # via -r requirements/production.in
 pymongo==3.13.0
     # via
     #   -r requirements/base.txt


### PR DESCRIPTION
## Description
- Under the issue https://github.com/openedx/edx-analytics-dashboard/issues/1493, adding the `pymemcache` dependency in the requirements in order to prepare for the migration of cache backend. 