### PR TITLE
fix: fix django 4.0 deprecation warnings

### DIFF
--- a/analytics_dashboard/__init__.py
+++ b/analytics_dashboard/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = 'core.apps.AnalyticsDashboardConfig'

--- a/analytics_dashboard/core/admin.py
+++ b/analytics_dashboard/core/admin.py
@@ -4,8 +4,6 @@ from django.contrib.auth.admin import UserAdmin
 from analytics_dashboard.core.models import User
 
 
+@admin.register(User)
 class AnalyticsDashboardUserAdmin(UserAdmin):
     pass
-
-
-admin.site.register(User, AnalyticsDashboardUserAdmin)

--- a/analytics_dashboard/core/templatetags/dashboard_extras.py
+++ b/analytics_dashboard/core/templatetags/dashboard_extras.py
@@ -4,7 +4,7 @@ from django import template
 from django.conf import settings
 from django.template.defaultfilters import stringfilter
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from opaque_keys.edx.keys import CourseKey
 from slugify import slugify
 

--- a/analytics_dashboard/core/tests/test_utils.py
+++ b/analytics_dashboard/core/tests/test_utils.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.test.utils import override_settings
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from analytics_dashboard.core.utils import (
     CourseStructureApiClient,

--- a/analytics_dashboard/core/tests/test_views.py
+++ b/analytics_dashboard/core/tests/test_views.py
@@ -9,7 +9,7 @@ from django.db import DatabaseError
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.urls import reverse, reverse_lazy
-from django.utils.http import urlquote
+from urllib.parse import quote
 from django_dynamic_fixture import G
 from testfixtures import LogCapture
 
@@ -55,7 +55,7 @@ class UserTestCaseMixin:
 class RedirectTestCaseMixin:
     def assertRedirectsNoFollow(self, response, expected_url, status_code=302, **querystringkwargs):
         if querystringkwargs:
-            expected_url += '?{}'.format('&'.join('{}={}'.format(key, urlquote(value))
+            expected_url += '?{}'.format('&'.join('{}={}'.format(key, quote(value))
                                                   for (key, value) in querystringkwargs.items()))
 
         self.assertEqual(response['Location'], f'{expected_url}')

--- a/analytics_dashboard/core/utils.py
+++ b/analytics_dashboard/core/utils.py
@@ -2,7 +2,7 @@ from hashlib import md5
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from soapbox.models import Message
 
 from common import clients

--- a/analytics_dashboard/courses/presenters/engagement.py
+++ b/analytics_dashboard/courses/presenters/engagement.py
@@ -6,7 +6,7 @@ import analyticsclient.constants.activity_types as AT
 from analyticsclient.client import Client
 from analyticsclient.exceptions import NotFoundError
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from waffle import switch_is_active
 
 from analytics_dashboard.core.templatetags.dashboard_extras import metric_percentage

--- a/analytics_dashboard/courses/presenters/enrollment.py
+++ b/analytics_dashboard/courses/presenters/enrollment.py
@@ -6,7 +6,7 @@ from analyticsclient.constants import UNKNOWN_COUNTRY_CODE, demographics
 from analyticsclient.constants import education_levels as EDUCATION_LEVEL
 from analyticsclient.constants import enrollment_modes
 from analyticsclient.constants import genders as GENDER
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django_countries import countries
 
 import analytics_dashboard.courses.utils as utils

--- a/analytics_dashboard/courses/presenters/performance.py
+++ b/analytics_dashboard/courses/presenters/performance.py
@@ -6,7 +6,7 @@ from analyticsclient.exceptions import NotFoundError
 from django.conf import settings
 from django.core.cache import cache
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from requests.exceptions import HTTPError
 from slugify import slugify
 

--- a/analytics_dashboard/courses/tests/test_serializers.py
+++ b/analytics_dashboard/courses/tests/test_serializers.py
@@ -1,7 +1,7 @@
 import json
 
 from django.test import TestCase
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from analytics_dashboard.courses.serializers import LazyEncoder
 

--- a/analytics_dashboard/courses/tests/test_views/__init__.py
+++ b/analytics_dashboard/courses/tests/test_views/__init__.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.contrib.humanize.templatetags.humanize import intcomma
 from django.core.cache import cache
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from waffle.testutils import override_switch
 
 from analytics_dashboard.core.tests.test_views import RedirectTestCaseMixin, UserTestCaseMixin

--- a/analytics_dashboard/courses/tests/test_views/test_engagement.py
+++ b/analytics_dashboard/courses/tests/test_views/test_engagement.py
@@ -4,7 +4,7 @@ import httpretty
 from ddt import ddt, data
 from django.test import TestCase
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from waffle.testutils import override_switch
 
 from analytics_dashboard.courses.tests import utils

--- a/analytics_dashboard/courses/tests/test_views/test_performance.py
+++ b/analytics_dashboard/courses/tests/test_views/test_performance.py
@@ -8,7 +8,7 @@ from ddt import ddt
 from django.conf import settings
 from django.test import TestCase
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from slugify import slugify
 from waffle.testutils import override_switch
 

--- a/analytics_dashboard/courses/urls.py
+++ b/analytics_dashboard/courses/urls.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.conf.urls import include, url
+from django.urls import include, path, re_path
 
 from analytics_dashboard.courses import views
 from analytics_dashboard.courses.views import (
@@ -34,100 +34,100 @@ video_timeline_regex = \
         SECTION_ID_PATTERN, SUBSECTION_ID_PATTERN, VIDEO_ID_PATTERN)
 
 ENROLLMENT_URLS = ([
-    url(r'^activity/$', enrollment.EnrollmentActivityView.as_view(), name='activity'),
-    url(r'^geography/$', enrollment.EnrollmentGeographyView.as_view(), name='geography'),
-    url(r'^demographics/age/$', enrollment.EnrollmentDemographicsAgeView.as_view(), name='demographics_age'),
-    url(r'^demographics/education/$', enrollment.EnrollmentDemographicsEducationView.as_view(),
+    path('activity/', enrollment.EnrollmentActivityView.as_view(), name='activity'),
+    path('geography/', enrollment.EnrollmentGeographyView.as_view(), name='geography'),
+    path('demographics/age/', enrollment.EnrollmentDemographicsAgeView.as_view(), name='demographics_age'),
+    path('demographics/education/', enrollment.EnrollmentDemographicsEducationView.as_view(),
         name='demographics_education'),
-    url(r'^demographics/gender/$', enrollment.EnrollmentDemographicsGenderView.as_view(), name='demographics_gender'),
+    path('demographics/gender/', enrollment.EnrollmentDemographicsGenderView.as_view(), name='demographics_gender'),
 ], 'enrollment')
 
 ENGAGEMENT_URLS = ([
-    url(r'^content/$', engagement.EngagementContentView.as_view(), name='content'),
-    url(r'^videos/$', engagement.EngagementVideoCourse.as_view(), name='videos'),
+    path('content/', engagement.EngagementContentView.as_view(), name='content'),
+    path('videos/', engagement.EngagementVideoCourse.as_view(), name='videos'),
     # ordering of the URLS is important for routing the the section, subsection, etc. correctly
-    url(video_timeline_regex, engagement.EngagementVideoTimeline.as_view(), name='video_timeline'),
-    url(fr'^videos/sections/{SECTION_ID_PATTERN}/subsections/{SUBSECTION_ID_PATTERN}/$',
+    re_path(video_timeline_regex, engagement.EngagementVideoTimeline.as_view(), name='video_timeline'),
+    re_path(fr'^videos/sections/{SECTION_ID_PATTERN}/subsections/{SUBSECTION_ID_PATTERN}/$',
         engagement.EngagementVideoSubsection.as_view(),
         name='video_subsection'),
-    url(fr'^videos/sections/{SECTION_ID_PATTERN}/$',
+    re_path(fr'^videos/sections/{SECTION_ID_PATTERN}/$',
         engagement.EngagementVideoSection.as_view(),
         name='video_section'),
 ], 'engagement')
 
 PERFORMANCE_URLS = ([
-    url(r'^ungraded_content/$', performance.PerformanceUngradedContent.as_view(), name='ungraded_content'),
-    url(ungraded_answer_distribution_regex, performance.PerformanceUngradedAnswerDistribution.as_view(),
+    path('ungraded_content/', performance.PerformanceUngradedContent.as_view(), name='ungraded_content'),
+    re_path(ungraded_answer_distribution_regex, performance.PerformanceUngradedAnswerDistribution.as_view(),
         name='ungraded_answer_distribution'),
-    url(fr'^ungraded_content/sections/{SECTION_ID_PATTERN}/subsections/{SUBSECTION_ID_PATTERN}/$',
+    re_path(fr'^ungraded_content/sections/{SECTION_ID_PATTERN}/subsections/{SUBSECTION_ID_PATTERN}/$',
         performance.PerformanceUngradedSubsection.as_view(),
         name='ungraded_subsection'),
-    url(fr'^ungraded_content/sections/{SECTION_ID_PATTERN}/$',
+    re_path(fr'^ungraded_content/sections/{SECTION_ID_PATTERN}/$',
         performance.PerformanceUngradedSection.as_view(),
         name='ungraded_section'),
-    url(r'^graded_content/$', performance.PerformanceGradedContent.as_view(), name='graded_content'),
-    url(r'^graded_content/(?P<assignment_type>[\w-]+)/$',
+    path('graded_content/', performance.PerformanceGradedContent.as_view(), name='graded_content'),
+    re_path(r'^graded_content/(?P<assignment_type>[\w-]+)/$',
         performance.PerformanceGradedContentByType.as_view(),
         name='graded_content_by_type'),
-    url(answer_distribution_regex, performance.PerformanceAnswerDistributionView.as_view(), name='answer_distribution'),
+    re_path(answer_distribution_regex, performance.PerformanceAnswerDistributionView.as_view(), name='answer_distribution'),
 
     # This MUST come AFTER the answer distribution pattern; otherwise, the answer distribution pattern
     # will be interpreted as an assignment pattern.
-    url(fr'^graded_content/assignments/{ASSIGNMENT_ID_PATTERN}/$',
+    re_path(fr'^graded_content/assignments/{ASSIGNMENT_ID_PATTERN}/$',
         performance.PerformanceAssignment.as_view(),
         name='assignment'),
-    url(r'^learning_outcomes/$',
+    path('learning_outcomes/',
         performance.PerformanceLearningOutcomesContent.as_view(),
         name='learning_outcomes'),
-    url(fr'^learning_outcomes/{TAG_VALUE_ID_PATTERN}/$',
+    re_path(fr'^learning_outcomes/{TAG_VALUE_ID_PATTERN}/$',
         performance.PerformanceLearningOutcomesSection.as_view(),
         name='learning_outcomes_section'),
-    url(fr'^learning_outcomes/{TAG_VALUE_ID_PATTERN}/problems/{PROBLEM_ID_PATTERN}/$',
+    re_path(fr'^learning_outcomes/{TAG_VALUE_ID_PATTERN}/problems/{PROBLEM_ID_PATTERN}/$',
         performance.PerformanceLearningOutcomesAnswersDistribution.as_view(),
         name='learning_outcomes_answers_distribution'),
-    url(r'^learning_outcomes/{}/problems/{}/{}/$'.format(TAG_VALUE_ID_PATTERN, PROBLEM_ID_PATTERN,
+    re_path(r'^learning_outcomes/{}/problems/{}/{}/$'.format(TAG_VALUE_ID_PATTERN, PROBLEM_ID_PATTERN,
                                                          PROBLEM_PART_ID_PATTERN),
         performance.PerformanceLearningOutcomesAnswersDistribution.as_view(),
         name='learning_outcomes_answers_distribution_with_part'),
 ], 'performance')
 
 CSV_URLS = ([
-    url(r'^enrollment/$', csv.CourseEnrollmentCSV.as_view(), name='enrollment'),
-    url(r'^enrollment/geography/$', csv.CourseEnrollmentByCountryCSV.as_view(), name='enrollment_geography'),
-    url(r'^enrollment/demographics/age/$',
+    path('enrollment/', csv.CourseEnrollmentCSV.as_view(), name='enrollment'),
+    path('enrollment/geography/', csv.CourseEnrollmentByCountryCSV.as_view(), name='enrollment_geography'),
+    path('enrollment/demographics/age/',
         csv.CourseEnrollmentDemographicsAgeCSV.as_view(),
         name='enrollment_demographics_age'),
-    url(r'^enrollment/demographics/education/$',
+    path('enrollment/demographics/education/',
         csv.CourseEnrollmentDemographicsEducationCSV.as_view(),
         name='enrollment_demographics_education'),
-    url(r'^enrollment/demographics/gender/$',
+    path('enrollment/demographics/gender/',
         csv.CourseEnrollmentDemographicsGenderCSV.as_view(),
         name='enrollment_demographics_gender'),
-    url(r'^engagement/activity_trend/$',
+    path('engagement/activity_trend/',
         csv.CourseEngagementActivityTrendCSV.as_view(),
         name='engagement_activity_trend'),
-    url(fr'^engagement/videos/{PIPELINE_VIDEO_ID}/$',
+    re_path(fr'^engagement/videos/{PIPELINE_VIDEO_ID}/$',
         csv.CourseEngagementVideoTimelineCSV.as_view(),
         name='engagement_video_timeline'),
-    url(r'^performance/graded_content/problems/{}/answer_distribution/{}/$'.format(CONTENT_ID_PATTERN,
+    re_path(r'^performance/graded_content/problems/{}/answer_distribution/{}/$'.format(CONTENT_ID_PATTERN,
                                                                                    PROBLEM_PART_ID_PATTERN),
         csv.PerformanceAnswerDistributionCSV.as_view(),
         name='performance_answer_distribution'),
-    url(r'problem_responses/', csv.PerformanceProblemResponseCSV.as_view(), name='performance_problem_responses')
+    re_path(r'problem_responses/', csv.PerformanceProblemResponseCSV.as_view(), name='performance_problem_responses')
 ], 'csv')
 
 COURSE_URLS = [
     # Course homepage. This should be the entry point for other applications linking to the course.
-    url(r'^$', views.CourseHome.as_view(), name='home'),
-    url(r'^enrollment/', include(ENROLLMENT_URLS)),
-    url(r'^engagement/', include(ENGAGEMENT_URLS)),
-    url(r'^performance/', include(PERFORMANCE_URLS)),
-    url(r'^csv/', include(CSV_URLS)),
+    path('', views.CourseHome.as_view(), name='home'),
+    path('enrollment/', include(ENROLLMENT_URLS)),
+    path('engagement/', include(ENGAGEMENT_URLS)),
+    path('performance/', include(PERFORMANCE_URLS)),
+    path('csv/', include(CSV_URLS)),
 ]
 
 app_name = 'courses'
 urlpatterns = [
-    url('^$', course_summaries.CourseIndex.as_view(), name='index'),
-    url(fr'^{settings.COURSE_ID_PATTERN}/', include(COURSE_URLS)),
-    url(r'csv/course_list/$', course_summaries.CourseIndexCSV.as_view(), name='index_csv')
+    path('', course_summaries.CourseIndex.as_view(), name='index'),
+    re_path(fr'^{settings.COURSE_ID_PATTERN}/', include(COURSE_URLS)),
+    path('csv/course_list/', course_summaries.CourseIndexCSV.as_view(), name='index_csv')
 ]

--- a/analytics_dashboard/courses/views/__init__.py
+++ b/analytics_dashboard/courses/views/__init__.py
@@ -16,8 +16,8 @@ from django.http import Http404
 from django.urls import reverse
 from django.utils import dateformat
 from django.utils.functional import cached_property
-from django.utils.translation import ugettext_lazy as _
-from django.utils.translation import ugettext_noop
+from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_noop
 from django.views import View
 from django.views.generic import TemplateView
 from requests.exceptions import HTTPError
@@ -304,7 +304,7 @@ class CourseNavBarMixin:
         items = [
             {
                 'name': 'enrollment',
-                'text': ugettext_noop('Enrollment'),
+                'text': gettext_noop('Enrollment'),
                 'view': 'courses:enrollment:activity',
                 'icon': 'fa-child',
                 'fragment': '',
@@ -315,7 +315,7 @@ class CourseNavBarMixin:
             },
             {
                 'name': 'engagement',
-                'text': ugettext_noop('Engagement'),
+                'text': gettext_noop('Engagement'),
                 'view': 'courses:engagement:content',
                 'icon': 'fa-bar-chart',
                 'fragment': '',
@@ -326,7 +326,7 @@ class CourseNavBarMixin:
             },
             {
                 'name': 'performance',
-                'text': ugettext_noop('Performance'),
+                'text': gettext_noop('Performance'),
                 'view': 'courses:performance:graded_content',
                 'icon': 'fa-check-square-o',
                 'switch': 'enable_course_api',
@@ -529,7 +529,7 @@ class CourseHome(AnalyticsV0Mixin, CourseTemplateWithNavView):
 
         enrollment_subitems = [
             {
-                'title': ugettext_noop('How many learners are in my course?'),
+                'title': gettext_noop('How many learners are in my course?'),
                 'view': 'courses:enrollment:activity',
                 'breadcrumbs': [_('Activity')],
                 'fragment': '',
@@ -541,7 +541,7 @@ class CourseHome(AnalyticsV0Mixin, CourseTemplateWithNavView):
         if age_available():
             enrollment_subitems = enrollment_subitems + [
                 {
-                    'title': ugettext_noop('How old are my learners?'),
+                    'title': gettext_noop('How old are my learners?'),
                     'view': 'courses:enrollment:demographics_age',
                     'breadcrumbs': [_('Demographics'), _('Age')],
                     'fragment': '',
@@ -552,7 +552,7 @@ class CourseHome(AnalyticsV0Mixin, CourseTemplateWithNavView):
                 }]
         enrollment_subitems = enrollment_subitems + [
             {
-                'title': ugettext_noop('What level of education do my learners have?'),
+                'title': gettext_noop('What level of education do my learners have?'),
                 'view': 'courses:enrollment:demographics_education',
                 'breadcrumbs': [_('Demographics'), _('Education')],
                 'fragment': '',
@@ -562,7 +562,7 @@ class CourseHome(AnalyticsV0Mixin, CourseTemplateWithNavView):
                 'depth': 'education'
             },
             {
-                'title': ugettext_noop('What is the learner gender breakdown?'),
+                'title': gettext_noop('What is the learner gender breakdown?'),
                 'view': 'courses:enrollment:demographics_gender',
                 'breadcrumbs': [_('Demographics'), _('Gender')],
                 'fragment': '',
@@ -572,7 +572,7 @@ class CourseHome(AnalyticsV0Mixin, CourseTemplateWithNavView):
                 'depth': 'gender'
             },
             {
-                'title': ugettext_noop('Where are my learners?'),
+                'title': gettext_noop('Where are my learners?'),
                 'view': 'courses:enrollment:geography',
                 'breadcrumbs': [_('Geography')],
                 'fragment': '',
@@ -597,7 +597,7 @@ class CourseHome(AnalyticsV0Mixin, CourseTemplateWithNavView):
             'heading': _('What are learners doing in my course?'),
             'items': [
                 {
-                    'title': ugettext_noop('How many learners are interacting with my course?'),
+                    'title': gettext_noop('How many learners are interacting with my course?'),
                     'view': 'courses:engagement:content',
                     'breadcrumbs': [_('Content')],
                     'fragment': '',
@@ -610,7 +610,7 @@ class CourseHome(AnalyticsV0Mixin, CourseTemplateWithNavView):
         }
         if switch_is_active('enable_engagement_videos_pages'):
             engagement_items['items'].append({
-                'title': ugettext_noop('How did learners interact with course videos?'),
+                'title': gettext_noop('How did learners interact with course videos?'),
                 'view': 'courses:engagement:videos',
                 'breadcrumbs': [_('Videos')],
                 'fragment': '',
@@ -624,7 +624,7 @@ class CourseHome(AnalyticsV0Mixin, CourseTemplateWithNavView):
 
         if self.course_api_enabled:
             subitems = [{
-                'title': ugettext_noop('How are learners doing on graded course assignments?'),
+                'title': gettext_noop('How are learners doing on graded course assignments?'),
                 'view': 'courses:performance:graded_content',
                 'breadcrumbs': [_('Graded Content')],
                 'fragment': '',
@@ -633,7 +633,7 @@ class CourseHome(AnalyticsV0Mixin, CourseTemplateWithNavView):
                 'report': 'graded',
                 'depth': ''
             }, {
-                'title': ugettext_noop('How are learners doing on ungraded exercises?'),
+                'title': gettext_noop('How are learners doing on ungraded exercises?'),
                 'view': 'courses:performance:ungraded_content',
                 'breadcrumbs': [_('Ungraded Problems')],
                 'fragment': '',
@@ -645,7 +645,7 @@ class CourseHome(AnalyticsV0Mixin, CourseTemplateWithNavView):
 
             if switch_is_active('enable_performance_learning_outcome'):
                 subitems.append({
-                    'title': ugettext_noop('What is the breakdown for course learning outcomes?'),
+                    'title': gettext_noop('What is the breakdown for course learning outcomes?'),
                     'view': 'courses:performance:learning_outcomes',
                     'breadcrumbs': [_('Learning Outcomes')],
                     'fragment': '',
@@ -665,7 +665,7 @@ class CourseHome(AnalyticsV0Mixin, CourseTemplateWithNavView):
                 if 'download_url' in info:
                     # A problem response report CSV is available:
                     subitems.append({
-                        'title': ugettext_noop('How are learners responding to questions?'),
+                        'title': gettext_noop('How are learners responding to questions?'),
                         'view': 'courses:csv:performance_problem_responses',
                         'breadcrumbs': [_('Problem Response Report')],
                         'format': 'csv',
@@ -731,12 +731,12 @@ class CourseHome(AnalyticsV0Mixin, CourseTemplateWithNavView):
 
         if settings.LMS_COURSE_SHORTCUT_BASE_URL:
             external_tools.append({
-                'title': ugettext_noop('Instructor Dashboard'),
+                'title': gettext_noop('Instructor Dashboard'),
                 'url': f"{settings.LMS_COURSE_SHORTCUT_BASE_URL}/{self.course_id}/instructor",
                 'icon': 'fa-dashboard',
             })
             external_tools.append({
-                'title': ugettext_noop('Courseware'),
+                'title': gettext_noop('Courseware'),
                 'url': f"{settings.LMS_COURSE_SHORTCUT_BASE_URL}/{self.course_id}/courseware",
                 'icon': 'fa-pencil-square-o',
             })

--- a/analytics_dashboard/courses/views/course_summaries.py
+++ b/analytics_dashboard/courses/views/course_summaries.py
@@ -4,7 +4,7 @@ from braces.views import LoginRequiredMixin
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from rest_framework_csv.renderers import CSVRenderer
 from waffle import switch_is_active
 

--- a/analytics_dashboard/courses/views/engagement.py
+++ b/analytics_dashboard/courses/views/engagement.py
@@ -3,8 +3,8 @@ import logging
 from analyticsclient.exceptions import NotFoundError
 from django.conf import settings
 from django.http import Http404
-from django.utils.translation import ugettext_lazy as _
-from django.utils.translation import ugettext_noop
+from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_noop
 from waffle import switch_is_active
 
 from analytics_dashboard.core.utils import translate_dict_values
@@ -30,7 +30,7 @@ class EngagementTemplateView(CourseTemplateWithNavView):
         {
             'name': 'content',
             # Translators: Content as in course content (e.g. things, not the feeling)
-            'text': ugettext_noop('Content'),
+            'text': gettext_noop('Content'),
             'view': 'courses:engagement:content',
             'scope': 'course',
             'lens': 'engagement',
@@ -39,7 +39,7 @@ class EngagementTemplateView(CourseTemplateWithNavView):
         },
         {
             'name': 'videos',
-            'text': ugettext_noop('Videos'),
+            'text': gettext_noop('Videos'),
             'view': 'courses:engagement:videos',
             'switch': 'enable_engagement_videos_pages',
             'scope': 'course',

--- a/analytics_dashboard/courses/views/enrollment.py
+++ b/analytics_dashboard/courses/views/enrollment.py
@@ -2,8 +2,8 @@ import logging
 
 from analyticsclient.exceptions import NotFoundError
 from django.contrib.humanize.templatetags.humanize import intcomma
-from django.utils.translation import ugettext_lazy as _
-from django.utils.translation import ugettext_noop
+from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_noop
 
 from analytics_dashboard.core.utils import translate_dict_values
 from analytics_dashboard.courses.presenters.enrollment import (
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 def _enrollment_secondary_nav():
     demographics_landing_view = {
         'name': 'demographics',
-        'text': ugettext_noop('Demographics'),
+        'text': gettext_noop('Demographics'),
         'view': 'courses:enrollment:demographics_age',
         'scope': 'course',
         'lens': 'enrollment',
@@ -28,7 +28,7 @@ def _enrollment_secondary_nav():
         'depth': 'age'
     } if age_available() else {
         'name': 'demographics',
-        'text': ugettext_noop('Demographics'),
+        'text': gettext_noop('Demographics'),
         'view': 'courses:enrollment:demographics_education',
         'scope': 'course',
         'lens': 'enrollment',
@@ -39,7 +39,7 @@ def _enrollment_secondary_nav():
     secondary_nav_items = [
         {
             'name': 'activity',
-            'text': ugettext_noop('Activity'),
+            'text': gettext_noop('Activity'),
             'view': 'courses:enrollment:activity',
             'scope': 'course',
             'lens': 'enrollment',
@@ -49,7 +49,7 @@ def _enrollment_secondary_nav():
         demographics_landing_view,
         {
             'name': 'geography',
-            'text': ugettext_noop('Geography'),
+            'text': gettext_noop('Geography'),
             'view': 'courses:enrollment:geography',
             'scope': 'course',
             'lens': 'enrollment',
@@ -74,7 +74,7 @@ def _enrollment_tertiary_nav():
     tertiary_age = [
         {
             'name': 'age',
-            'text': ugettext_noop('Age'),
+            'text': gettext_noop('Age'),
             'view': 'courses:enrollment:demographics_age',
             'scope': 'course',
             'lens': 'enrollment',
@@ -85,7 +85,7 @@ def _enrollment_tertiary_nav():
     tertiary_nav_items = tertiary_age + [
         {
             'name': 'education',
-            'text': ugettext_noop('Education'),
+            'text': gettext_noop('Education'),
             'view': 'courses:enrollment:demographics_education',
             'scope': 'course',
             'lens': 'enrollment',
@@ -94,7 +94,7 @@ def _enrollment_tertiary_nav():
         },
         {
             'name': 'gender',
-            'text': ugettext_noop('Gender'),
+            'text': gettext_noop('Gender'),
             'view': 'courses:enrollment:demographics_gender',
             'scope': 'course',
             'lens': 'enrollment',

--- a/analytics_dashboard/courses/views/performance.py
+++ b/analytics_dashboard/courses/views/performance.py
@@ -3,8 +3,8 @@ import logging
 
 from django.conf import settings
 from django.http import Http404
-from django.utils.translation import ugettext_lazy as _
-from django.utils.translation import ugettext_noop
+from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_noop
 from slugify import slugify
 from waffle import switch_is_active
 
@@ -40,7 +40,7 @@ class PerformanceTemplateView(AnalyticsV1Mixin, CourseStructureExceptionMixin, C
     secondary_nav_items_base = [
         {
             'name': 'graded_content',
-            'text': ugettext_noop('Graded Content'),
+            'text': gettext_noop('Graded Content'),
             'view': 'courses:performance:graded_content',
             'scope': 'course',
             'lens': 'performance',
@@ -49,7 +49,7 @@ class PerformanceTemplateView(AnalyticsV1Mixin, CourseStructureExceptionMixin, C
         },
         {
             'name': 'ungraded_content',
-            'text': ugettext_noop('Ungraded Problems'),
+            'text': gettext_noop('Ungraded Problems'),
             'view': 'courses:performance:ungraded_content',
             'scope': 'course',
             'lens': 'performance',
@@ -67,7 +67,7 @@ class PerformanceTemplateView(AnalyticsV1Mixin, CourseStructureExceptionMixin, C
             if not any(d['name'] == 'learning_outcomes' for d in self.secondary_nav_items):
                 self.secondary_nav_items.append({
                     'name': 'learning_outcomes',
-                    'text': ugettext_noop('Learning Outcomes'),
+                    'text': gettext_noop('Learning Outcomes'),
                     'view': 'courses:performance:learning_outcomes',
                     'scope': 'course',
                     'lens': 'performance',

--- a/analytics_dashboard/urls.py
+++ b/analytics_dashboard/urls.py
@@ -2,7 +2,7 @@ import os
 
 from auth_backends.urls import oauth2_urlpatterns
 from django.conf import settings
-from django.conf.urls import include, url
+from django.urls import include, path, re_path
 from django.contrib import admin
 from django.contrib.staticfiles import views as static_views
 from django.views import defaults
@@ -15,26 +15,26 @@ admin.autodiscover()
 # NOTE 1: Add our logout override first to ensure it is registered by Django as the actual logout view.
 # NOTE 2: These same patterns are used for rest_framework's browseable API authentication links.
 AUTH_URLS = [
-    url(r'^logout/$', views.InsightsLogoutView.as_view(), name='logout'),
-    url(r'^logout_then_login/$', views.insights_logout_then_login, name='logout_then_login'),
+    path('logout/', views.InsightsLogoutView.as_view(), name='logout'),
+    path('logout_then_login/', views.insights_logout_then_login, name='logout_then_login'),
 ] + oauth2_urlpatterns
 
 urlpatterns = AUTH_URLS + [
-    url(r'^$', views.LandingView.as_view(), name='landing'),
-    url(
-        r'^jsi18n/$',
+    path('', views.LandingView.as_view(), name='landing'),
+    path(
+        'jsi18n/',
         JavaScriptCatalog.as_view(
             packages=['analytics_dashboard.core', 'analytics_dashboard.courses']
         ),
         name='javascript-catalog',
     ),
-    url(r'^status/$', views.status, name='status'),
-    url(r'^health/$', views.health, name='health'),
-    url(r'^courses/', include('courses.urls')),
-    url(r'^admin/', admin.site.urls),
-    url(r'^api-auth/', include((AUTH_URLS, 'auth_urls'), namespace='rest_framework')),
-    url(r'^test/auto_auth/$', views.AutoAuth.as_view(), name='auto_auth'),
-    url(r'^announcements/', include('pinax.announcements.urls', namespace='pinax_announcements')),
+    path('status/', views.status, name='status'),
+    path('health/', views.health, name='health'),
+    path('courses/', include('courses.urls')),
+    re_path(r'^admin/', admin.site.urls),
+    path('api-auth/', include((AUTH_URLS, 'auth_urls'), namespace='rest_framework')),
+    path('test/auto_auth/', views.AutoAuth.as_view(), name='auto_auth'),
+    path('announcements/', include('pinax.announcements.urls', namespace='pinax_announcements')),
 ]
 
 
@@ -48,20 +48,20 @@ def debug_permission_denied(request):
 
 if settings.DEBUG:  # pragma: no cover
     urlpatterns += [
-        url(r'^403/$', debug_permission_denied),
-        url(r'^404/$', debug_page_not_found),
-        url(r'^500/$', defaults.server_error),
-        url(r'^503/$', views.ServiceUnavailableView.as_view()),
+        path('403/', debug_permission_denied),
+        path('404/', debug_page_not_found),
+        path('500/', defaults.server_error),
+        path('503/', views.ServiceUnavailableView.as_view()),
     ]
 
     if os.environ.get('ENABLE_DJANGO_TOOLBAR', False):
         import debug_toolbar
 
         urlpatterns += [
-            url(r'^__debug__/', include(debug_toolbar.urls)),
+            path('__debug__/', include(debug_toolbar.urls)),
         ]
 
     if settings.ENABLE_INSECURE_STATIC_FILES:
         urlpatterns += [
-            url(r'^static/(?P<path>.*)$', static_views.serve),
+            re_path(r'^static/(?P<path>.*)$', static_views.serve),
         ]


### PR DESCRIPTION
## Description
- Fixed the `Django>4.0 Deprecation Warnings` in order to prepare for `Django 4.2` upgrade
- Used the third party tool [django-upgrade](https://github.com/adamchainz/django-upgrade) to refactor the code.