### PR TITLE
Fix broken mysql-migrations workflow due to python-xmlsec.

### DIFF
--- a/.github/workflows/mysql-migrations.yml
+++ b/.github/workflows/mysql-migrations.yml
@@ -52,7 +52,7 @@ jobs:
         pip uninstall -y mysqlclient
         pip install --no-binary mysqlclient mysqlclient
         pip uninstall -y xmlsec
-        pip install --no-binary xmlsec xmlsec
+        pip install --no-binary xmlsec xmlsec==1.3.13
 
     - name: Initiate Services
       run: |


### PR DESCRIPTION
### Description

The latest version of `python-xmlsec` is breaking the `mysql-migrations` Github action. See [issue #314](https://github.com/xmlsec/python-xmlsec/issues/314).

The recommended course of action is to pin the version of `python-xmlsec` in the action.