### PR TITLE
build: add django 42 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         python-version: ["3.8"]
         os: [ubuntu-20.04]
-        toxenv: [django32]
+        toxenv: [django32, django42]
         node: [16]
     env:
       DATA_API_VERSION: "latest"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38-django{32}
+envlist = py38-django{32, 42}
 skipsdist = true
 
 [pytest]
@@ -23,6 +23,7 @@ passenv =
     BOKCHOY_HEADLESS
 deps = 
     django32: -r requirements/django.txt
+    django42: Django>=4.2,<5.0
     -r {toxinidir}/requirements/test.txt
 allowlist_externals = 
     make


### PR DESCRIPTION
## Description
- Under the issue https://github.com/openedx/edx-analytics-dashboard/issues/1488, added `django42` in tox and github CI in order to prepare for `Django 4.2` upgrade. 